### PR TITLE
Add onPrem explicit options and check if accessKey is set or fail

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -5,6 +5,13 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.7.17
+
+### Minor changes
+
+* Add onPrem as explicit option to set collector host, port and settings
+* Fail if no sysdig.accessKey value is provided
+
 ## v1.7.16
 
 ### Minor changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.7.16
+version: 1.7.17
 appVersion: 10.0.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -96,19 +96,21 @@ Installing the agent using the Helm chart is also possible in this scenario, and
 
 | Parameter                                | Description                                              | Default |
 | ---                                      | ---                                                      | ---     |
-| `sysdig.settings.collector`              | The IP address or hostname of the collector              | ` `     |
-| `sysdig.settings.collector_port`         | The port where collector is listening                    | ` `
-| `sysdig.settings.ssl`                    | The collector accepts SSL                                | `true`  |
-| `sysdig.settings.ssl_verify_certificate` | Set to false if you don't want to verify SSL certificate | `true`  |
+| `onPrem.enabled`                         | Set to _true_ to enable the On-Prem setting              | `false` |
+| `onPrem.collectorHost`                   | The IP address or hostname of the collector              | ` `     |
+| `onPrem.collectorPort`                   | The port where collector is listening                    | 6443    |
+| `onPrem.ssl`                             | The collector accepts SSL                                | `true`  |
+| `onPrem.sslVerifyCertificate`            | Set to false if you don't want to verify SSL certificate | `true`  |
 
 For example:
 
 ```bash
 $ helm install --name my-release \
     --set sysdig.accessKey=YOUR-KEY-HERE \
-    --set sysdig.settings.collector=42.32.196.18 \
-    --set sysdig.settings.collector_port=6443 \
-    --set sysdig.settings.ssl_verify_certificate=false \
+    --set onPrem=true \
+    --set onPrem.collectorHost=42.32.196.18 \
+    --set onPrem.collectorPort=6443 \
+    --set onPrem.sslVerifyCertificate=false \
     stable/sysdig
 ```
 

--- a/charts/sysdig/ci/test-values.yaml
+++ b/charts/sysdig/ci/test-values.yaml
@@ -1,0 +1,2 @@
+sysdig:
+  accessKey: xxx

--- a/charts/sysdig/templates/configmap.yaml
+++ b/charts/sysdig/templates/configmap.yaml
@@ -21,6 +21,16 @@ data:
       enabled: true
 {{- end }}
 {{- end }}
+{{- if .Values.onPrem.enabled }}
+    {{- if hasKey .Values.sysdig.settings "collector" }}{{ fail "Collector host specified in both .onPrem.collectorHost and sysdig.settings.collector"}}{{ end }}
+    {{- if hasKey .Values.sysdig.settings "collector_port" }}{{ fail "Collector port specified in both .onPrem.collectorPort and sysdig.settings.collector_port"}}{{ end }}
+    {{- if hasKey .Values.sysdig.settings "ssl"  }}{{ fail "Collector SSL option specified in both .onPrem.ssl and sysdig.settings.ssl"}}{{ end }}
+    {{- if hasKey .Values.sysdig.settings "ssl_verify_certificate" }}{{ fail "Collector SSL Verify Certificate option specified in both .onPrem.sslVerifyCertificate and sysdig.settings.ssl_verify_certificate"}}{{ end }}
+    collector: {{ .Values.onPrem.collectorHost }}
+    collector_port: {{ .Values.onPrem.collectorPort }}
+    ssl: {{ .Values.onPrem.ssl }}
+    ssl_verify_certificate: {{ .Values.onPrem.sslVerifyCertificate }}
+{{- end }}
 {{- if .Values.sysdig.settings }}
 {{ toYaml .Values.sysdig.settings | indent 4 }}
 {{- end }}

--- a/charts/sysdig/templates/secrets.yaml
+++ b/charts/sysdig/templates/secrets.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.sysdig.accessKey }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +7,3 @@ metadata:
 type: Opaque
 data:
  access-key : {{ required "A valid .Values.sysdig.accessKey is required" .Values.sysdig.accessKey | b64enc | quote }}
-{{- end }}

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -108,6 +108,14 @@ slim:
     limits:
       memory: 512Mi
 
+# Set onPrem.enabled=true and set corresponding fields for Sysdig On-Prem installations
+onPrem:
+  enabled: false
+  collectorHost:
+  collectorPort: 6443
+  ssl: true
+  sslVerifyCertificate: true
+
 sysdig:
   # Required: You need your Sysdig Monitor access key before running agents.
   accessKey: ""
@@ -115,15 +123,6 @@ sysdig:
   settings: {}
     ### Agent tags
     # tags: linux:ubuntu,dept:dev,local:nyc
-    #### Sysdig Software related config ####
-    # Sysdig collector address
-    # collector: 192.168.1.1
-    # Collector TCP port
-    # collector_port: 6666
-    # Whether collector accepts ssl
-    # ssl: true
-    # collector certificate validation
-    # ssl_verify_certificate: true
     #######################################
     # k8s_cluster_name: production
 


### PR DESCRIPTION
Take the collector options out of settings and create an "onPrem" map to enable it. These options will be put inside the agent settings. This is good for MCM, where the On-Prem options are displayed in their own UI section.

An additional check is done so if the collector options appear twice (in onPrem.xxx and sysdig.settings.xxx) the helm deploy fails with an error.

Also, fail the deployment if accessKey is not specified, instead of deploying without secret or daemonset.