### PR TITLE
[charts/sysdig] variable to add extra volumes

### DIFF
--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.8.2
+version: 1.8.3
 appVersion: 10.2.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -81,8 +81,8 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `tolerations`                     | The tolerations for scheduling                                                      | `node-role.kubernetes.io/master:NoSchedule` |
 | `prometheus.file`                 | Use file to configure promscrape                                                    | `false`                                     |
 | `prometheus.yaml`                 | prometheus.yaml content to configure metric collection: relabelling and filtering   | ` `                                         |
-| `extraVolume.volumes`             | Additional volumes to mount in the sysdig agent to pass new secrets or configmaps   | `{}`                                         |
-| `extraVolume.mounts`              | Mount points for additional volumes                                                 | `{}`                                         |
+| `extraVolume.volumes`             | Additional volumes to mount in the sysdig agent to pass new secrets or configmaps   | `[]`                                        |
+| `extraVolume.mounts`              | Mount points for additional volumes                                                 | `[]`                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -81,8 +81,8 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `tolerations`                     | The tolerations for scheduling                                                      | `node-role.kubernetes.io/master:NoSchedule` |
 | `prometheus.file`                 | Use file to configure promscrape                                                    | `false`                                     |
 | `prometheus.yaml`                 | prometheus.yaml content to configure metric collection: relabelling and filtering   | ` `                                         |
-| `extraVolume.volumes`             | Additional volumes to mount in the sysdig agent to pass new secrets or configmaps   | ` `                                         |
-| `extraVolume.mounts`              | Mount points for additional volumes                                                 | ` `                                         |
+| `extraVolume.volumes`             | Additional volumes to mount in the sysdig agent to pass new secrets or configmaps   | `{}`                                         |
+| `extraVolume.mounts`              | Mount points for additional volumes                                                 | `{}`                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -79,8 +79,10 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `auditLog.dynamicBackend.enabled` | Deploy the Audit Sink where Sysdig listens for K8s audit log events                 | `false`                                     |
 | `customAppChecks`                 | The custom app checks deployed with your agent                                      | `{}`                                        |
 | `tolerations`                     | The tolerations for scheduling                                                      | `node-role.kubernetes.io/master:NoSchedule` |
-| `prometheus.file`                 | Use file to configure promscrape                                                    | `false`                                         |
+| `prometheus.file`                 | Use file to configure promscrape                                                    | `false`                                     |
 | `prometheus.yaml`                 | prometheus.yaml content to configure metric collection: relabelling and filtering   | ` `                                         |
+| `extraVolume.volumes`             | Additional volumes to mount in the sysdig agent to pass new secrets or configmaps   | ` `                                         |
+| `extraVolume.mounts`              | Mount points for additional volumes                                                 | ` `                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -327,6 +329,30 @@ scrape_configs:
       deployment: prometheus-server
 ```
 `sysdig_sd_configs` allows to select the targets obtained by Sysdig agents to apply the rules in the job. Check [how to configure filtering in sysdig documentation](https://docs.sysdig.com/en/filtering-prometheus-metrics.html).
+
+
+### Adding additional volumes
+
+To add a new volume to the sysdig agent. 
+
+In order to pass new config maps or secrets used for authentication (for example for Prometheus endpoints) you can mount additional secrets, configmaps or volumes. An example of this could be:
+
+```yaml
+extraVolumes:
+  volumes:
+    - name: sysdig-new-cm
+      configMap:
+        name: my-cm
+        optional: true
+    - name: sysdig-new-secret
+        secret:
+        secretName: my-secret
+  mounts:
+    - mountPath: /opt/draios/cm
+      name: sysdig-new-cm
+    - mountPath: /opt/draios/secret
+      name: sysdig-new-secret
+```
 
 ## Support
 

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -165,6 +165,9 @@ spec:
             - mountPath: /host/etc/os-release
               name: osrel
               readOnly: true
+            {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes.mounts | indent 12 }}
+            {{- end }}
       volumes:
         - name: modprobe-d
           hostPath:
@@ -213,6 +216,9 @@ spec:
         - name: custom-app-checks-volume
           configMap:
             name: {{ template "sysdig.fullname" . }}-custom-app-checks
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes.volumes | indent 8 }}
         {{- end }}
   updateStrategy:
 {{ toYaml .Values.daemonset.updateStrategy | indent 4 }}

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -165,7 +165,7 @@ spec:
             - mountPath: /host/etc/os-release
               name: osrel
               readOnly: true
-            {{- if .Values.extraVolumes }}
+            {{- if .Values.extraVolumes.mounts }}
 {{ toYaml .Values.extraVolumes.mounts | indent 12 }}
             {{- end }}
       volumes:
@@ -217,7 +217,7 @@ spec:
           configMap:
             name: {{ template "sysdig.fullname" . }}-custom-app-checks
         {{- end }}
-        {{- if .Values.extraVolumes }}
+        {{- if .Values.extraVolumes.volumes }}
 {{ toYaml .Values.extraVolumes.volumes | indent 8 }}
         {{- end }}
   updateStrategy:

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -180,7 +180,7 @@ prometheus:
 
 extraVolumes:
   volumes: {}
-  mount: {}
+  mounts: {}
   # Allow passing extra volumes to the agent to mount secrets or certificates
   # to authenticate in different services.
   # Any kind of volume can be passed. Example:

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -179,8 +179,8 @@ prometheus:
   yaml: {}
 
 extraVolumes:
-  volumes: {}
-  mounts: {}
+  volumes: []
+  mounts: []
   # Allow passing extra volumes to the agent to mount secrets or certificates
   # to authenticate in different services.
   # Any kind of volume can be passed. Example:

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -178,7 +178,7 @@ prometheus:
   file: false
   yaml: {}
 
- #extraVolumes: {}
+extraVolumes: {}
   # Allow passing extra volumes to the agent to mount secrets or certificates
   # to authenticate in different services.
   # Any kind of volume can be passed. Example:

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -177,3 +177,23 @@ tolerations:
 prometheus:
   file: false
   yaml: {}
+
+#extraVolumes: {}
+  # Allow passing extra volumes to the agent to mount secrets or certificates
+  # to authenticate in different services.
+  # Any kind of volume can be passed. Example:
+  # 
+  # extraVolumes:
+  #   volumes:
+  #     - name: sysdig-new-cm
+  #       configMap:
+  #         name: my-cm
+  #         optional: true
+  #     - name: sysdig-new-secret
+  #       secret:
+  #         secretName: my-secret
+  #   mounts:
+  #     - mountPath: /opt/draios/cm
+  #       name: sysdig-new-cm
+  #     - mountPath: /opt/draios/secret
+  #       name: sysdig-new-secret

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -178,11 +178,11 @@ prometheus:
   file: false
   yaml: {}
 
-#extraVolumes: {}
+ #extraVolumes: {}
   # Allow passing extra volumes to the agent to mount secrets or certificates
   # to authenticate in different services.
   # Any kind of volume can be passed. Example:
-  # 
+  #
   # extraVolumes:
   #   volumes:
   #     - name: sysdig-new-cm

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -178,7 +178,9 @@ prometheus:
   file: false
   yaml: {}
 
-extraVolumes: {}
+extraVolumes:
+  volumes: {}
+  mount: {}
   # Allow passing extra volumes to the agent to mount secrets or certificates
   # to authenticate in different services.
   # Any kind of volume can be passed. Example:


### PR DESCRIPTION
add extra volumes in daemonset if set
examples in values
documented in readme

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] PR only contains changes for one chart
