### PR TITLE
Sysdig Helm Chart output message

### DIFF
--- a/charts/sysdig/templates/NOTES.txt
+++ b/charts/sysdig/templates/NOTES.txt
@@ -1,8 +1,8 @@
 The agent for Sysdig Secure DevOps Platform is spinning up on each node in your
 cluster. After a few seconds, you should see your hosts appearing in the
-Explore tab:
+Sysdig Agent Health & Status Dashboard:
 
-  https://app.sysdigcloud.com/#/explore/overview/l:10
+  https://app.sysdigcloud.com/#/dashboard-template/view.sysdig.agents?last=10
 
   https://secure.sysdig.com/#/events/l:600/*/*?viewAs=list
 


### PR DESCRIPTION
After deployment message updated. 

To check for a successful installation of the agent, we may point users to the new Dashboard Template for Agent Health & Status, instead of Explore.

Pls @nestorsalceda review this PR. Let me know if this is not the right way to do this! Thanks!

## What this PR does / why we need it:
This just updates the message displayed after deploying the agent with Helm. Or at least that is what I tried :D

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart

None of the above fields applies I guess, it is the same message no matter the chart, no new variables to document, 
