### PR TITLE
[sysdig-admission-controller] Add SCC in chart templates to support Openshift

### DIFF
--- a/charts/sysdig-admission-controller/CHANGELOG.md
+++ b/charts/sysdig-admission-controller/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2020-06-26 Charts v1.1.3 app v1.1.0
+
+### Minor changes
+
+- Add pre-install hook in charts to automatically label admission controller namespace
+
 ## 2020-06-26 Charts v1.1.2 app v1.1.0
 
 ### Minor changes

--- a/charts/sysdig-admission-controller/CHANGELOG.md
+++ b/charts/sysdig-admission-controller/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+## 2020-06-26 Charts v1.1.2 app v1.1.0
+
+### Minor changes
+
+- Add support for Openshift by deploying SecurityContextConstraint in Helm charts
+
+## 2020-06-25 Charts v1.1.1 app v1.1.0
+
+- Allow overriding registry in Helm Charts using `global.imageRegistry` for airgapped installs
+
+## 2020-05-27 Charts v1.1.0 app v1.1.0
+
+- Allow "check-scan" option in preScanPolicies to check scan result if available, but don't trigger a new scan
+
+## 2020-05-14 Charts v1.0.4 app v1.0.1
+
+- Fix glitch in namespace evaluation. Namespace can be in the object, or in the AdmissionReview (and object namespace be blank in that case)
+
+## 2020-05-13 Charts v1.0.3, app v1.0.1
+
+- Add proxy support
+
+## 2020-05-13 Charts v1.0.1, app v1.0.0
+
+- Fix: use object namespace instead of AdmissionReview namespace for evaluation 
+
+## 2020-05-12 Chart v1.0.0, app v1.0.0
+
+- Rebranding to sysdig-admission-controller
+- Simplified README.md move technical details to docs/Advanced.md
+
+## 2020-05-07 v0.2.0 
+
+- New pre-scan evaluation phase to make decissions before triggering image scan
+- Complete rewrite of evaluation rules
+- Include full set of automated testing for the rego rules
+
+## 2020-04-09 v0.1.2
+
+- Fix UID permission mismatch that made the container fail on some environments
+- Require sysdigSecureToken in values.yaml or fail
+
+## 2020-04-02 v0.1.1 
+
+- Add some more debug information
+- fix some default rules in helm charts
+
+## v0.1.0
+
+Initial release

--- a/charts/sysdig-admission-controller/Chart.yaml
+++ b/charts/sysdig-admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-admission-controller
 description: Sysdig Admission Controller using Sysdig Secure image scanner
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: 1.1.0
 home: https://sysdiglabs.github.io/sysdig-admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/sysdig-admission-controller/Chart.yaml
+++ b/charts/sysdig-admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-admission-controller
 description: Sysdig Admission Controller using Sysdig Secure image scanner
 type: application
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.1.0
 home: https://sysdiglabs.github.io/sysdig-admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/sysdig-admission-controller/templates/_helpers.tpl
+++ b/charts/sysdig-admission-controller/templates/_helpers.tpl
@@ -85,3 +85,15 @@ Allow overriding registry and repository for air-gapped environments
     {{- $globalRegistry | default $imageRegistry | default "docker.io" -}} / {{- $imageRepository -}} : {{- $imageTag -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "sysdig-image-scanner.kubectlImage" -}}
+{{- if .Values.kubectlImage.overrideValue -}}
+    {{- .Values.kubectlImage.overrideValue -}}
+{{- else -}}
+    {{- $imageRegistry := .Values.kubectlImage.registry -}}
+    {{- $imageRepository := .Values.kubectlImage.repository -}}
+    {{- $imageTag := .Values.kubectlImage.tag -}}
+    {{- $globalRegistry := (default .Values.global dict).imageRegistry -}}
+    {{- $globalRegistry | default $imageRegistry | default "docker.io" -}} / {{- $imageRepository -}} : {{- $imageTag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/sysdig-admission-controller/templates/patch-ns.yaml
+++ b/charts/sysdig-admission-controller/templates/patch-ns.yaml
@@ -1,0 +1,52 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  name: {{ .Release.Name }}-ns-patch
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  name: {{ .Release.Name }}-ns-patch
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-ns-patch
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-ns-patch
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: ns-patch
+        image: "{{ include "sysdig-image-scanner.kubectlImage" . }}"
+        imagePullPolicy: {{ .Values.kubectlImage.pullPolicy }}
+        args: ["label", "namespace", "{{ .Release.Namespace }}", "imagechecks.admission.sysdig.com/skip=true"]

--- a/charts/sysdig-admission-controller/templates/securitycontextconstraints.yaml
+++ b/charts/sysdig-admission-controller/templates/securitycontextconstraints.yaml
@@ -1,0 +1,25 @@
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: |
+      This provides the minimum requirements to the Sysdig Admission Controller to run in the Openshift.
+  name: {{ template "sysdig-image-scanner.fullname" . }}-scc
+  labels:
+{{ include "sysdig-image-scanner.labels" . | indent 4 }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+readOnlyRootFilesystem: true
+runAsUser:
+  type: "MustRunAs"
+  uid: 65532
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ include "sysdig-image-scanner.serviceAccountName" . }}
+{{- end }}

--- a/charts/sysdig-admission-controller/values.yaml
+++ b/charts/sysdig-admission-controller/values.yaml
@@ -10,6 +10,13 @@ image:
   # Override the default image tag. If not specified, it defaults to appVersion in Chart.yaml
   tag:
 
+kubectlImage:
+  # This image is used for running kubectl and patch the sysdig-admission-controller NS labels
+  repository: bitnami/kubectl
+  tag: 1.17.4
+  pullPolicy: IfNotPresent
+
+
 service:
   port: 8443
 


### PR DESCRIPTION
Add support for Openshift.

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] PR only contains changes for one chart
