### PR TITLE
[charts/harbor-scanner-sysdig-secure] fix: Apply the b64encode and then the quote

### DIFF
--- a/charts/harbor-scanner-sysdig-secure/Chart.yaml
+++ b/charts/harbor-scanner-sysdig-secure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: harbor-scanner-sysdig-secure
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 home: https://github.com/sysdiglabs/harbor-scanner-sysdig-secure
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/harbor-scanner-sysdig-secure/templates/secret.yaml
+++ b/charts/harbor-scanner-sysdig-secure/templates/secret.yaml
@@ -6,6 +6,6 @@ metadata:
     {{- include "harbor-scanner-sysdig-secure.labels" . | nindent 4 }}
 type: Opaque
 data:
-  sysdig_secure_api_token: {{ required "A valid .Values.sysdig.secure.apiToken is required" .Values.sysdig.secure.apiToken | quote | b64enc }}
-  harbor_robot_account_name: {{ .Values.inlineScanning.harbor.robotAccount.name | quote | b64enc }}
-  harbor_robot_account_password: {{ .Values.inlineScanning.harbor.robotAccount.password | quote | b64enc }}
+  sysdig_secure_api_token: {{ required "A valid .Values.sysdig.secure.apiToken is required" .Values.sysdig.secure.apiToken | b64enc | quote }}
+  harbor_robot_account_name: {{ .Values.inlineScanning.harbor.robotAccount.name | b64enc | quote }}
+  harbor_robot_account_password: {{ .Values.inlineScanning.harbor.robotAccount.password | b64enc | quote }}


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fixes the b64encoding and quotes

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x| Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] PR only contains changes for one chart
