### PR TITLE
[sysdig] Remove onPrem section and onprem.enable. Use collectorSettings instead

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -5,6 +5,12 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.9.1
+
+### Minor changes
+
+* Remove explicit *onPrem* option. Use *collectorSettings* section instead.
+
 ## v1.9.0
 
 ### Major changes
@@ -14,7 +20,6 @@ numbering uses [semantic versioning](http://semver.org).
 ### Minor changes
 
 * Include get/list/watch endpoints in agent clusterrole permissions.
-
 
 ## v1.8.1
 

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.9.0
+version: 1.9.1
 appVersion: 10.2.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -118,21 +118,19 @@ Installing the agent using the Helm chart is also possible in this scenario, and
 
 | Parameter                                | Description                                              | Default |
 | ---                                      | ---                                                      | ---     |
-| `onPrem.enabled`                         | Set to _true_ to enable the On-Prem setting              | `false` |
-| `onPrem.collectorHost`                   | The IP address or hostname of the collector              | ` `     |
-| `onPrem.collectorPort`                   | The port where collector is listening                    | 6443    |
-| `onPrem.ssl`                             | The collector accepts SSL                                | `true`  |
-| `onPrem.sslVerifyCertificate`            | Set to false if you don't want to verify SSL certificate | `true`  |
+| `collectorSettings.collectorHost`        | The IP address or hostname of the collector              | ` `     |
+| `collectorSettings.collectorPort`        | The port where collector is listening                    | 6443    |
+| `collectorSettings.ssl`                  | The collector accepts SSL                                | `true`  |
+| `collectorSettings.sslVerifyCertificate` | Set to false if you don't want to verify SSL certificate | `true`  |
 
 For example:
 
 ```bash
 $ helm install --name my-release \
     --set sysdig.accessKey=YOUR-KEY-HERE \
-    --set onPrem=true \
-    --set onPrem.collectorHost=42.32.196.18 \
-    --set onPrem.collectorPort=6443 \
-    --set onPrem.sslVerifyCertificate=false \
+    --set collectorSettings.collectorHost=42.32.196.18 \
+    --set collectorSettings.collectorPort=6443 \
+    --set collectorSettings.sslVerifyCertificate=false \
     sysdiglabs/sysdig
 ```
 

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -71,7 +71,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `clusterName`                     | Set a cluster name to identify events using *kubernetes.cluster.name* tag               | ` `                                         |
 | `sysdig.accessKey`                | Your Sysdig Monitor Access Key                                                          | `Nil` You must provide your own key         |
 | `sysdig.disableCaptures`          | Disable capture functionality (see https://docs.sysdig.com/en/disable-captures.html)    | `false`                                     |
-| `sysdig.settings`                 | Settings for agent's configuration file                                                 | ` `                                         |
+| `sysdig.settings`                 | Additional settings, directly included in the agent's configuration file `dragent.yaml` | `{}`                                        |
 | `secure.enabled`                  | Enable Sysdig Secure                                                                    | `true`                                      |
 | `auditLog.enabled`                | Enable K8s audit log support for Sysdig Secure                                          | `false`                                     |
 | `auditLog.auditServerUrl`         | The URL where Sysdig Agent listens for K8s audit log events                             | `0.0.0.0`                                   |

--- a/charts/sysdig/templates/configmap.yaml
+++ b/charts/sysdig/templates/configmap.yaml
@@ -29,11 +29,21 @@ data:
 {{- if eq $disableCaptures "true" }}
     sysdig_capture_enabled: false 
 {{- end }}
-{{- if .Values.onPrem.enabled }}
-    collector: {{ include "get_or_fail_if_in_settings" (dict "root" . "key" "onPrem.collectorHost" "setting" "collector") }}
-    collector_port: {{ include "get_or_fail_if_in_settings" (dict "root" . "key" "onPrem.collectorPort" "setting" "collector_port") }}
-    ssl: {{ include "get_or_fail_if_in_settings" (dict "root" . "key" "onPrem.ssl" "setting" "ssl") }}
-    ssl_verify_certificate:  {{ include "get_or_fail_if_in_settings" (dict "root" . "key" "onPrem.sslVerifyCertificate" "setting" "ssl_verify_certificate") }}
+{{- $collectorHost := include "get_or_fail_if_in_settings" (dict "root" . "key" "collectorSettings.collectorHost" "setting" "collector")}}
+{{- if $collectorHost }}
+    collector: {{ $collectorHost }}
+{{- end }}
+{{- $collectorPort := include "get_or_fail_if_in_settings" (dict "root" . "key" "collectorSettings.collectorPort" "setting" "collector_port")}}
+{{- if $collectorPort }}
+    collector_port: {{ $collectorPort }}
+{{- end }}
+{{- $ssl := include "get_or_fail_if_in_settings" (dict "root" . "key" "collectorSettings.ssl" "setting" "ssl")}}
+{{- if $ssl }}
+    ssl: {{ $ssl }}
+{{- end }}
+{{- $sslVerifyCertificate := include "get_or_fail_if_in_settings" (dict "root" . "key" "collectorSettings.sslVerifyCertificate" "setting" "ssl_verify_certificate")}}
+{{- if $sslVerifyCertificate }}
+    ssl_verify_certificate: {{ $sslVerifyCertificate }}
 {{- end }}
 {{- if .Values.sysdig.settings }}
 {{ toYaml .Values.sysdig.settings | indent 4 }}

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -121,13 +121,12 @@ slim:
     limits:
       memory: 512Mi
 
-# Set onPrem.enabled=true and set corresponding fields for Sysdig On-Prem installations
-onPrem:
-  enabled: false
+# For Sysdig On-Prem installations or for custom collector settings, set the following fields
+collectorSettings:
   collectorHost:
-  collectorPort: 6443
-  ssl: true
-  sslVerifyCertificate: true
+  collectorPort:
+  ssl:
+  sslVerifyCertificate:
 
 # Setting a cluster name allows you to filter events from this cluster using kubernetes.cluster.name
 clusterName: ""
@@ -139,6 +138,7 @@ sysdig:
   # Disable capture functionality (see https://docs.sysdig.com/en/disable-captures.html)
   disableCaptures: false
 
+  # Advanced settings. Any option in here will be directly translated into dragent.yaml in the Configmap
   settings: {}
     ### Agent tags
     # tags: linux:ubuntu,dept:dev,local:nyc


### PR DESCRIPTION
* onPrem section might cause confusion, as the collector settings have other use cases, like IBM Cloud or SaaS in different regions. Remove that section and use *collectorSettings* instead, and update documentation.
* Make clear that sysdig.settings is a raw YAML setting that gets directly translated into dragent.yaml in the configmap.

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
