### PR TITLE
[admission-controller] Allow to load rules from configmap

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.1.0
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/ci/required-values.yaml
+++ b/charts/admission-controller/ci/required-values.yaml
@@ -1,1 +1,3 @@
 sysdigSecureToken: xxxxx
+clusterName: CI-Cluster
+clusterId: foobar

--- a/charts/admission-controller/templates/webhook/admissionregistration.yaml
+++ b/charts/admission-controller/templates/webhook/admissionregistration.yaml
@@ -10,7 +10,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: {{ include "admission-controller.webhook.fullname" . }}
 webhooks:
-- name: secure.sysdig.com
+- name: scanning.secure.sysdig.com
   matchPolicy: Equivalent
   reinvocationPolicy: IfNeeded
   rules:
@@ -23,7 +23,7 @@ webhooks:
     service:
       namespace: {{ .Release.Namespace }}
       name: {{ include "admission-controller.webhook.fullname" . }}
-      path: /admit
+      path: /allow-pod
     caBundle: {{ $certList._2 }}
   admissionReviewVersions: ["v1", "v1beta1"]
   sideEffects: None

--- a/charts/admission-controller/templates/webhook/configmap-rules.yaml
+++ b/charts/admission-controller/templates/webhook/configmap-rules.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "admission-controller.webhook.fullname" . }}-rules
+  labels:
+    {{ include "admission-controller.webhook.labels" . | nindent 4 }}
+data:
+  policies.json: |
+    {{ .Values.webhook.policies | toJson | nindent 4 }}
+  assignments.json: |
+    {{ .Values.webhook.assignments | toJson | nindent 4 }}

--- a/charts/admission-controller/templates/webhook/configmap.yaml
+++ b/charts/admission-controller/templates/webhook/configmap.yaml
@@ -6,3 +6,5 @@ metadata:
     {{ include "admission-controller.webhook.labels" . | nindent 4 }}
 data:
   SECURE_URL: https://{{ include "admission-controller.scanner.fullname" . }}:{{ .Values.scanner.service.port }}
+  CLUSTER_NAME: {{ required "value 'clusterName' is required, but is not set"  .Values.clusterName }}
+  CLUSTER_ID: {{ required "value 'clusterId' is required, but is not set" .Values.clusterId }}

--- a/charts/admission-controller/templates/webhook/deployment.yaml
+++ b/charts/admission-controller/templates/webhook/deployment.yaml
@@ -36,6 +36,10 @@ spec:
             - /cert/tls.crt
             - --tls_private_key_file
             - /cert/tls.key
+            - --policies_file
+            - /rules/policies.json
+            - --assignments_file
+            - /rules/assignments.json
           securityContext:
             {{- toYaml .Values.webhook.securityContext | nindent 12 }}
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
@@ -69,12 +73,18 @@ spec:
             - name: cert
               mountPath: /cert
               readOnly: true
+            - name: rules
+              mountPath: /rules
+              readOnly: true
           resources:
             {{- toYaml .Values.webhook.resources | nindent 12 }}
       volumes:
       - name: cert
         secret:
           secretName: {{ include "admission-controller.webhook.fullname" . }}-tls
+      - name: rules
+        configMap:
+          name: {{ include "admission-controller.webhook.fullname" . }}-rules
     {{- with .Values.webhook.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -4,6 +4,8 @@
 
 sysdigSecureToken: ""
 sysdigSecureUrl: "https://secure.sysdig.com"
+clusterName: ""
+clusterId: ""
 
 serviceAccounts:
   webhook:
@@ -67,6 +69,22 @@ webhook:
   tolerations: []
 
   affinity: {}
+
+  policies:
+    - id: "only-scanned"
+      name: "Allow only Scanned Images"
+      description: "Allow only pods which have been scanned"
+      rejectIfEvaluationFailed: true
+      rejectIfUnscanned: true
+      scanIfUnscanned: true
+
+  assignments:
+    enabled: true
+    defaultBehaviour: allowall
+    assignments:
+      - namespace: scanned
+        prefix: ""
+        policyID: only-scanned
 
 # inline scanner configuration
 scanner:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
