### PR TITLE
Chart v1.0.1 - fix namespace issue in rules

### DIFF
--- a/charts/sysdig-admission-controller/Chart.yaml
+++ b/charts/sysdig-admission-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sysdig-admission-controller
 description: Sysdig Admission Controller using Sysdig Secure image scanner
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.0.0

--- a/charts/sysdig-admission-controller/commonrules.rego
+++ b/charts/sysdig-admission-controller/commonrules.rego
@@ -2,6 +2,8 @@
 # Common rules
 ##############################
 
+namespace := input.AdmissionRequest.object.metadata.namespace
+
 ##############################
 # helper functions
 

--- a/charts/sysdig-admission-controller/templates/configmap-opa-post-scan-rules.yaml
+++ b/charts/sysdig-admission-controller/templates/configmap-opa-post-scan-rules.yaml
@@ -8,7 +8,6 @@ data:
   post-scan-rules.rego: |
     package imageadmission
     # Helper variables
-    namespace := input.AdmissionRequest.namespace
     policies := data.policies
     {{- if .Values.scanPolicies.autoGenerate }}
     {{- $common := .Files.Get "commonrules.rego"}}

--- a/charts/sysdig-admission-controller/templates/configmap-opa-pre-scan-rules.yaml
+++ b/charts/sysdig-admission-controller/templates/configmap-opa-pre-scan-rules.yaml
@@ -8,7 +8,6 @@ data:
   pre-scan-rules.rego: |
     package imageadmission
     # Helper variables
-    namespace := input.AdmissionRequest.namespace
     policies := data.preScanPolicies
     {{- if .Values.preScanPolicies.autoGenerate }}
     {{- $common := .Files.Get "commonrules.rego"}}


### PR DESCRIPTION
Fix an issue in evaluation where the AdmissionReview namespace is used instead of the object namespace. In same cases, they can differ.

Signed-off-by: Alvaro Iradier <alvaro.iradier@sysdig.com>