### PR TITLE
After release, copy README.md files to gh-pages branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,11 @@ jobs:
         uses: helm/chart-releaser-action@v1.0.0-rc.2
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Copy README.md files to gh-pages
+        run: |
+          git rm --cached charts/**/README.md
+          git checkout -f gh-pages
+          git add charts
+          git commit -m "Updating README.md files"
+          git push


### PR DESCRIPTION
## What this PR does / why we need it:

The gh-pages branch template now can generate dynamically a list of charts and links to the README.md files converted by Jekyll. But in order for that to work, we need to copy the README.md files to that branch.

This step in the workflow copies the README.md files to the gh-pages branch and creates a commit, making all updates in the README.md available and published in the Github Pages after every commit.

See the commit https://github.com/sysdiglabs/charts/commit/76ffc359500070d86c9b7ec0461056682da9a1e9 for the dynamic inventory of README.md files.