### PR TITLE
Updated to support Agent 10.8.0 and NIA 0.1.7

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -5,6 +5,13 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.11.1
+
+### Minor Changes
+
+* Use the latest image from Agent (10.8.0)
+* Use the latest image from Node Image Analyzer (0.1.7)
+
 ## v1.11.0
 
 ### Major changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sysdig
-version: 1.11.0
-appVersion: 10.7.0
+version: 1.11.1
+appVersion: 10.8.0
 description: Sysdig Monitor and Secure agent
 keywords:
   - monitoring

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | ---                                               | ---                                                                                      | ---                                         |
 | `image.registry`                                  | Sysdig Agent image registry                                                              | `docker.io`                                 |
 | `image.repository`                                | The image repository to pull from                                                        | `sysdig/agent`                              |
-| `image.tag`                                       | The image tag to pull                                                                    | `10.7.0`                                    |
+| `image.tag`                                       | The image tag to pull                                                                    | `10.8.0`                                    |
 | `image.pullPolicy`                                | The Image pull policy                                                                    | `IfNotPresent`                              |
 | `image.pullSecrets`                               | Image pull secrets                                                                       | `nil`                                       |
 | `resources.requests.cpu`                          | CPU requested for being run in a node                                                    | `600m`                                      |
@@ -96,7 +96,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `nodeImageAnalyzer.settings.httpsProxy`           | Proxy configuration variables                                                            |                                             |
 | `nodeImageAnalyzer.settings.noProxy`              | Proxy configuration variables                                                            |                                             |
 | `nodeImageAnalyzer.image.repository`              | The image repository to pull the Node Image Analyzer from                                | `sysdig/node-image-analyzer`                |
-| `nodeImageAnalyzer.image.tag`                     | The image tag to pull the Node Image Analyzer                                            | `0.1.6`                                     |
+| `nodeImageAnalyzer.image.tag`                     | The image tag to pull the Node Image Analyzer                                            | `0.1.7`                                     |
 | `nodeImageAnalyzer.image.pullPolicy`              | The Image pull policy for the Node Image Analyzer                                        | `IfNotPresent`                              |
 | `nodeImageAnalyzer.image.pullSecrets`             | Image pull secrets for the Node Image Analyzer                                           | `nil`                                       |
 | `nodeImageAnalyzer.resources.requests.cpu`        | Node Image Analyzer CPU requests per node                                                | `250m`                                      |

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -9,7 +9,7 @@ image:
 
   registry: docker.io
   repository: sysdig/agent
-  tag: 10.7.0
+  tag: 10.8.0
   # Specify a imagePullPolicy
   # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -175,7 +175,7 @@ nodeImageAnalyzer:
   deploy: true
   image:
     repository: sysdig/node-image-analyzer
-    tag: 0.1.6
+    tag: 0.1.7
     pullPolicy: IfNotPresent
     # pullSecrets:
     #   - name: myRegistrKeySecretName


### PR DESCRIPTION
## What this PR does / why we need it:

This is to update the chart for agent 10.8.0 and NIA 0.1.7. At time of the PR, agent 10.8.0 is still being baked, so please don't immediately accept. Just staging so it's ready to roll.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] PR only contains changes for one chart
