### PR TITLE
[sysdig] Sysdig agent 1.11.0

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -5,6 +5,17 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.11.0
+
+### Major changes
+
+* Node Image Analyzer now deployed by default (`nodeImageAnalyzer.deploy` set to `true` by default)
+
+### Minor changes
+
+** Use the latest image from Agent (10.7.0)
+
+
 ## v1.10.5
 
 * Use the latest image from Node Image Analyzer (0.1.6)

--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -10,11 +10,12 @@ numbering uses [semantic versioning](http://semver.org).
 ### Major changes
 
 * Node Image Analyzer now deployed by default (`nodeImageAnalyzer.deploy` set to `true` by default)
+* Explain all Node Image Analyzer settings in values.yaml and README, and link to official Sysdig docs
 
 ### Minor changes
 
-** Use the latest image from Agent (10.7.0)
-
+* Use the latest image from Agent (10.7.0)
+* Change check_certificate to ssl_verify_certificate in NIA settings to sync with NIA configmap
 
 ## v1.10.5
 

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sysdig
-version: 1.10.5
-appVersion: 10.6.0
+version: 1.11.0
+appVersion: 10.7.0
 description: Sysdig Monitor and Secure agent
 keywords:
   - monitoring

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -43,58 +43,66 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Sysdig chart and their default values.
 
-| Parameter                                     | Description                                                                              | Default                                     |
-| ---                                           | ---                                                                                      | ---                                         |
-| `image.registry`                              | Sysdig Agent image registry                                                              | `docker.io`                                 |
-| `image.repository`                            | The image repository to pull from                                                        | `sysdig/agent`                              |
-| `image.tag`                                   | The image tag to pull                                                                    | `10.7.0`                                    |
-| `image.pullPolicy`                            | The Image pull policy                                                                    | `IfNotPresent`                              |
-| `image.pullSecrets`                           | Image pull secrets                                                                       | `nil`                                       |
-| `resources.requests.cpu`                      | CPU requested for being run in a node                                                    | `600m`                                      |
-| `resources.requests.memory`                   | Memory requested for being run in a node                                                 | `512Mi`                                     |
-| `resources.limits.cpu`                        | CPU limit                                                                                | `2000m`                                     |
-| `resources.limits.memory`                     | Memory limit                                                                             | `1536Mi`                                    |
-| `rbac.create`                                 | If true, create & use RBAC resources                                                     | `true`                                      |
-| `scc.create`                                  | Create OpenShift's Security Context Constraint                                           | `true`                                      |
-| `psp.create`                                  | Create Pod Security Policy to allow the agent running in clusters with PSP enabled       | `true`                                      |
-| `serviceAccount.create`                       | Create serviceAccount                                                                    | `true`                                      |
-| `serviceAccount.name`                         | Use this value as serviceAccountName                                                     | ` `                                         |
-| `daemonset.updateStrategy.type`               | The updateStrategy for updating the daemonset                                            | `RollingUpdate`                             |
-| `daemonset.nodeSelector`                      | Node Selector                                                                            | `{}`                                        |
-| `daemonset.affinity`                          | Node affinities                                                                          | `schedule on amd64 and linux`               |
-| `daemonset.annotations`                       | Custom annotations for daemonset                                                         | `{}`                                        |
-| `slim.enabled`                                | Use the slim based Sysdig Agent image                                                    | `false`                                     |
-| `slim.kmoduleImage.repository`                | The kernel module image builder repository to pull from                                  | `sysdig/agent-kmodule`                      |
-| `slim.resources.requests.cpu`                 | CPU requested for building the kernel module                                             | `1000m`                                     |
-| `slim.resources.requests.memory`              | Memory requested for building the kernel module                                          | `348Mi`                                     |
-| `slim.resources.limits.memory`                | Memory limit for building the kernel module                                              | `512Mi`                                     |
-| `ebpf.enabled`                                | Enable eBPF support for Sysdig instead of `sysdig-probe` kernel module                   | `false`                                     |
-| `ebpf.settings.mountEtcVolume`                | Needed to detect which kernel version are running in Google COS                          | `true`                                      |
-| `clusterName`                                 | Set a cluster name to identify events using *kubernetes.cluster.name* tag                | ` `                                         |
-| `sysdig.accessKey`                            | Your Sysdig Monitor Access Key                                                           | `Nil` You must provide your own key         |
-| `sysdig.disableCaptures`                      | Disable capture functionality (see https://docs.sysdig.com/en/disable-captures.html)     | `false`                                     |
-| `sysdig.settings`                             | Additional settings, directly included in the agent's configuration file `dragent.yaml`  | `{}`                                        |
-| `secure.enabled`                              | Enable Sysdig Secure                                                                     | `true`                                      |
-| `auditLog.enabled`                            | Enable K8s audit log support for Sysdig Secure                                           | `false`                                     |
-| `auditLog.auditServerUrl`                     | The URL where Sysdig Agent listens for K8s audit log events                              | `0.0.0.0`                                   |
-| `auditLog.auditServerPort`                    | Port where Sysdig Agent listens for K8s audit log events                                 | `7765`                                      |
-| `auditLog.dynamicBackend.enabled`             | Deploy the Audit Sink where Sysdig listens for K8s audit log events                      | `false`                                     |
-| `customAppChecks`                             | The custom app checks deployed with your agent                                           | `{}`                                        |
-| `nodeImageAnalyzer.deploy`                    | Deploy the Node Image Analyzer (See https://docs.sysdig.com/en/scan-running-images.html) | `true`                                      |
-| `nodeImageAnalyzer.image.repository`          | The image repository to pull the Node Image Analyzer from                                | `sysdig/node-image-analyzer`                |
-| `nodeImageAnalyzer.image.tag`                 | The image tag to pull the Node Image Analyzer                                            | `0.1.6`                                     |
-| `nodeImageAnalyzer.image.pullPolicy`          | The Image pull policy for the Node Image Analyzer                                        | `IfNotPresent`                              |
-| `nodeImageAnalyzer.image.pullSecrets`         | Image pull secrets for the Node Image Analyzer                                           | `nil`                                       |
-| `nodeImageAnalyzer.resources.requests.cpu`    | Node Image Analyzer CPU requests per node                                                | `250m`                                      |
-| `nodeImageAnalyzer.resources.requests.memory` | Node Image Analyzer Memory requests per node                                             | `512Mi`                                     |
-| `nodeImageAnalyzer.resources.limits.cpu`      | Node Image Analyzer CPU limit per node                                                   | `500m`                                      |
-| `nodeImageAnalyzer.resources.limits.memory`   | Node Image Analyzer Memory limit per node                                                | `1024Mi`                                    |
-| `nodeImageAnalyzer.settings`                  | Additional Node Image Analyzer settings                                                  | `{}`                                        |
-| `tolerations`                                 | The tolerations for scheduling                                                           | `node-role.kubernetes.io/master:NoSchedule` |
-| `prometheus.file`                             | Use file to configure promscrape                                                         | `false`                                     |
-| `prometheus.yaml`                             | prometheus.yaml content to configure metric collection: relabelling and filtering        | ` `                                         |
-| `extraVolume.volumes`                         | Additional volumes to mount in the sysdig agent to pass new secrets or configmaps        | `[]`                                        |
-| `extraVolume.mounts`                          | Mount points for additional volumes                                                      | `[]`                                        |
+| Parameter                                         | Description                                                                              | Default                                     |
+| ---                                               | ---                                                                                      | ---                                         |
+| `image.registry`                                  | Sysdig Agent image registry                                                              | `docker.io`                                 |
+| `image.repository`                                | The image repository to pull from                                                        | `sysdig/agent`                              |
+| `image.tag`                                       | The image tag to pull                                                                    | `10.7.0`                                    |
+| `image.pullPolicy`                                | The Image pull policy                                                                    | `IfNotPresent`                              |
+| `image.pullSecrets`                               | Image pull secrets                                                                       | `nil`                                       |
+| `resources.requests.cpu`                          | CPU requested for being run in a node                                                    | `600m`                                      |
+| `resources.requests.memory`                       | Memory requested for being run in a node                                                 | `512Mi`                                     |
+| `resources.limits.cpu`                            | CPU limit                                                                                | `2000m`                                     |
+| `resources.limits.memory`                         | Memory limit                                                                             | `1536Mi`                                    |
+| `rbac.create`                                     | If true, create & use RBAC resources                                                     | `true`                                      |
+| `scc.create`                                      | Create OpenShift's Security Context Constraint                                           | `true`                                      |
+| `psp.create`                                      | Create Pod Security Policy to allow the agent running in clusters with PSP enabled       | `true`                                      |
+| `serviceAccount.create`                           | Create serviceAccount                                                                    | `true`                                      |
+| `serviceAccount.name`                             | Use this value as serviceAccountName                                                     | ` `                                         |
+| `daemonset.updateStrategy.type`                   | The updateStrategy for updating the daemonset                                            | `RollingUpdate`                             |
+| `daemonset.nodeSelector`                          | Node Selector                                                                            | `{}`                                        |
+| `daemonset.affinity`                              | Node affinities                                                                          | `schedule on amd64 and linux`               |
+| `daemonset.annotations`                           | Custom annotations for daemonset                                                         | `{}`                                        |
+| `slim.enabled`                                    | Use the slim based Sysdig Agent image                                                    | `false`                                     |
+| `slim.kmoduleImage.repository`                    | The kernel module image builder repository to pull from                                  | `sysdig/agent-kmodule`                      |
+| `slim.resources.requests.cpu`                     | CPU requested for building the kernel module                                             | `1000m`                                     |
+| `slim.resources.requests.memory`                  | Memory requested for building the kernel module                                          | `348Mi`                                     |
+| `slim.resources.limits.memory`                    | Memory limit for building the kernel module                                              | `512Mi`                                     |
+| `ebpf.enabled`                                    | Enable eBPF support for Sysdig instead of `sysdig-probe` kernel module                   | `false`                                     |
+| `ebpf.settings.mountEtcVolume`                    | Needed to detect which kernel version are running in Google COS                          | `true`                                      |
+| `clusterName`                                     | Set a cluster name to identify events using *kubernetes.cluster.name* tag                | ` `                                         |
+| `sysdig.accessKey`                                | Your Sysdig Monitor Access Key                                                           | `Nil` You must provide your own key         |
+| `sysdig.disableCaptures`                          | Disable capture functionality (see https://docs.sysdig.com/en/disable-captures.html)     | `false`                                     |
+| `sysdig.settings`                                 | Additional settings, directly included in the agent's configuration file `dragent.yaml`  | `{}`                                        |
+| `secure.enabled`                                  | Enable Sysdig Secure                                                                     | `true`                                      |
+| `auditLog.enabled`                                | Enable K8s audit log support for Sysdig Secure                                           | `false`                                     |
+| `auditLog.auditServerUrl`                         | The URL where Sysdig Agent listens for K8s audit log events                              | `0.0.0.0`                                   |
+| `auditLog.auditServerPort`                        | Port where Sysdig Agent listens for K8s audit log events                                 | `7765`                                      |
+| `auditLog.dynamicBackend.enabled`                 | Deploy the Audit Sink where Sysdig listens for K8s audit log events                      | `false`                                     |
+| `customAppChecks`                                 | The custom app checks deployed with your agent                                           | `{}`                                        |
+| `nodeImageAnalyzer.deploy`                        | Deploy the Node Image Analyzer (See https://docs.sysdig.com/en/scan-running-images.html) | `true`                                      |
+| `nodeImageAnalyzer.settings.dockerSocketPath`     | The Docker socket path                                                                   |                                             |
+| `nodeImageAnalyzer.settings.criSocketPath`        | The socket path to a CRI compatible runtime, such as CRI-O                               |                                             |
+| `nodeImageAnalyzer.settings.containerdSocketPath` | The socket path to a CRI-Containerd daemon                                               |                                             |
+| `nodeImageAnalyzer.settings.collectorEndpoint`    | The endpoint to the Scanning Analysis collector                                          |                                             |
+| `nodeImageAnalyzer.settings.sslVerifyCertificate` | Can be set to false to allow insecure connections to the Sysdig backend, such as On-Prem |                                             |
+| `nodeImageAnalyzer.settings.debug`                | Can be set to true to show debug logging, useful for troubleshooting                     |                                             |
+| `nodeImageAnalyzer.settings.httpProxy`            | Proxy configuration variables                                                            |                                             |
+| `nodeImageAnalyzer.settings.httpsProxy`           | Proxy configuration variables                                                            |                                             |
+| `nodeImageAnalyzer.settings.noProxy`              | Proxy configuration variables                                                            |                                             |
+| `nodeImageAnalyzer.image.repository`              | The image repository to pull the Node Image Analyzer from                                | `sysdig/node-image-analyzer`                |
+| `nodeImageAnalyzer.image.tag`                     | The image tag to pull the Node Image Analyzer                                            | `0.1.6`                                     |
+| `nodeImageAnalyzer.image.pullPolicy`              | The Image pull policy for the Node Image Analyzer                                        | `IfNotPresent`                              |
+| `nodeImageAnalyzer.image.pullSecrets`             | Image pull secrets for the Node Image Analyzer                                           | `nil`                                       |
+| `nodeImageAnalyzer.resources.requests.cpu`        | Node Image Analyzer CPU requests per node                                                | `250m`                                      |
+| `nodeImageAnalyzer.resources.requests.memory`     | Node Image Analyzer Memory requests per node                                             | `512Mi`                                     |
+| `nodeImageAnalyzer.resources.limits.cpu`          | Node Image Analyzer CPU limit per node                                                   | `500m`                                      |
+| `nodeImageAnalyzer.resources.limits.memory`       | Node Image Analyzer Memory limit per node                                                | `1024Mi`                                    |
+| `tolerations`                                     | The tolerations for scheduling                                                           | `node-role.kubernetes.io/master:NoSchedule` |
+| `prometheus.file`                                 | Use file to configure promscrape                                                         | `false`                                     |
+| `prometheus.yaml`                                 | prometheus.yaml content to configure metric collection: relabelling and filtering        | ` `                                         |
+| `extraVolume.volumes`                             | Additional volumes to mount in the sysdig agent to pass new secrets or configmaps        | `[]`                                        |
+| `extraVolume.mounts`                              | Mount points for additional volumes                                                      | `[]`                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -111,6 +119,17 @@ $ helm install --name my-release -f values.yaml sysdiglabs/sysdig
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Node Image Analyzer
+
+The Node Image Analyzer is now deployed by default unless you set the value `nodeImageAnalyzer.deploy` to `false`.
+
+See the [Node Image Analyzer documentation](https://docs.sysdig.com/en/scan-running-images.html) for details about the available options, and
+[Running Node Image Analyzer Behind a Proxy](https://docs.sysdig.com/en/scan-running-images.html#UUID-b3b07aa6-db02-eb58-050f-15c9e053bb64_section-idm232105909710949) for proxy settings.
+
+The node image analyzer (NIA) provides the capability to scan images as soon as they start running on hosts where the analyzer is installed. It is typically installed alongside the Sysdig agent container.
+
+On container start-up, the analyzer scans all pre-existing running images present in the node. Additionally, it will scan any new image that enters a running state in the node. It will scan each image once, then forward the results to the Sysdig Secure scanning backend. Image metadata and the full scan report is then available in the Sysdig Secure UI.
 
 ## On-Premise backend deployment settings
 

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | ---                                           | ---                                                                                      | ---                                         |
 | `image.registry`                              | Sysdig Agent image registry                                                              | `docker.io`                                 |
 | `image.repository`                            | The image repository to pull from                                                        | `sysdig/agent`                              |
-| `image.tag`                                   | The image tag to pull                                                                    | `10.6.0`                                    |
+| `image.tag`                                   | The image tag to pull                                                                    | `10.7.0`                                    |
 | `image.pullPolicy`                            | The Image pull policy                                                                    | `IfNotPresent`                              |
 | `image.pullSecrets`                           | Image pull secrets                                                                       | `nil`                                       |
 | `resources.requests.cpu`                      | CPU requested for being run in a node                                                    | `600m`                                      |
@@ -80,7 +80,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `auditLog.auditServerPort`                    | Port where Sysdig Agent listens for K8s audit log events                                 | `7765`                                      |
 | `auditLog.dynamicBackend.enabled`             | Deploy the Audit Sink where Sysdig listens for K8s audit log events                      | `false`                                     |
 | `customAppChecks`                             | The custom app checks deployed with your agent                                           | `{}`                                        |
-| `nodeImageAnalyzer.deploy`                    | Deploy the Node Image Analyzer (See https://docs.sysdig.com/en/scan-running-images.html) | `false`                                     |
+| `nodeImageAnalyzer.deploy`                    | Deploy the Node Image Analyzer (See https://docs.sysdig.com/en/scan-running-images.html) | `true`                                      |
 | `nodeImageAnalyzer.image.repository`          | The image repository to pull the Node Image Analyzer from                                | `sysdig/node-image-analyzer`                |
 | `nodeImageAnalyzer.image.tag`                 | The image tag to pull the Node Image Analyzer                                            | `0.1.6`                                     |
 | `nodeImageAnalyzer.image.pullPolicy`          | The Image pull policy for the Node Image Analyzer                                        | `IfNotPresent`                              |

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -80,6 +80,11 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `auditLog.auditServerPort`                        | Port where Sysdig Agent listens for K8s audit log events                                 | `7765`                                      |
 | `auditLog.dynamicBackend.enabled`                 | Deploy the Audit Sink where Sysdig listens for K8s audit log events                      | `false`                                     |
 | `customAppChecks`                                 | The custom app checks deployed with your agent                                           | `{}`                                        |
+| `tolerations`                                     | The tolerations for scheduling                                                           | `node-role.kubernetes.io/master:NoSchedule` |
+| `prometheus.file`                                 | Use file to configure promscrape                                                         | `false`                                     |
+| `prometheus.yaml`                                 | prometheus.yaml content to configure metric collection: relabelling and filtering        | ` `                                         |
+| `extraVolume.volumes`                             | Additional volumes to mount in the sysdig agent to pass new secrets or configmaps        | `[]`                                        |
+| `extraVolume.mounts`                              | Mount points for additional volumes                                                      | `[]`                                        |
 | `nodeImageAnalyzer.deploy`                        | Deploy the Node Image Analyzer (See https://docs.sysdig.com/en/scan-running-images.html) | `true`                                      |
 | `nodeImageAnalyzer.settings.dockerSocketPath`     | The Docker socket path                                                                   |                                             |
 | `nodeImageAnalyzer.settings.criSocketPath`        | The socket path to a CRI compatible runtime, such as CRI-O                               |                                             |
@@ -98,11 +103,8 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `nodeImageAnalyzer.resources.requests.memory`     | Node Image Analyzer Memory requests per node                                             | `512Mi`                                     |
 | `nodeImageAnalyzer.resources.limits.cpu`          | Node Image Analyzer CPU limit per node                                                   | `500m`                                      |
 | `nodeImageAnalyzer.resources.limits.memory`       | Node Image Analyzer Memory limit per node                                                | `1024Mi`                                    |
-| `tolerations`                                     | The tolerations for scheduling                                                           | `node-role.kubernetes.io/master:NoSchedule` |
-| `prometheus.file`                                 | Use file to configure promscrape                                                         | `false`                                     |
-| `prometheus.yaml`                                 | prometheus.yaml content to configure metric collection: relabelling and filtering        | ` `                                         |
-| `extraVolume.volumes`                             | Additional volumes to mount in the sysdig agent to pass new secrets or configmaps        | `[]`                                        |
-| `extraVolume.mounts`                              | Mount points for additional volumes                                                      | `[]`                                        |
+| `nodeImageAnalyzer.extraVolume.volumes`           | Additional volumes to mount in the Node Image Analyzer (i.e. for docker socket)          | `[]`                                        |
+| `nodeImageAnalyzer.extraVolume.mounts`            | Mount points for additional volumes                                                      | `[]`                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/sysdig/templates/configmap-image-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-image-analyzer.yaml
@@ -6,7 +6,24 @@ metadata:
   labels:
 {{ include "sysdig.labels" . | indent 4 }}
 data:
+  {{- if .Values.nodeImageAnalyzer.settings.dockerSocketPath }}
+  docker_socket_path: {{ .Values.nodeImageAnalyzer.settings.dockerSocketPath }}
+  {{- end }}
+  {{- if .Values.nodeImageAnalyzer.settings.criSocketPath }}
+  cri_socket_path: {{ .Values.nodeImageAnalyzer.settings.criSocketPath }}
+  {{- end }}
+  {{- if .Values.nodeImageAnalyzer.settings.containerdSocketPath }}
+  containerd_socket_path: {{ .Values.nodeImageAnalyzer.settings.containerdSocketPath }}
+  {{- end }}
+  {{- if .Values.nodeImageAnalyzer.settings.collectorEndpoint }}
+  collector_endpoint: {{ .Values.nodeImageAnalyzer.settings.collectorEndpoint }}
+  {{- end }}
+  {{- if .Values.nodeImageAnalyzer.settings.sslVerifyCertificate }}
+  ssl_verify_certificate: {{ .Values.nodeImageAnalyzer.settings.sslVerifyCertificate }}
+  {{- end }}
+
   debug: "{{ .Values.nodeImageAnalyzer.settings.debug | default false }}"
+
   {{- if .Values.nodeImageAnalyzer.settings.imagePeriod }}
   image_period: {{ .Values.nodeImageAnalyzer.settings.imagePeriod }}
   {{- end }}
@@ -16,19 +33,16 @@ data:
   {{- if .Values.nodeImageAnalyzer.settings.reportPeriod }}
   report_period: {{ .Values.nodeImageAnalyzer.settings.reportPeriod }}
   {{- end }}
-  {{- if .Values.nodeImageAnalyzer.settings.dockerSocketPath }}
-  docker_socket_path: {{ .Values.nodeImageAnalyzer.settings.dockerSocketPath }}
-  {{- end }}
-  {{- if .Values.nodeImageAnalyzer.settings.criSocketPath }}
-  cri_socket_path: {{ .Values.nodeImageAnalyzer.settings.criSocketPath }}
-  {{- end }}
-  {{- if .Values.nodeImageAnalyzer.settings.collectorEndpoint }}
-  collector_endpoint: {{ .Values.nodeImageAnalyzer.settings.collectorEndpoint }}
-  {{- end }}
-  {{- if .Values.nodeImageAnalyzer.settings.checkCertificate }}
-  check_certificate: {{ .Values.nodeImageAnalyzer.settings.checkCertificate }}
-  {{- end }}
   {{- if .Values.nodeImageAnalyzer.settings.collectorTimeout }}
   collector_timeout: {{ .Values.nodeImageAnalyzer.settings.collectorTimeout }}
   {{- end }}
+  {{- if .Values.nodeImageAnalyzer.settings.httpProxy }}
+  http_proxy: {{ .Values.nodeImageAnalyzer.settings.httpProxy }}
+  {{- end -}}
+  {{- if .Values.nodeImageAnalyzer.settings.httpsProxy }}
+  https_proxy: {{ .Values.nodeImageAnalyzer.settings.httpsProxy }}
+  {{- end -}}
+  {{- if .Values.nodeImageAnalyzer.settings.noProxy }}
+  no_proxy: {{ .Values.nodeImageAnalyzer.settings.noProxy }}
+  {{- end -}}
 {{- end }}

--- a/charts/sysdig/templates/daemonset-image-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-image-analyzer.yaml
@@ -43,6 +43,9 @@ spec:
           configMap:
             name: {{ template "sysdig.fullname" . }}-image-analyzer
             optional: true
+        {{- if .Values.nodeImageAnalyzer.extraVolumes.volumes }}
+{{ toYaml .Values.nodeImageAnalyzer.extraVolumesvolumes | indent 8 }}
+        {{- end }}
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
@@ -71,6 +74,10 @@ spec:
             readOnly: true
           - mountPath: /var/lib/containers
             name: var-lib-containers-vol
+          # Custom volume mount here
+          {{- if .Values.extraVolumes.mounts }}
+{{ toYaml .Values.nodeImageAnalyzer.extraVolumes.mounts | indent 10 }}
+          {{- end }}
         env:
         - name: ACCESS_KEY
           valueFrom:
@@ -107,14 +114,18 @@ spec:
               name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: cri_socket_path
               optional: true
-        #TODO: Get from agent config instead?
+        - name: CONTAINERD_SOCKET_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              key: containerd_socket_path
+              optional: true
         - name: AM_COLLECTOR_ENDPOINT
           valueFrom:
             configMapKeyRef:
               name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: collector_endpoint
               optional: true
-        #TODO: Get from agent config instead?
         - name: AM_COLLECTOR_TIMEOUT
           valueFrom:
             configMapKeyRef:
@@ -144,5 +155,23 @@ spec:
             configMapKeyRef:
               name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: debug
+              optional: true
+        - name: HTTP_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              key: http_proxy
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              key: https_proxy
+              optional: true
+        - name: NO_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              key: no_proxy
               optional: true
 {{- end }}

--- a/charts/sysdig/templates/daemonset-image-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-image-analyzer.yaml
@@ -121,11 +121,11 @@ spec:
               name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: collector_timeout
               optional: true
-        - name: CHECK_CERTIFICATE
+        - name: VERIFY_CERTIFICATE
           valueFrom:
             configMapKeyRef:
               name: {{ template "sysdig.fullname" . }}-image-analyzer
-              key: check_certificate
+              key: ssl_verify_certificate
               optional: true
         - name: K8S_NODE_NAME
           valueFrom:

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -179,6 +179,41 @@ nodeImageAnalyzer:
     pullPolicy: IfNotPresent
     # pullSecrets:
     #   - name: myRegistrKeySecretName
+
+  settings:
+    # The Docker socket path.
+    # If a custom path is specified, ensure it is correctly mounted from the host inside the container.
+    #dockerSocketPath: unix:///var/run/docker/docker.sock
+
+    # The socket path to a CRI compatible runtime, such as CRI-O.
+    # If a custom path is specified, ensure it is correctly mounted from the host inside the container.
+    #criSocketPath: unix:///var/run/crio/crio.sock
+
+    # The socket path to a CRI-Containerd daemon.
+    # If a custom path is specified, ensure it is correctly mounted from the host inside the container.
+    #containerdSocketPath: unix:///var/run/containerd/containerd.sock
+
+    # The endpoint to the Scanning Analysis collector, specified in the following format:
+    # https://<API_ENDPOINT>/internal/scanning/scanning-analysis-collector
+    # * SaaS default region (US East): leave empty
+    # * SaaS US Web: https://us2.app.sysdig.com/internal/scanning/scanning-analysis-collector
+    # * SaaS European Union: https://eu1.app.sysdig.com/internal/scanning/scanning-analysis-collector
+    # * On-Prem: https://sysdig.my.company.com/internal/scanning/scanning-analysis-collector
+    #collectorEndpoint: https://sysdig.my.company.com/internal/scanning/scanning-analysis-collector
+
+    # Can be set to false to allow insecure connections to the Sysdig backend,
+    # such as for on-premise installs that use self-signed certificates.
+    # By default, certificates are always verified.
+    #sslVerifyCertificate: false
+
+    # Can be set to true to show debug logging, useful for troubleshooting.
+    #debug: false
+
+    # Proxy configuration variables. See also: [Running Node Image Analyzer Behind a Proxy](https://docs.sysdig.com/en/scan-running-images.html#UUID-b3b07aa6-db02-eb58-050f-15c9e053bb64_section-idm232105909710949)
+    #httpProxy:
+    #httpsProxy:
+    #noProxy:
+
   resources:
     requests:
       cpu: 250m
@@ -186,9 +221,6 @@ nodeImageAnalyzer:
     limits:
       cpu: 500m
       memory: 1024Mi
-
-  # Additional advanced settings
-  settings: {}
 
 customAppChecks: {}
   # Allow passing custom app checks for Sysdig Agent.

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -183,7 +183,7 @@ nodeImageAnalyzer:
   settings:
     # The Docker socket path.
     # If a custom path is specified, ensure it is correctly mounted from the host inside the container.
-    # dockerSocketPath: unix:///var/run/docker/docker.sock
+    # dockerSocketPath: unix:///var/run/docker.sock
 
     # The socket path to a CRI compatible runtime, such as CRI-O.
     # If a custom path is specified, ensure it is correctly mounted from the host inside the container.

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -183,15 +183,15 @@ nodeImageAnalyzer:
   settings:
     # The Docker socket path.
     # If a custom path is specified, ensure it is correctly mounted from the host inside the container.
-    #dockerSocketPath: unix:///var/run/docker/docker.sock
+    # dockerSocketPath: unix:///var/run/docker/docker.sock
 
     # The socket path to a CRI compatible runtime, such as CRI-O.
     # If a custom path is specified, ensure it is correctly mounted from the host inside the container.
-    #criSocketPath: unix:///var/run/crio/crio.sock
+    # criSocketPath: unix:///var/run/crio/crio.sock
 
     # The socket path to a CRI-Containerd daemon.
     # If a custom path is specified, ensure it is correctly mounted from the host inside the container.
-    #containerdSocketPath: unix:///var/run/containerd/containerd.sock
+    # containerdSocketPath: unix:///var/run/containerd/containerd.sock
 
     # The endpoint to the Scanning Analysis collector, specified in the following format:
     # https://<API_ENDPOINT>/internal/scanning/scanning-analysis-collector
@@ -199,20 +199,36 @@ nodeImageAnalyzer:
     # * SaaS US Web: https://us2.app.sysdig.com/internal/scanning/scanning-analysis-collector
     # * SaaS European Union: https://eu1.app.sysdig.com/internal/scanning/scanning-analysis-collector
     # * On-Prem: https://sysdig.my.company.com/internal/scanning/scanning-analysis-collector
-    #collectorEndpoint: https://sysdig.my.company.com/internal/scanning/scanning-analysis-collector
+    # collectorEndpoint: https://sysdig.my.company.com/internal/scanning/scanning-analysis-collector
 
     # Can be set to false to allow insecure connections to the Sysdig backend,
     # such as for on-premise installs that use self-signed certificates.
     # By default, certificates are always verified.
-    #sslVerifyCertificate: false
+    # sslVerifyCertificate: false
 
     # Can be set to true to show debug logging, useful for troubleshooting.
-    #debug: false
+    debug: false
 
     # Proxy configuration variables. See also: [Running Node Image Analyzer Behind a Proxy](https://docs.sysdig.com/en/scan-running-images.html#UUID-b3b07aa6-db02-eb58-050f-15c9e053bb64_section-idm232105909710949)
-    #httpProxy:
-    #httpsProxy:
-    #noProxy:
+    httpProxy:
+    httpsProxy:
+    noProxy:
+
+
+  # Allow passing extra volumes to the Node Image Analyzer to mount docker socket, cri-o socket, etc.
+  extraVolumes:
+    volumes: []
+    mounts: []
+
+    # Example:
+
+    # volumes:
+    # - name: docker-sock
+    #   hostPath:
+    #     path: /var/run/docker.sock
+    # mounts:
+    # - mountPath: /var/run/docker.sock
+    #   name: docker-sock
 
   resources:
     requests:

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -9,7 +9,7 @@ image:
 
   registry: docker.io
   repository: sysdig/agent
-  tag: 10.6.0
+  tag: 10.7.0
   # Specify a imagePullPolicy
   # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -172,7 +172,7 @@ auditLog:
     enabled: false
 
 nodeImageAnalyzer:
-  deploy: false
+  deploy: true
   image:
     repository: sysdig/node-image-analyzer
     tag: 0.1.6


### PR DESCRIPTION
## What this PR does / why we need it:

### Major changes

* Node Image Analyzer now deployed by default (`nodeImageAnalyzer.deploy` set to `true` by default)
* Explain all Node Image Analyzer settings in values.yaml and README, and link to official Sysdig docs

### Minor changes

* Use the latest image from Agent (10.7.0)
* Change check_certificate to ssl_verify_certificate in NIA settings to sync with NIA configmap

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
