### PR TITLE
[sysdig] Bump version agent to 10.3.0 and chart to 1.9.2

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -5,6 +5,12 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.9.2
+
+### Minor changes
+
+* Use latest image from Agent (10.3.0)
+
 ## v1.9.1
 
 ### Minor changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sysdig
-version: 1.9.1
-appVersion: 10.2.0
+version: 1.9.2
+appVersion: 10.3.0
 description: Sysdig Monitor and Secure agent
 keywords:
   - monitoring

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | ---                               | ---                                                                                     | ---                                         |
 | `image.registry`                  | Sysdig Agent image registry                                                             | `docker.io`                                 |
 | `image.repository`                | The image repository to pull from                                                       | `sysdig/agent`                              |
-| `image.tag`                       | The image tag to pull                                                                   | `10.2.0`                       |
+| `image.tag`                       | The image tag to pull                                                                   | `10.3.0`                       |
 | `image.pullPolicy`                | The Image pull policy                                                                   | `IfNotPresent`                              |
 | `image.pullSecrets`               | Image pull secrets                                                                      | `nil`                                       |
 | `resources.requests.cpu`          | CPU requested for being run in a node                                                   | `600m`                                      |

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -9,7 +9,7 @@ image:
 
   registry: docker.io
   repository: sysdig/agent
-  tag: 10.2.0
+  tag: 10.3.0
   # Specify a imagePullPolicy
   # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
