### PR TITLE
Template system using jinja2 to generate ibm and official charts

### DIFF
--- a/create_charts_from_templates.sh
+++ b/create_charts_from_templates.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+command -v jinja2 >/dev/null 2>&1 || { echo >&2 "ERROR: jinja2 command (from jinja2-cli) is required."; exit 1; }
+
+set -e
+
+while read target template ; do
+	echo "Creating charts for $target"
+	prefix=templates/${template}/
+	for file in $(find ${prefix}* -type f -not -name config.json); do
+		outfile=generated_from_template/${target}/${file##$prefix}
+		if [[ $file == *.j2 ]]; then
+
+			test -f ${prefix}config.json || { echo >&2 "  ERROR: File ${prefix}config.json does not exist"; exit 1; }
+
+			outfile=${outfile%.j2}
+			mkdir -p $(dirname $outfile)
+			jinja2 --strict $file \
+				-D target=${target} \
+				${prefix}config.json \
+				> $outfile
+		else
+			mkdir -p $(dirname $outfile)
+			cp $file $outfile
+		fi
+
+		echo "  $file > $outfile"
+	done
+done < templates/targets.cfg

--- a/templates/agent_template/CHANGELOG.md
+++ b/templates/agent_template/CHANGELOG.md
@@ -1,0 +1,387 @@
+# Chart: Sysdig
+
+## Change Log
+
+This file documents all notable changes to Sysdig Helm Chart. The release
+numbering uses [semantic versioning](http://semver.org).
+
+## v1.17.19
+
+###  Minor changes
+
+* Use the latest image from Agent (10.1.0) by default.
+
+## v1.7.18
+
+### Minor changes
+
+* Add explicit *disable captures* option to agent settings.
+
+## v1.7.17
+
+### Minor changes
+
+* Add onPrem as explicit option to set collector host, port and settings
+* Fail if no sysdig.accessKey value is provided
+
+## v1.7.16
+
+### Minor changes
+
+* Include support links in README.md
+
+## v1.7.15
+
+### Minor changes
+
+* Use the latest image from Agent (10.0.0) by default.
+
+## v1.7.14
+
+### Minor changes
+
+* Implement a more comprehensive securityContext for running the pod.
+
+## v1.7.13
+
+### Minor changes
+
+* Implement scheduling with affinity and not with nodeSelector on amd64 & linux nodes.
+* Add support for custom annotations on daemonSet.
+
+## v1.7.12
+
+### Minor changes
+
+* Use the latest image from Agent (9.9.1) by default.
+* Use kubernetes.io/arch label on daemonSet to schedule pods only on amd64 nodes.
+* Add a livenessProbe to daemonSet.
+
+## v1.7.11
+
+### Minor changes
+
+* Use app.kubernetes.io labels instead of custom ones
+
+## v1.7.10
+
+### Minor changes
+
+* Use the latest image from Agent (9.9.0) by default.
+
+## v1.7.9
+
+### Minor changes
+
+* Add the SecurityContextConstraints if the security.openshift.io/v1 API is detected.
+
+## v1.7.8
+
+### Minor changes
+
+* Add an image.overrideValue value which is a hack to support
+  RELATED_IMAGE_<identifier> feature in Helm based operators.
+
+## v1.7.7
+
+### Minor changes
+
+* Use the latest image from Agent (9.8.0) by default.
+
+## v1.7.6
+
+### Minor changes
+
+* Use rbac.authorization.k8s.io/v1 instead of the beta1 API.
+* Fix security key duplication when enabling secure and auditLog.
+
+## v1.7.5
+
+### Minor changes
+
+* Use the latest image from Agent (9.7.0) by default.
+
+## v1.7.4
+
+### Minor changes
+
+* Use the latest image from Agent (9.6.1) by default.
+
+## v1.7.3
+
+### Minor changes
+
+* Removed dependency on ebpf.enabled to set environment variables
+
+## v1.7.2
+
+### Minor changes
+
+* Use the latest image from Agent (9.5.0) by default.
+
+## v1.7.1
+
+### Major changes
+
+* Remove the auditLog.clusterIP dependency. Using dynamic backend allows to
+  rely on DNS queries.
+
+## v1.7.0
+
+### Major changes
+
+* Enable Sysdig Secure by default.
+
+## v1.6.0
+
+### Major changes
+
+* Add audit log configuration when deploying the agent.
+
+## v1.5.0
+
+### Major changes
+
+* Add slim configuration for deploying the agent.
+
+### Minor changes
+
+* Mount /etc/modprobe.d from host.
+* Drop permissions to read secrets and configmaps.
+
+## v1.4.25
+
+### Minor changes
+
+* Use the latest image from Agent (0.94.0) by default.
+
+## v1.4.24
+
+### Minor changes
+
+* Use the latest image from Agent (0.93.1) by default.
+
+## v1.4.23
+
+### Minor changes
+
+* Update NOTES.txt to use the newest URL for finding the infrastructure.
+
+## v1.4.22
+
+### Minor changes
+
+* Use the latest image from Agent (0.93.0) by default.
+
+## v1.4.21
+
+* Add 'How to upgrade to last version' to the README
+
+## v1.4.20
+
+### Minor changes
+
+* Fixes compatibility errors introduced in v1.4.19.
+
+## v1.4.19
+
+### Minor changes
+
+* Fixes compatibility with kubernetes 1.16.
+
+## v1.4.18
+
+### Minor changes
+
+* Use the latest image from Agent (0.92.3) by default.
+
+## v1.4.17
+
+### Minor changes
+
+* Use the latest image from Agent (0.92.2) by default.
+
+## v1.4.16
+
+### Minor changes
+
+* Allow the DaemonSet to schedule using affinity rules
+
+## v1.4.15
+
+### Minor changes
+
+* Add configmaps and secrets to the resources we can read
+* Add support for priorityClassName, httpProxy, timezone and any env variable settings
+
+## v1.4.14
+
+### Minor changes
+
+* Update REAMED.md to fix the example in how to use the `sysdig.settings.tags` in the command line with `--set`
+
+## v1.4.13
+
+### Minor changes
+
+* Use the latest image from Agent (0.92.1) by default.
+* Increase `resources.requests` and `resources.limits` to match the [values
+  provided by Sysdig's agent team.](https://github.com/draios/sysdig-cloud-scripts/blob/master/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml#L70)
+
+## v1.4.12
+
+### Minor changes
+
+* Use the latest image from Agent (0.92.0) by default.
+
+## v1.4.11
+
+### Minor Changes
+
+* Add nestorsalceda as an approver in the OWNERS file
+
+## v1.4.10
+
+### Minor Changes
+
+* Use the latest image from Agent (0.90.3) by default.
+
+## v1.4.9
+
+### Minor Changes
+
+* Use the latest image from Agent (0.90.2) by default.
+
+## v1.4.8
+
+### Minor Changes
+
+* Add a volume with the os release information.
+* Use the latest image from Agent (0.90.1) by default.
+
+## v1.4.7
+
+### Minor Changes
+
+* Add apiVersion to Chart.yaml.
+
+## v1.4.6
+
+### Minor Changes
+
+* Dont allow to change the value of `new_k8s` flag.
+
+## v1.4.5
+
+### Minor Changes
+
+* Enable `new_k8s` flag by default.  This allows kube state metrics to be
+  automatically detected, monitored, and displayed in Sysdig Monitor.
+
+## v1.4.4
+
+### Minor Changes
+
+* Use the latest image from Agent (0.89.5) by default.
+* Add `persistentvolumes` and `persistentvolumeclaims` to ClusterRole
+
+## v1.4.3
+
+### Minor Changes
+
+* Provide an empty value to `sysdig.accessKey` key.
+
+## v1.4.2
+
+### Minor Changes
+
+* Use the latest image from Agent (0.89.4) by default.
+* Use latest shovel logo.
+
+## v1.4.0
+
+### Major Changes
+
+* Use the latest image from Agent (0.89.0) by default.
+* eBPF support added.
+
+## v1.3.2
+
+### Minor Changes
+
+* Provide sane defaults resources for the Sysdig Agent.
+* Use RollingUpdate strategy by default.
+
+## v1.3.1
+
+### Minor Changes
+
+* Revert v1.2.1 changes. The agent automatically restarts when detects a change in the configuration.
+
+## v1.3.0
+
+### Major Changes
+
+* Use a lower pod termination grace period for avoiding data gaps when pod fails to terminate quickly.
+* Check running file on readinessProbe instead of relaying on logs.
+* Mount /run and /var/run instead of Docker socket. It allows to access CRI / containerd socket.
+* Avoid floating references for the image.
+
+## v1.2.2
+
+### Minor Changes
+
+* Fix value in the agent tags example.
+
+## v1.2.1
+
+### Minor Changes
+
+* Add checksum annotations to DaemonSet so that rolling upgrades works when a ConfigMap changes.
+
+## v1.2.0
+
+### Major Changes
+
+* Allow to use other Docker registries (ECR, Quay ...) to download the Sysdig agent image.
+
+## v1.1.0
+
+### Major Changes
+
+* Add support for uploading custom app checks for Sysdig agent
+
+## v1.0.4
+
+### Minor Changes
+
+* Update README file with instructions for setting up the agent with On-Premise deployments
+
+## v1.0.3
+
+### Minor Changes
+
+* Fixed error in ClusterRoleBinding's roleRef
+
+## v1.0.2
+
+### Minor Changes
+
+* Fix readinessProbe in daemonset's pod spec
+
+## v1.0.1
+
+### Minor Changes
+
+* Add dnsPolicy to daemonset. Its value is ClusterFirstWithHostNet
+* Fix link target for retrieving Sysdig Monitor Access Key in README
+
+## v1.0.0
+
+### Major Changes
+
+* Run Sysdig agent as [daemonset v2.0](https://github.com/draios/sysdig-cloud-scripts/blob/master/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml).
+* Fix value's naming in order to follow [best practices](https://docs.helm.sh/chart_best_practices/#naming-conventions).
+* Use a secure.enabled flag for enabling Sysdig Secure.
+* Allow rbac resource creation or use existing serviceAccountName.
+* Use required function for retrieving sysdig.accessKey. This ensures that key is present.

--- a/templates/agent_template/Chart.yaml.j2
+++ b/templates/agent_template/Chart.yaml.j2
@@ -1,0 +1,35 @@
+apiVersion: v1
+name: sysdig
+version: {{ chart_version }}
+appVersion: {{ agent_version }}
+description: Sysdig Monitor and Secure agent
+keywords:
+  - monitoring
+  - security
+  - alerting
+  - metric
+  - troubleshooting
+  - run-time
+{%- if target=='ibm' %}
+  - ICP
+  - IKS
+  - amd64
+  - DevOps
+  - Operations
+  - Security
+  - Tools
+{%- endif %}
+home: https://www.sysdig.com/
+icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+sources:
+  - https://app.sysdigcloud.com/#/settings/user
+  - https://github.com/draios/sysdig
+maintainers:
+  - name: lachie83
+    email: lachlan@deis.com
+  - name: bencer
+    email: jorge.salamero@sysdig.com
+  - name: nestorsalceda
+    email: nestor.salceda@sysdig.com
+  - name: airadier
+    email: alvaro.iradier@sysdig.com

--- a/templates/agent_template/DESIGN.md
+++ b/templates/agent_template/DESIGN.md
@@ -1,0 +1,34 @@
+# Chart: Sysdig
+
+## Design and Known Issues Justification Document
+
+### Goal
+
+The goal of this file is to document and give some context about some issues that
+forced me to take some decisions in this Chart.
+
+### Loading Custom App Checks using a ConfigMap and a Yaml file
+
+In Helm, we are not able to add an external file to a Chart deployment, in fact,
+there is an [issue](https://github.com/helm/helm/issues/3276) about this.
+
+This means that external files like SSL certificates or pluggable files, like
+Falco rules or Custom App Checks, should be managed using Helm exclusively. You
+can see comments in [first Falco pull request](https://github.com/helm/charts/pull/5853).
+
+And the way to manage them using Helm is to pass file contents as values to Chart
+deployment. A nice tip is using a Yaml file and pass to deployment command line
+using the -f flag.
+
+### OpenShift support
+
+Right now, there are an issue in [OpenShift](https://github.com/openshift/origin/issues/20788)
+and other in [Helm](https://github.com/helm/helm/issues/4533) that makes a bit
+cumbersome the OpenShift support for this Chart.
+
+Eventually, they will be fixed. But meanwhile a workaround is to create a
+serviceAccount using the `oc` utility. Also manage permissions for creating privileged
+containers and allowing hostPath mount with `oc` and deploy the Chart with the
+`serviceAccount.name` created with `oc`.
+
+You can see more details about this workaround on [Sysdig Documentation about OpenShift](https://sysdigdocs.atlassian.net/wiki/spaces/Platform/pages/256671843/).

--- a/templates/agent_template/OWNERS
+++ b/templates/agent_template/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- bencer
+- nestorsalceda
+reviewers:
+- bencer
+- nestorsalceda

--- a/templates/agent_template/README-AWS.md
+++ b/templates/agent_template/README-AWS.md
@@ -1,0 +1,45 @@
+# Chart: Sysdig
+
+## Deploying the AWS Marketplace Sysdig agent image
+
+This is an use case similar to pulling images from a private registry. First you
+need to get the authorization token for the AWS Marketplace ECS image registry:
+
+```bash
+aws ecr --region=us-east-1 get-authorization-token --output text --query authorizationData[].authorizationToken | base64 -d | cut -d: -f2
+```
+
+And then use it to create the Secret. Don't forget to replace TOKEN and EMAIL
+with your own values:
+
+```bash
+kubectl create secret docker-registry aws-marketplace-credentials \
+ --docker-server=217273820646.dkr.ecr.us-east-1.amazonaws.com \
+ --docker-username=AWS \
+ --docker-password="TOKEN" \
+ --docker-email="EMAIL"
+```
+
+Next you need to create a values YAML file to pass the specific ECS registry
+configuration (you will find these values when you activate the software from
+the AWS Marketplace):
+
+```yaml
+sysdig:
+  accessKey: XxxXXxXXxXXxxx
+
+image:
+  registry: 217273820646.dkr.ecr.us-east-1.amazonaws.com
+  repository: 2df5da52-6fa2-46f6-b164-5b879e86fd85/cg-3361214151/agent
+  tag: 0.85.1-latest
+  pullSecrets:
+    - name: aws-marketplace-credentials
+```
+
+Finally, set the accessKey value and you are ready to deploy the Sysdig agent
+using the Helm chart:
+
+```bash
+helm install --name sysdig-agent -f aws-marketplace-values.yaml stable/sysdig
+```
+

--- a/templates/agent_template/README.md.j2
+++ b/templates/agent_template/README.md.j2
@@ -1,0 +1,326 @@
+{%- if target=='ibm' %}
+{%- set chart_source = 'community/sysdig' %}
+{%- else %}
+{%- set chart_source = 'stable/sysdig' %}
+{%- endif -%}
+# Chart: Sysdig
+
+[Sysdig](https://sysdig.com/) is a unified platform for container and microservices monitoring, troubleshooting, security and forensics. Sysdig platform has been built on top of [Sysdig tool](https://sysdig.com/opensource/sysdig/) and [Sysdig Inspect](https://sysdig.com/blog/sysdig-inspect/) open-source technologies.
+
+## Introduction
+
+This chart adds the Sysdig agent for [Sysdig Monitor](https://sysdig.com/product/monitor/) and [Sysdig Secure](https://sysdig.com/product/secure/) to all nodes in your cluster via a DaemonSet.
+
+## Prerequisites
+
+- Kubernetes 1.9+ with Beta APIs enabled
+{% if target=='ibm' %}
+### Installing on IBM Private Cloud
+
+If you are going to use this Helm Chart you must take account of Sysdig needs to be run as privileged pod.
+
+Supposing you are going to install the chart under the sysdig namespace, use the following commmand for granting those privileges:
+
+```bash
+kubectl -n sysdig create rolebinding ibm-privileged-clusterrole-rolebinding --clusterrole=ibm-privileged-clusterrole --group=system:serviceaccounts:sysdig
+```
+{% endif %}
+## Installing the Chart
+
+To install the chart with the release name `my-release`, retrieve your Sysdig Monitor Access Key from your [Account Settings](https://app.sysdigcloud.com/#/settings/agentInstallation) and run:
+
+```bash
+$ helm install --name my-release --set sysdig.accessKey=YOUR-KEY-HERE {{ chart_source }}
+```
+
+After a few seconds, you should see hosts and containers appearing in Sysdig Monitor and Sysdig Secure.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+> **Tip**: Use helm delete --purge my-release to completely remove the release from Helm internal storage
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Sysdig chart and their default values.
+
+| Parameter                         | Description                                                                         | Default                                     |
+| ---                               | ---                                                                                 | ---                                         |
+| `image.registry`                  | Sysdig Agent image registry                                                         | `docker.io`                                 |
+| `image.repository`                | The image repository to pull from                                                   | `sysdig/agent`                              |
+| `image.tag`                       | The image tag to pull                                                               | `{{ agent_version }}`                                    |
+| `image.pullPolicy`                | The Image pull policy                                                               | `IfNotPresent`                              |
+| `image.pullSecrets`               | Image pull secrets                                                                  | `nil`                                       |
+| `resources.requests.cpu`          | CPU requested for being run in a node                                               | `600m`                                      |
+| `resources.requests.memory`       | Memory requested for being run in a node                                            | `512Mi`                                     |
+| `resources.limits.cpu`            | CPU limit                                                                           | `2000m`                                     |
+| `resources.limits.memory`         | Memory limit                                                                        | `1536Mi`                                    |
+| `rbac.create`                     | If true, create & use RBAC resources                                                | `true`                                      |
+| `serviceAccount.create`           | Create serviceAccount                                                               | `true`                                      |
+| `serviceAccount.name`             | Use this value as serviceAccountName                                                | ` `                                         |
+| `daemonset.updateStrategy.type`   | The updateStrategy for updating the daemonset                                       | `RollingUpdate`                             |
+| `daemonset.affinity`              | Node affinities                                                                     | `schedule on amd64 and linux`               |
+| `daemonset.annotations`           | Custom annotations for daemonset                                                    | `{}`                                        |
+| `slim.enabled`                    | Use the slim based Sysdig Agent image                                               | `false`                                     |
+| `slim.kmoduleImage.repository`    | The kernel module image builder repository to pull from                             | `sysdig/agent-kmodule`                      |
+| `slim.resources.requests.cpu`     | CPU requested for building the kernel module                                        | `1000m`                                     |
+| `slim.resources.requests.memory`  | Memory requested for building the kernel module                                     | `348Mi`                                     |
+| `slim.resources.limits.memory`    | Memory limit for building the kernel module                                         | `512Mi`                                     |
+| `ebpf.enabled`                    | Enable eBPF support for Sysdig instead of `sysdig-probe` kernel module              | `false`                                     |
+| `ebpf.settings.mountEtcVolume`    | Needed to detect which kernel version are running in Google COS                     | `true`                                      |
+| `sysdig.accessKey`                | Your Sysdig Monitor Access Key                                                      | `Nil` You must provide your own key         |
+| `sysdig.disableCaptures`          | Disable capture functionality (see https://docs.sysdig.com/en/disable-captures.html)| `false`                                     |
+| `sysdig.settings`                 | Settings for agent's configuration file                                             | ` `                                         |
+| `secure.enabled`                  | Enable Sysdig Secure                                                                | `true`                                      |
+| `auditLog.enabled`                | Enable K8s audit log support for Sysdig Secure                                      | `false`                                     |
+| `auditLog.auditServerUrl`         | The URL where Sysdig Agent listens for K8s audit log events                         | `0.0.0.0`                                   |
+| `auditLog.auditServerPort`        | Port where Sysdig Agent listens for K8s audit log events                            | `7765`                                      |
+| `auditLog.dynamicBackend.enabled` | Deploy the Audit Sink where Sysdig listens for K8s audit log events                 | `false`                                     |
+| `customAppChecks`                 | The custom app checks deployed with your agent                                      | `{}`                                        |
+| `tolerations`                     | The tolerations for scheduling                                                      | `node-role.kubernetes.io/master:NoSchedule` |
+| `scc.create`                      | Create OpenShift's Security Context Constraint                                      | `false`                                     |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+    --set sysdig.accessKey=YOUR-KEY-HERE,sysdig.settings.tags="role:webserver\,location:europe" \
+    {{ chart_source }}
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml {{ chart_source }}
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## On-Premise backend deployment settings
+
+Sysdig platform backend can be also deployed On-Premise in your own infrastructure.
+
+Installing the agent using the Helm chart is also possible in this scenario, and you can enable it with the following parameters:
+
+| Parameter                                | Description                                              | Default |
+| ---                                      | ---                                                      | ---     |
+| `onPrem.enabled`                         | Set to _true_ to enable the On-Prem setting              | `false` |
+| `onPrem.collectorHost`                   | The IP address or hostname of the collector              | ` `     |
+| `onPrem.collectorPort`                   | The port where collector is listening                    | 6443    |
+| `onPrem.ssl`                             | The collector accepts SSL                                | `true`  |
+| `onPrem.sslVerifyCertificate`            | Set to false if you don't want to verify SSL certificate | `true`  |
+
+For example:
+
+```bash
+$ helm install --name my-release \
+    --set sysdig.accessKey=YOUR-KEY-HERE \
+    --set onPrem=true \
+    --set onPrem.collectorHost=42.32.196.18 \
+    --set onPrem.collectorPort=6443 \
+    --set onPrem.sslVerifyCertificate=false \
+    {{ chart_source }}
+```
+
+## Using private Docker image registry
+
+If you pull the Sysdig agent Docker image from a private registry that requires authentication, some additional configuration is required.
+
+First, create a secret that stores the registry credentials:
+
+```bash
+$ kubectl create secret docker-registry SECRET_NAME \
+  --docker-server=SERVER \
+  --docker-username=USERNAME \
+  --docker-password=TOKEN \
+  --docker-email=EMAIL
+```
+
+Then, point to this secret in the values YAML file:
+
+```yaml
+sysdig:
+  accessKey: YOUR-KEY-HERE
+image:
+  registry: myrepo.mydomain.tld
+  repository: sysdig-agent
+  tag: latest-tag
+  pullSecrets:
+    - name: SECRET_NAME
+```
+
+Finally, set the accessKey value and you are ready to deploy the Sysdig agent
+using the Helm chart:
+
+```bash
+$ helm install --name my-release -f values.yaml {{ chart_source }}
+```
+
+You can read more details about this in [Kubernetes Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+
+## Modifying Sysdig agent configuration
+
+The Sysdig agent uses a file called `dragent.yaml` to store the configuration.
+
+Using the Helm chart, the default configuration settings can be updated using `sysdig.settings` either via `--set sysdig.settings.key = value` or in the values YAML file. For example, to eanble Prometheus metrics scraping, you need this in your `values.yaml` file::
+
+```yaml
+sysdig:
+  accessKey: YOUR-KEY-HERE
+  settings:
+    prometheus:
+      enabled: true
+      histograms: true
+```
+
+```bash
+$ helm install --name my-release -f values.yaml {{ chart_source }}
+```
+
+## Upgrading Sysdig agent configuration
+
+If you need to upgrade the agent configuration file, first modify the YAML file (in this case we are increasing the metrics limit scraping Prometheus metrics):
+
+```yaml
+sysdig:
+  accessKey: YOUR-KEY-HERE
+  settings:
+    prometheus:
+      enabled: true
+      histograms: true
+      max_metrics: 2000
+      max_metrics_per_process: 400
+```
+
+And then, upgrade Helm chart with:
+
+```bash
+$ helm upgrade my-release -f values.yaml {{ chart_source }}
+```
+
+## How to upgrade to the last version
+
+First of all ensure you have the lastest chart version
+
+```bash
+$ helm repo update
+```
+
+In case you deployed the chart with a values.yaml file, you just need to modify (or add if it's missing) the `image.tag` field and execute:
+
+```bash
+$ helm install --name sysdig -f values.yaml {{ chart_source }}
+```
+
+If you deployed the chart setting the values as CLI parameters, like for example:
+
+```bash
+$ helm install \
+    --name sysdig \
+    --set sysdig.accessKey=xxxx \
+    --set ebpf.enabled=true \
+    --namespace sysdig-agent \
+    {{ chart_source }}
+```
+
+You will need to execute:
+
+```bash
+$ helm upgrade --set image.tag=<last_version> --reuse-values sysdig {{ chart_source }}
+```
+
+## Adding custom AppChecks
+
+[Application checks](https://sysdigdocs.atlassian.net/wiki/spaces/Monitor/pages/204767363/) are integrations that allow the Sysdig agent to collect metrics exposed by specific services. Sysdig has several built-in AppChecks, but sometimes you might need to [create your own](https://sysdigdocs.atlassian.net/wiki/spaces/Monitor/pages/204767436/).
+
+Your own AppChecks can deployed with the Helm chart embedding them in the values YAML file:
+
+```yaml
+customAppChecks:
+  sample.py: |-
+    from checks import AgentCheck
+
+    class MyCustomCheck(AgentCheck):
+        def check(self, instance):
+            self.gauge("testhelm", 1)
+
+sysdig:
+  accessKey: YOUR-KEY-HERE
+  settings:
+    app_checks:
+      - name: sample
+        interval: 10
+        pattern: # pattern to match the application
+          comm: myprocess
+        conf:
+          mykey: myvalue
+```
+
+The first section, dumps the AppCheck in a Kubernetes configmap and makes it available within the Sysdig agent container. The second, configures it on the `dragent.yaml` file.
+
+Once the values YAML file is ready, we will deploy the Chart like before:
+
+```bash
+$ helm install --name my-release -f values.yaml {{ chart_source }}
+```
+
+### Automating the generation of custom-app-checks.yaml file
+
+Sometimes editing and maintaining YAML files can be a bit cumbersome and error-prone, so we have created a script for automating this process and make your life easier.
+
+Imagine that you have custom AppChecks for a number of services like Redis, MongoDB and Traefik.
+
+You have already a `values.yaml` with just your configuration:
+
+```yaml
+sysdig:
+  accessKey: YOUR-KEY-HERE
+  settings:
+    app_checks:
+      - name: myredis
+        [...]
+      - name: mymongo
+        [...]
+      - name: mytraefik
+        [...]
+```
+
+You can generate an additional values YAML file with the custom AppChecks:
+
+```bash
+{%- if target=='ibm' %}
+$ git clone https://github.com/IBM/charts.git
+{%- else %}
+$ git clone https://github.com/kubernetes/charts.git
+{%- endif %}
+$ cd charts/{{ chart_source }}
+$ ./scripts/appchecks2helm appChecks/solr.py appChecks/traefik.py appChecks/nats.py > custom-app-checks.yaml
+```
+
+And deploy the Chart with both of them:
+
+```bash
+$ helm install --name my-release -f custom-app-checks.yaml -f values.yaml {{ chart_source }}
+```
+
+## Support
+
+For getting support from the Sysdig team, you should refer to the official
+[Sysdig Support page](https://sysdig.com/support).
+
+In addition to this, you can browse the documentation for the different
+components of the Sysdig Platform:
+
+* [Sysdig Monitor](https://app.sysdigcloud.com)
+* [Sysdig Secure](https://secure.sysdig.com)
+* [Platform Documentation](https://docs.sysdig.com/en/sysdig-platform.html)
+* [Monitor Documentation](https://docs.sysdig.com/en/sysdig-monitor.html)
+* [Secure Documentation](https://docs.sysdig.com/en/sysdig-secure.html)

--- a/templates/agent_template/ci/test-values.yaml
+++ b/templates/agent_template/ci/test-values.yaml
@@ -1,0 +1,2 @@
+sysdig:
+  accessKey: xxx

--- a/templates/agent_template/config.json
+++ b/templates/agent_template/config.json
@@ -1,0 +1,4 @@
+{
+    "chart_version": "1.7.20",
+    "agent_version": "10.1.1"
+}

--- a/templates/agent_template/scripts/appchecks2helm
+++ b/templates/agent_template/scripts/appchecks2helm
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "customAppChecks:"
+for app_check in "$@"
+do
+  echo -e "  $(basename $app_check): |-"
+  while IFS= read -r line
+  do
+    echo -e "    $line"
+  done <"$app_check"
+done

--- a/templates/agent_template/templates/NOTES.txt
+++ b/templates/agent_template/templates/NOTES.txt
@@ -1,0 +1,9 @@
+The agent for Sysdig Secure DevOps Platform is spinning up on each node in your
+cluster. After a few seconds, you should see your hosts appearing in the
+Explore tab:
+
+  https://app.sysdigcloud.com/#/explore/overview/l:10
+
+  https://secure.sysdig.com/#/events/l:600/*/*?viewAs=list
+
+No further action should be required.

--- a/templates/agent_template/templates/_helpers.tpl
+++ b/templates/agent_template/templates/_helpers.tpl
@@ -1,0 +1,109 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sysdig.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sysdig.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sysdig.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sysdig.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "sysdig.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Sysdig Agent image name
+*/}}
+{{- define "sysdig.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.image.overrideValue }}
+    {{- printf .Values.image.overrideValue -}}
+{{- else -}}
+    {{- if .Values.slim.enabled }}
+    {{- $repositoryName = printf "%s-%s" .Values.image.repository "slim" -}}
+    {{- end -}}
+    {{- if .Values.global }}
+        {{- if .Values.global.imageRegistry }}
+            {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+        {{- else -}}
+            {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+        {{- end -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Sysdig Agent image name for module building
+*/}}
+{{- define "sysdig.image.kmodule" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.slim.kmoduleImage.repository -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "sysdig.labels" -}}
+app.kubernetes.io/name: {{ include "sysdig.name" . }}
+helm.sh/chart: {{ include "sysdig.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/templates/agent_template/templates/auditsink.yaml
+++ b/templates/agent_template/templates/auditsink.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.auditLog.enabled .Values.auditLog.dynamicBackend.enabled }}
+apiVersion: auditregistration.k8s.io/v1alpha1
+kind: AuditSink
+metadata:
+  name: {{ template "sysdig.fullname" . }}
+  labels:
+{{ include "sysdig.labels" . | indent 4 }}
+spec:
+  policy:
+    level: RequestResponse
+    stages:
+      - ResponseComplete
+      - ResponseStarted
+  webhook:
+    throttle:
+      qps: 10
+      burst: 15
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace }}
+        name: {{ template "sysdig.fullname" . }}
+        port: {{ .Values.auditLog.auditServerPort }}
+        path: /k8s_audit
+{{- end }}

--- a/templates/agent_template/templates/clusterrole.yaml
+++ b/templates/agent_template/templates/clusterrole.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "sysdig.fullname" .}}
+  labels:
+{{ include "sysdig.labels" . | indent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - replicationcontrollers
+      - services
+      - events
+      - limitranges
+      - namespaces
+      - nodes
+      - resourcequotas
+      - persistentvolumes
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - ingresses
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/templates/agent_template/templates/clusterrolebinding.yaml
+++ b/templates/agent_template/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "sysdig.fullname" .}}
+  labels:
+{{ include "sysdig.labels" . | indent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "sysdig.serviceAccountName" .}}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "sysdig.fullname" .}}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/templates/agent_template/templates/configmap-custom-app-checks.yaml
+++ b/templates/agent_template/templates/configmap-custom-app-checks.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.customAppChecks }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "sysdig.fullname" . }}-custom-app-checks
+  labels:
+{{ include "sysdig.labels" . | indent 4 }}
+data:
+{{- range $file, $content :=  .Values.customAppChecks }}
+  {{ $file }}: |-
+{{ $content | indent 4}}
+{{- end }}
+{{- end }}

--- a/templates/agent_template/templates/configmap.yaml
+++ b/templates/agent_template/templates/configmap.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "sysdig.fullname" . }}
+  labels:
+{{ include "sysdig.labels" . | indent 4 }}
+data:
+  dragent.yaml: |
+    new_k8s: true
+{{- if or .Values.secure.enabled .Values.auditLog.enabled }}
+    security:
+{{- if .Values.auditLog.enabled }}
+      k8s_audit_server_url: {{ .Values.auditLog.auditServerUrl }}
+      k8s_audit_server_port: {{ .Values.auditLog.auditServerPort }}
+{{- end }}
+{{- if .Values.secure.enabled }}
+      enabled: true
+    commandlines_capture:
+      enabled: true
+    memdump:
+      enabled: true
+{{- end }}
+{{- end }}
+{{- if eq .Values.sysdig.disableCaptures true }}
+    {{- if hasKey .Values.sysdig.settings "sysdig_capture_enabled" }}{{ fail "sysdig_capture_enabled options in both .sysdig.disableCaptures and sysdig.settings.collesysdig_capture_enabledctor"}}{{ end }}
+    sysdig_capture_enabled: false 
+{{- end }}
+{{- if .Values.onPrem.enabled }}
+    {{- if hasKey .Values.sysdig.settings "collector" }}{{ fail "Collector host specified in both .onPrem.collectorHost and sysdig.settings.collector"}}{{ end }}
+    {{- if hasKey .Values.sysdig.settings "collector_port" }}{{ fail "Collector port specified in both .onPrem.collectorPort and sysdig.settings.collector_port"}}{{ end }}
+    {{- if hasKey .Values.sysdig.settings "ssl"  }}{{ fail "Collector SSL option specified in both .onPrem.ssl and sysdig.settings.ssl"}}{{ end }}
+    {{- if hasKey .Values.sysdig.settings "ssl_verify_certificate" }}{{ fail "Collector SSL Verify Certificate option specified in both .onPrem.sslVerifyCertificate and sysdig.settings.ssl_verify_certificate"}}{{ end }}
+    collector: {{ .Values.onPrem.collectorHost }}
+    collector_port: {{ .Values.onPrem.collectorPort }}
+    ssl: {{ .Values.onPrem.ssl }}
+    ssl_verify_certificate: {{ .Values.onPrem.sslVerifyCertificate }}
+{{- end }}
+{{- if .Values.sysdig.settings }}
+{{ toYaml .Values.sysdig.settings | indent 4 }}
+{{- end }}

--- a/templates/agent_template/templates/daemonset.yaml
+++ b/templates/agent_template/templates/daemonset.yaml
@@ -1,0 +1,219 @@
+{{- if .Values.sysdig.accessKey }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "sysdig.fullname" . }}
+  labels:
+{{ include "sysdig.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "sysdig.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ template "sysdig.fullname" .}}
+      labels:
+{{ include "sysdig.labels" . | indent 8 }}
+      {{- if .Values.daemonset.annotations }}
+      annotations:
+{{ toYaml .Values.daemonset.annotations | indent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ template "sysdig.serviceAccountName" .}}
+{{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      hostPID: true
+      terminationGracePeriodSeconds: 5
+      {{- if .Values.daemonset.affinity }}
+      affinity:
+{{ toYaml .Values.daemonset.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.slim.enabled }}
+      initContainers:
+        - name: sysdig-agent-kmodule
+          image: {{ template "sysdig.image.kmodule" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.image.pullSecrets }}
+          imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 12 }}
+          {{- end }}
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            privileged: true
+            runAsNonRoot: false
+            runAsUser: 0
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: true
+          resources:
+{{ toYaml .Values.slim.resources | indent 12 }}
+          volumeMounts:
+            - mountPath: /etc/modprobe.d
+              name: modprobe-d
+              readOnly: true
+            - mountPath: /host/boot
+              name: boot-vol
+              readOnly: true
+            - mountPath: /host/lib/modules
+              name: modules-vol
+              readOnly: true
+            - mountPath: /host/usr
+              name: usr-vol
+              readOnly: true
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ template "sysdig.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            privileged: true
+            runAsNonRoot: false
+            runAsUser: 0
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: true
+          env:
+            {{- if .Values.ebpf.enabled }}
+            - name: SYSDIG_BPF_PROBE
+              value:
+            {{- end }}
+            {{- if .Values.proxy.httpProxy }}
+            - name: http_proxy
+              value: {{ .Values.proxy.httpProxy }}
+            {{- end }}
+            {{- if .Values.proxy.httpsProxy }}
+            - name: https_proxy
+              value: {{ .Values.proxy.httpsProxy }}
+            {{- end }}
+            {{- if .Values.proxy.noProxy }}
+            - name: no_proxy
+              value: {{ .Values.proxy.noProxy }}
+            {{- end }}
+            {{- if .Values.timezone }}
+            - name: TZ
+              value: {{ .Values.timezone }}
+            {{- end }}
+            {{- range $key, $value := .Values.daemonset.env }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+            {{- end }}
+          readinessProbe:
+            exec:
+              command: [ "test", "-e", "/opt/draios/logs/running" ]
+            initialDelaySeconds: 10
+          livenessProbe:
+            exec:
+              command: [ "test", "-e", "/opt/draios/logs/running" ]
+            initialDelaySeconds: 10
+          volumeMounts:
+            {{- if not .Values.slim.enabled }}
+            - mountPath: /etc/modprobe.d
+              name: modprobe-d
+              readOnly: true
+            {{- end }}
+            - mountPath: /host/dev
+              name: dev-vol
+              readOnly: false
+            - mountPath: /host/proc
+              name: proc-vol
+              readOnly: true
+            {{- if not .Values.slim.enabled }}
+            - mountPath: /host/boot
+              name: boot-vol
+              readOnly: true
+            - mountPath: /host/lib/modules
+              name: modules-vol
+              readOnly: true
+            - mountPath: /host/usr
+              name: usr-vol
+              readOnly: true
+            {{- end }}
+            - mountPath: /host/run
+              name: run-vol
+            - mountPath: /host/var/run
+              name: varrun-vol
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /opt/draios/etc/kubernetes/config
+              name: sysdig-agent-config
+            - mountPath: /opt/draios/etc/kubernetes/secrets
+              name: sysdig-agent-secrets
+            {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.mountEtcVolume) }}
+            - mountPath: /host/etc
+              name: etc-fs
+              readOnly: true
+            {{- end }}
+            {{- if .Values.customAppChecks }}
+            - mountPath: /opt/draios/lib/python/checks.custom.d
+              name: custom-app-checks-volume
+            {{- end }}
+            - mountPath: /host/etc/os-release
+              name: osrel
+              readOnly: true
+      volumes:
+        - name: modprobe-d
+          hostPath:
+            path: /etc/modprobe.d
+        - name: osrel
+          hostPath:
+            path: /etc/os-release
+            type: FileOrCreate
+        - name: dshm
+          emptyDir:
+            medium: Memory
+        - name: dev-vol
+          hostPath:
+            path: /dev
+        - name: proc-vol
+          hostPath:
+            path: /proc
+        - name: boot-vol
+          hostPath:
+            path: /boot
+        - name: modules-vol
+          hostPath:
+            path: /lib/modules
+        - name: usr-vol
+          hostPath:
+            path: /usr
+        - name: run-vol
+          hostPath:
+            path: /run
+        - name: varrun-vol
+          hostPath:
+            path: /var/run
+        {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.mountEtcVolume) }}
+        - name: etc-fs
+          hostPath:
+            path: /etc
+        {{- end }}
+        - name: sysdig-agent-config
+          configMap:
+            name: {{ template "sysdig.fullname" . }}
+            optional: true
+        - name: sysdig-agent-secrets
+          secret:
+            secretName: {{ template "sysdig.fullname" . }}
+        {{- if .Values.customAppChecks }}
+        - name: custom-app-checks-volume
+          configMap:
+            name: {{ template "sysdig.fullname" . }}-custom-app-checks
+        {{- end }}
+  updateStrategy:
+{{ toYaml .Values.daemonset.updateStrategy | indent 4 }}
+{{- end }}

--- a/templates/agent_template/templates/secrets.yaml
+++ b/templates/agent_template/templates/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sysdig.fullname" . }}
+  labels:
+{{ include "sysdig.labels" . | indent 4 }}
+type: Opaque
+data:
+ access-key : {{ required "A valid .Values.sysdig.accessKey is required" .Values.sysdig.accessKey | b64enc | quote }}

--- a/templates/agent_template/templates/securitycontextconstraint.yaml
+++ b/templates/agent_template/templates/securitycontextconstraint.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.scc.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: |
+      This provides the minimum requirements to the Sysdig agent to run in the Openshift.
+  name: {{ template "sysdig.fullname" . }}
+  labels:
+{{ include "sysdig.labels" . | indent 4 }}
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: []
+allowedUnsafeSysctls: []
+defaultAddCapabilities: []
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: 0
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ template "sysdig.serviceAccountName" .}}
+volumes:
+- hostPath
+- emptyDir
+- secret
+- configMap
+{{- end -}}

--- a/templates/agent_template/templates/service.yaml
+++ b/templates/agent_template/templates/service.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.auditLog.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "sysdig.fullname" . }}
+  labels:
+{{ include "sysdig.labels" . | indent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "sysdig.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+  - protocol: TCP
+    port: {{ .Values.auditLog.auditServerPort }}
+{{- end }}

--- a/templates/agent_template/templates/serviceaccount.yaml
+++ b/templates/agent_template/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "sysdig.serviceAccountName" .}}
+  labels:
+{{ include "sysdig.labels" . | indent 4 }}
+{{- end }}

--- a/templates/agent_template/values.yaml.j2
+++ b/templates/agent_template/values.yaml.j2
@@ -1,0 +1,163 @@
+# Default values for Sysdig Monitor and Secure Helm package.
+
+image:
+  # This is a hack to support RELATED_IMAGE_<identifier> feature in Helm based
+  # Operators
+  #
+  # As long as I don't want to people to use this, I will keep it undocumented
+  overrideValue:
+
+  registry: docker.io
+  repository: sysdig/agent
+  tag: {{ agent_version }}
+  # Specify a imagePullPolicy
+  # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  pullPolicy: IfNotPresent
+  # Optionally specify an array of imagePullSecrets.
+  # Secrets must be manually created in the namespace.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  #
+  # pullSecrets:
+  #   - name: myRegistrKeySecretName
+
+resources:
+  # Although resources needed are subjective on the actual workload we provide
+  # a sane defaults ones. If you have more questions or concerns, please refer
+  # to Sysdig Support for more info about it
+  requests:
+    cpu: 600m
+    memory: 512Mi
+  limits:
+    cpu: 2000m
+    memory: 1536Mi
+
+rbac:
+  # true here enables creation of rbac resources
+  create: true
+
+serviceAccount:
+  # Create and use serviceAccount resources
+  create: true
+  # Use this value as serviceAccountName
+  name:
+
+daemonset:
+  # Perform rolling updates by default in the DaemonSet agent
+  # ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
+  updateStrategy:
+    # You can also customize maxUnavailable, maxSurge or minReadySeconds if you
+    # need it
+    type: RollingUpdate
+  ## Extra environment variables that will be pass onto deployment pods
+  env: {}
+  # Allow the DaemonSet to schedule using affinity rules
+  # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/arch
+            operator: In
+            values:
+              - amd64
+          - key: kubernetes.io/os
+            operator: In
+            values:
+              - linux
+  # Allow the DaemonSet to set annotations
+  annotations: {}
+
+# If is behind a proxy you can set the proxy server
+proxy:
+  httpProxy:
+  httpsProxy:
+  noProxy:
+
+# Set daemonset timezone
+timezone:
+
+# Set daemonset priorityClassName
+priorityClassName:
+
+ebpf:
+  # Enable eBPF support for Sysdig Agent
+  enabled: false
+
+  settings:
+    # Needed to correctly detect the kernel version for the eBPF program
+    # Set to false if not running on Google COS
+    mountEtcVolume: true
+
+slim:
+  # Uses a slim version of the Sysdig Agent
+  enabled: false
+  # When using slim the kernel module is built in other container, which
+  # contains the toolchain required to build the kernel module.
+  kmoduleImage:
+    repository: sysdig/agent-kmodule
+
+  resources:
+    # Resources required by the kernel module builder image. These are some
+    # a sane defaults ones, but you can tweak or ask Sysdig Support for more
+    # info about this
+    requests:
+      cpu: 1000m
+      memory: 348Mi
+    limits:
+      memory: 512Mi
+
+# Set onPrem.enabled=true and set corresponding fields for Sysdig On-Prem installations
+onPrem:
+  enabled: false
+  collectorHost:
+  collectorPort: 6443
+  ssl: true
+  sslVerifyCertificate: true
+
+sysdig:
+  # Required: You need your Sysdig Monitor access key before running agents.
+  accessKey: ""
+
+  # Disable capture functionality (see https://docs.sysdig.com/en/disable-captures.html)
+  disableCaptures: false
+
+  settings: {}
+    ### Agent tags
+    # tags: linux:ubuntu,dept:dev,local:nyc
+    #######################################
+    # k8s_cluster_name: production
+
+secure:
+  # true here enables Sysdig Secure: container run-time security & forensics
+  enabled: true
+
+auditLog:
+  # true here activates the K8s Audit Log feature for Sysdig Secure
+  enabled: false
+  auditServerUrl: 0.0.0.0
+  auditServerPort: 7765
+
+  dynamicBackend:
+    # true here configures an AuditSink who will receive the K8s audit logs
+    enabled: false
+
+scc:
+  create: false
+
+customAppChecks: {}
+  # Allow passing custom app checks for Sysdig Agent.
+  # Example:
+  #
+  # sample.py: |-
+  #   from checks import AgentCheck
+  #
+  #   class MyCustomCheck(AgentCheck):
+  #       def check(self, instance):
+  #           self.gauge("testhelm", 1)
+
+# Allow sysdig to run on Kubernetes 1.6 masters.
+tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master

--- a/templates/targets.cfg
+++ b/templates/targets.cfg
@@ -1,0 +1,2 @@
+ibm agent_template
+sysdig agent_template 


### PR DESCRIPTION
Signed-off-by: Alvaro Iradier <alvaro.iradier@sysdig.com>

## What this PR does / why we need it:

This PR adds a templating system to create multiple chart variants from a template, like IBM and Rancher variants for Sysdig Agent.