### PR TITLE
[sysdiglabs/sydig] Sysdig agent chart version 1.8.0

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -5,7 +5,25 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-## v1.17.19
+## v1.8.0
+
+### Major changes
+
+* Migrated charts to *sysdiglabs* repository
+
+###  Minor changes
+
+* Add explicit *clusterName* option in values.yaml
+* Add beta.kubernetes.io labels for node affinity, to support older versions
+* SCC deployed by default in Openshift (check API security.openshift.io/v1)
+
+## v1.7.20
+
+###  Minor changes
+
+* Use the latest image from Agent (10.1.1) by default.
+
+## v1.7.19
 
 ###  Minor changes
 

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.7.20
+version: 1.8.0
 appVersion: 10.1.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -15,7 +15,13 @@ This chart adds the Sysdig agent for [Sysdig Monitor](https://sysdig.com/product
 To install the chart with the release name `my-release`, retrieve your Sysdig Monitor Access Key from your [Account Settings](https://app.sysdigcloud.com/#/settings/agentInstallation) and run:
 
 ```bash
-$ helm install --name my-release --set sysdig.accessKey=YOUR-KEY-HERE stable/sysdig
+$ helm repo add sysdiglabs https://sysdiglabs.github.io/charts/
+```
+
+to add the `sysdiglabs` Helm chart repository. Then run:
+
+```bash
+$ helm install --name my-release --set sysdig.accessKey=YOUR-KEY-HERE sysdiglabs/sysdig
 ```
 
 After a few seconds, you should see hosts and containers appearing in Sysdig Monitor and Sysdig Secure.
@@ -49,6 +55,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `resources.limits.cpu`            | CPU limit                                                                           | `2000m`                                     |
 | `resources.limits.memory`         | Memory limit                                                                        | `1536Mi`                                    |
 | `rbac.create`                     | If true, create & use RBAC resources                                                | `true`                                      |
+| `scc.create`                      | Create OpenShift's Security Context Constraint                                      | `true`                                     |
 | `serviceAccount.create`           | Create serviceAccount                                                               | `true`                                      |
 | `serviceAccount.name`             | Use this value as serviceAccountName                                                | ` `                                         |
 | `daemonset.updateStrategy.type`   | The updateStrategy for updating the daemonset                                       | `RollingUpdate`                             |
@@ -61,6 +68,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `slim.resources.limits.memory`    | Memory limit for building the kernel module                                         | `512Mi`                                     |
 | `ebpf.enabled`                    | Enable eBPF support for Sysdig instead of `sysdig-probe` kernel module              | `false`                                     |
 | `ebpf.settings.mountEtcVolume`    | Needed to detect which kernel version are running in Google COS                     | `true`                                      |
+| `clusterName`                     | Set a cluster name to identify events using *kubernetes.cluster.name* tag           | ` `                                         |
 | `sysdig.accessKey`                | Your Sysdig Monitor Access Key                                                      | `Nil` You must provide your own key         |
 | `sysdig.disableCaptures`          | Disable capture functionality (see https://docs.sysdig.com/en/disable-captures.html)| `false`                                     |
 | `sysdig.settings`                 | Settings for agent's configuration file                                             | ` `                                         |
@@ -71,20 +79,19 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `auditLog.dynamicBackend.enabled` | Deploy the Audit Sink where Sysdig listens for K8s audit log events                 | `false`                                     |
 | `customAppChecks`                 | The custom app checks deployed with your agent                                      | `{}`                                        |
 | `tolerations`                     | The tolerations for scheduling                                                      | `node-role.kubernetes.io/master:NoSchedule` |
-| `scc.create`                      | Create OpenShift's Security Context Constraint                                      | `false`                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
 $ helm install --name my-release \
     --set sysdig.accessKey=YOUR-KEY-HERE,sysdig.settings.tags="role:webserver\,location:europe" \
-    stable/sysdig
+    sysdiglabs/sysdig
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/sysdig
+$ helm install --name my-release -f values.yaml sysdiglabs/sysdig
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -112,7 +119,7 @@ $ helm install --name my-release \
     --set onPrem.collectorHost=42.32.196.18 \
     --set onPrem.collectorPort=6443 \
     --set onPrem.sslVerifyCertificate=false \
-    stable/sysdig
+    sysdiglabs/sysdig
 ```
 
 ## Using private Docker image registry
@@ -146,7 +153,7 @@ Finally, set the accessKey value and you are ready to deploy the Sysdig agent
 using the Helm chart:
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/sysdig
+$ helm install --name my-release -f values.yaml sysdiglabs/sysdig
 ```
 
 You can read more details about this in [Kubernetes Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
@@ -167,7 +174,7 @@ sysdig:
 ```
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/sysdig
+$ helm install --name my-release -f values.yaml sysdiglabs/sysdig
 ```
 
 ## Upgrading Sysdig agent configuration
@@ -188,7 +195,7 @@ sysdig:
 And then, upgrade Helm chart with:
 
 ```bash
-$ helm upgrade my-release -f values.yaml stable/sysdig
+$ helm upgrade my-release -f values.yaml sysdiglabs/sysdig
 ```
 
 ## How to upgrade to the last version
@@ -202,7 +209,7 @@ $ helm repo update
 In case you deployed the chart with a values.yaml file, you just need to modify (or add if it's missing) the `image.tag` field and execute:
 
 ```bash
-$ helm install --name sysdig -f values.yaml stable/sysdig
+$ helm install --name sysdig -f values.yaml sysdiglabs/sysdig
 ```
 
 If you deployed the chart setting the values as CLI parameters, like for example:
@@ -213,13 +220,13 @@ $ helm install \
     --set sysdig.accessKey=xxxx \
     --set ebpf.enabled=true \
     --namespace sysdig-agent \
-    stable/sysdig
+    sysdiglabs/sysdig
 ```
 
 You will need to execute:
 
 ```bash
-$ helm upgrade --set image.tag=<last_version> --reuse-values sysdig stable/sysdig
+$ helm upgrade --set image.tag=<last_version> --reuse-values sysdig sysdiglabs/sysdig
 ```
 
 ## Adding custom AppChecks
@@ -254,7 +261,7 @@ The first section, dumps the AppCheck in a Kubernetes configmap and makes it ava
 Once the values YAML file is ready, we will deploy the Chart like before:
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/sysdig
+$ helm install --name my-release -f values.yaml sysdiglabs/sysdig
 ```
 
 ### Automating the generation of custom-app-checks.yaml file
@@ -282,14 +289,14 @@ You can generate an additional values YAML file with the custom AppChecks:
 
 ```bash
 $ git clone https://github.com/kubernetes/charts.git
-$ cd charts/stable/sysdig
+$ cd charts/sysdiglabs/sysdig
 $ ./scripts/appchecks2helm appChecks/solr.py appChecks/traefik.py appChecks/nats.py > custom-app-checks.yaml
 ```
 
 And deploy the Chart with both of them:
 
 ```bash
-$ helm install --name my-release -f custom-app-checks.yaml -f values.yaml stable/sysdig
+$ helm install --name my-release -f custom-app-checks.yaml -f values.yaml sysdiglabs/sysdig
 ```
 
 ## Support

--- a/charts/sysdig/templates/configmap.yaml
+++ b/charts/sysdig/templates/configmap.yaml
@@ -7,33 +7,33 @@ metadata:
 data:
   dragent.yaml: |
     new_k8s: true
+{{- $clusterName := include "get_or_fail_if_in_settings" (dict "root" . "key" "clusterName" "setting" "k8s_cluster_name")}}
+{{- if $clusterName }}
+    k8s_cluster_name: {{ $clusterName }}
+{{- end }}
 {{- if or .Values.secure.enabled .Values.auditLog.enabled }}
     security:
-{{- if .Values.auditLog.enabled }}
+  {{- if .Values.auditLog.enabled }}
       k8s_audit_server_url: {{ .Values.auditLog.auditServerUrl }}
       k8s_audit_server_port: {{ .Values.auditLog.auditServerPort }}
-{{- end }}
-{{- if .Values.secure.enabled }}
+  {{- end }}
+  {{- if .Values.secure.enabled }}
       enabled: true
     commandlines_capture:
       enabled: true
     memdump:
       enabled: true
+  {{- end }}
 {{- end }}
-{{- end }}
-{{- if eq .Values.sysdig.disableCaptures true }}
-    {{- if hasKey .Values.sysdig.settings "sysdig_capture_enabled" }}{{ fail "sysdig_capture_enabled options in both .sysdig.disableCaptures and sysdig.settings.collesysdig_capture_enabledctor"}}{{ end }}
+{{- $disableCaptures := include "get_or_fail_if_in_settings" (dict "root" . "key" "sysdig.disableCaptures" "setting" "sysdig_capture_enabled")}}
+{{- if $disableCaptures }}
     sysdig_capture_enabled: false 
 {{- end }}
 {{- if .Values.onPrem.enabled }}
-    {{- if hasKey .Values.sysdig.settings "collector" }}{{ fail "Collector host specified in both .onPrem.collectorHost and sysdig.settings.collector"}}{{ end }}
-    {{- if hasKey .Values.sysdig.settings "collector_port" }}{{ fail "Collector port specified in both .onPrem.collectorPort and sysdig.settings.collector_port"}}{{ end }}
-    {{- if hasKey .Values.sysdig.settings "ssl"  }}{{ fail "Collector SSL option specified in both .onPrem.ssl and sysdig.settings.ssl"}}{{ end }}
-    {{- if hasKey .Values.sysdig.settings "ssl_verify_certificate" }}{{ fail "Collector SSL Verify Certificate option specified in both .onPrem.sslVerifyCertificate and sysdig.settings.ssl_verify_certificate"}}{{ end }}
-    collector: {{ .Values.onPrem.collectorHost }}
-    collector_port: {{ .Values.onPrem.collectorPort }}
-    ssl: {{ .Values.onPrem.ssl }}
-    ssl_verify_certificate: {{ .Values.onPrem.sslVerifyCertificate }}
+    collector: {{ include "get_or_fail_if_in_settings" (dict "root" . "key" "onPrem.collectorHost" "setting" "collector") }}
+    collector_port: {{ include "get_or_fail_if_in_settings" (dict "root" . "key" "onPrem.collectorPort" "setting" "collector_port") }}
+    ssl: {{ include "get_or_fail_if_in_settings" (dict "root" . "key" "onPrem.ssl" "setting" "ssl") }}
+    ssl_verify_certificate:  {{ include "get_or_fail_if_in_settings" (dict "root" . "key" "onPrem.sslVerifyCertificate" "setting" "ssl_verify_certificate") }}
 {{- end }}
 {{- if .Values.sysdig.settings }}
 {{ toYaml .Values.sysdig.settings | indent 4 }}

--- a/charts/sysdig/templates/securitycontextconstraint.yaml
+++ b/charts/sysdig/templates/securitycontextconstraint.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.scc.create }}
+{{- if and .Values.scc.create (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
@@ -39,4 +39,4 @@ volumes:
 - emptyDir
 - secret
 - configMap
-{{- end -}}
+{{- end }}

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -36,6 +36,10 @@ rbac:
   # true here enables creation of rbac resources
   create: true
 
+scc:
+  # true here enabled creation of Security Context Constraints in Openshift
+  create: true
+
 serviceAccount:
   # Create and use serviceAccount resources
   create: true
@@ -63,6 +67,15 @@ daemonset:
             values:
               - amd64
           - key: kubernetes.io/os
+            operator: In
+            values:
+              - linux
+        - matchExpressions:
+          - key: beta.kubernetes.io/arch
+            operator: In
+            values:
+              - amd64
+          - key: beta.kubernetes.io/os
             operator: In
             values:
               - linux
@@ -116,6 +129,9 @@ onPrem:
   ssl: true
   sslVerifyCertificate: true
 
+# Setting a cluster name allows you to filter events from this cluster using kubernetes.cluster.name
+clusterName: ""
+
 sysdig:
   # Required: You need your Sysdig Monitor access key before running agents.
   accessKey: ""
@@ -126,8 +142,6 @@ sysdig:
   settings: {}
     ### Agent tags
     # tags: linux:ubuntu,dept:dev,local:nyc
-    #######################################
-    # k8s_cluster_name: production
 
 secure:
   # true here enables Sysdig Secure: container run-time security & forensics
@@ -142,9 +156,6 @@ auditLog:
   dynamicBackend:
     # true here configures an AuditSink who will receive the K8s audit logs
     enabled: false
-
-scc:
-  create: false
 
 customAppChecks: {}
   # Allow passing custom app checks for Sysdig Agent.


### PR DESCRIPTION
* Update README to reflect new sysdiglabs repo
* Add explicit *clusterName* option in values.yaml
* Add beta.kubernetes.io labels for node affinity, to support older versions
* SCC deployed by default in Openshift (check API security.openshift.io/v1)

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] PR only contains changes for one chart
