### PR TITLE
[sysdiglabs/sysdig-admission-controller] Fixes

### DIFF
--- a/charts/sysdig-admission-controller/Chart.yaml
+++ b/charts/sysdig-admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-admission-controller
 description: Sysdig Admission Controller using Sysdig Secure image scanner
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.1.0
 home: https://sysdiglabs.github.io/sysdig-admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/sysdig-admission-controller/templates/_helpers.tpl
+++ b/charts/sysdig-admission-controller/templates/_helpers.tpl
@@ -24,15 +24,6 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
-{{- define "sysdig-image-scanner.tag" -}}
-{{- if .Values.image.tag -}}
-{{- .Values.image.tag -}}
-{{- else -}}
-{{- .Chart.AppVersion -}}
-{{- end -}}
-{{- end -}}
-
-
 {{/*
 Create chart name and version as used by the chart label.
 */}}
@@ -77,4 +68,20 @@ Generate certificates for aggregated api server
 {{- $ca := genCA "sysdig-image-scanner-ca" 3650 -}}
 {{- $cert := genSignedCert ( printf "%s.%s.svc" (include "sysdig-image-scanner.name" .) .Release.Namespace ) nil nil 3650 $ca -}}
 {{- printf "%s$%s$%s" ($cert.Cert | b64enc) ($cert.Key | b64enc) ($ca.Cert | b64enc) -}}
+{{- end -}}
+
+
+{{/*
+Allow overriding registry and repository for air-gapped environments
+*/}}
+{{- define "sysdig-image-scanner.image" -}}
+{{- if .Values.image.overrideValue -}}
+    {{- .Values.image.overrideValue -}}
+{{- else -}}
+    {{- $imageRegistry := .Values.image.registry -}}
+    {{- $imageRepository := .Values.image.repository -}}
+    {{- $imageTag := .Values.image.tag | default .Chart.AppVersion -}}
+    {{- $globalRegistry := (default .Values.global dict).imageRegistry -}}
+    {{- $globalRegistry | default $imageRegistry | default "docker.io" -}} / {{- $imageRepository -}} : {{- $imageTag -}}
+{{- end -}}
 {{- end -}}

--- a/charts/sysdig-admission-controller/templates/certs.yaml
+++ b/charts/sysdig-admission-controller/templates/certs.yaml
@@ -28,12 +28,18 @@ metadata:
   name: {{ include "sysdig-image-scanner.name" . }}-webhook
 webhooks:
 - name: imagechecks.admission.sysdig.com
+  matchPolicy: Equivalent
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]
-    operations: ["CREATE"]
+    operations: ["CREATE", "UPDATE"]
     resources: ["pods"]
-    scope: "*"
+    scope: "Namespaced"
+  namespaceSelector:
+    matchExpressions:
+    - key: "imagechecks.admission.sysdig.com/skip"
+      operator: NotIn
+      values: ["true"]
   clientConfig:
     service:
       namespace: default
@@ -42,7 +48,8 @@ webhooks:
     caBundle: {{ $certList._2 }}
   admissionReviewVersions: ["v1beta1"]
   sideEffects: Some
-  timeoutSeconds: 10
+  timeoutSeconds: 15
+  failurePolicy: Fail
   reinvocationPolicy: IfNeeded
 ---
 apiVersion: v1

--- a/charts/sysdig-admission-controller/templates/deployment.yaml
+++ b/charts/sysdig-admission-controller/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 65532
       containers:
         - name: {{ .Chart.Name }}-webhook
-          image: "{{ .Values.image.repository }}:{{ include "sysdig-image-scanner.tag" . }}"
+          image: "{{ include "sysdig-image-scanner.image" . }}"
           args:
             - --secure-port={{ .Values.service.port }}
             - --tls-cert-file


### PR DESCRIPTION
Fix missing update in chart, and standard global.imageRegistry for registry override

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] PR only contains changes for one chart
