### PR TITLE
Check worktree and remove if already existing

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Run chart-testing (install)
         uses: helm/chart-testing-action@v1.0.0-rc.2
+        if: steps.lint.outputs.changed == 'true'
         with:
           command: install
           config: ct.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Copy README.md files to gh-pages
         run: |
-          # Remove worktree from previous step, if existing
-          git worktree remove gh-pages || true
+          existing_worktree=$(git worktree list --porcelain | grep -B 2 "branch refs/heads/gh-pages" | head -n 1 | cut -d ' ' -f 2)
+          if [[ $existing_worktree != "" ]]; then git worktree remove -f $existing_worktree; fi
           tmp_folder=$(mktemp -d)
           git worktree add ${tmp_folder} gh-pages
           rm -f -r ${tmp_folder}/charts


### PR DESCRIPTION
## What this PR does / why we need it:

Fix some checks that are done before the README.md files are copied to the gh-pages branch
