### PR TITLE
[sysdig] Add templates to customize probes initial delay

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -5,6 +5,12 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.11.1
+
+### Minor changes
+
+* Allow for customisation of liveness and readiness probes initial delay
+
 ## v1.11.0
 
 ### Major changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.11.0
+version: 1.11.1
 appVersion: 10.7.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -63,6 +63,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `daemonset.nodeSelector`                          | Node Selector                                                                            | `{}`                                        |
 | `daemonset.affinity`                              | Node affinities                                                                          | `schedule on amd64 and linux`               |
 | `daemonset.annotations`                           | Custom annotations for daemonset                                                         | `{}`                                        |
+| `daemonset.probes.initialDelay`                   | Initial delay for liveness and readiness probes. daemonset                                                         | `{}`                                        |
 | `slim.enabled`                                    | Use the slim based Sysdig Agent image                                                    | `false`                                     |
 | `slim.kmoduleImage.repository`                    | The kernel module image builder repository to pull from                                  | `sysdig/agent-kmodule`                      |
 | `slim.resources.requests.cpu`                     | CPU requested for building the kernel module                                             | `1000m`                                     |

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -121,11 +121,11 @@ spec:
           readinessProbe:
             exec:
               command: [ "test", "-e", "/opt/draios/logs/running" ]
-            initialDelaySeconds: 10
+            initialDelaySeconds: {{ .Values.daemonset.probes.initialDelay }}
           livenessProbe:
             exec:
               command: [ "test", "-e", "/opt/draios/logs/running" ]
-            initialDelaySeconds: 10
+            initialDelaySeconds: {{ .Values.daemonset.probes.initialDelay }}
           volumeMounts:
             {{- if not .Values.slim.enabled }}
             - mountPath: /etc/modprobe.d

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -86,6 +86,9 @@ daemonset:
               - linux
   # Allow the DaemonSet to set annotations
   annotations: {}
+  # Liveness and readiness probes initial delay (in seconds)
+  probes:
+    initialDelay: 10
 
 # If is behind a proxy you can set the proxy server
 # This proxy settings apply for the App-Checks.


### PR DESCRIPTION
## What this PR does / why we need it:
On some of our GKE nodes, Sysdig agents take too much time to launch and Kubernetes end-up restarting the pods in loop. By increasing the initial delay to 30s, agents have enough time to start and report successful liveness and readiness.

Current chart doesn't allow for customisation of the probes initial delay so we had to fork it and then merge new changes manually. However I don't see why this customisation would be an issue so I though it could be pushed into the official chart.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
