### PR TITLE
[admission-controller] Add required permissions to get clusterId

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -3,7 +3,7 @@ name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
 version: 0.1.7
-appVersion: 0.1.1
+appVersion: 0.1.0
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
 maintainers:

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.1.6
-appVersion: 0.1.0
+version: 0.1.7
+appVersion: 0.1.1
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
 maintainers:

--- a/charts/admission-controller/ci/required-values.yaml
+++ b/charts/admission-controller/ci/required-values.yaml
@@ -1,4 +1,3 @@
 sysdigSecureToken: xxxxx
 sysdigAgentKey: yyyyy
 clusterName: CI-Cluster
-clusterId: foobar

--- a/charts/admission-controller/templates/webhook/clusterrole.yaml
+++ b/charts/admission-controller/templates/webhook/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "admission-controller.webhook.fullname" . }}
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - kube-system
+  resources:
+  - namespaces
+  verbs:
+  - get

--- a/charts/admission-controller/templates/webhook/clusterrolebinding.yaml
+++ b/charts/admission-controller/templates/webhook/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "admission-controller.webhook.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "admission-controller.webhook.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "admission-controller.webhook.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/admission-controller/templates/webhook/configmap.yaml
+++ b/charts/admission-controller/templates/webhook/configmap.yaml
@@ -8,4 +8,6 @@ data:
   SECURE_URL: "{{ .Values.sysdigSecureUrl }}"
   SCANNER_URL: https://{{ include "admission-controller.scanner.fullname" . }}:{{ .Values.scanner.service.port }}
   CLUSTER_NAME: {{ required "value 'clusterName' is required, but is not set"  .Values.clusterName }}
-  CLUSTER_ID: {{ required "value 'clusterId' is required, but is not set" .Values.clusterId }}
+  {{- if .Values.clusterId }}
+  CLUSTER_ID: {{ .Values.clusterId }}
+  {{- end }}

--- a/charts/admission-controller/templates/webhook/configmap.yaml
+++ b/charts/admission-controller/templates/webhook/configmap.yaml
@@ -8,6 +8,3 @@ data:
   SECURE_URL: "{{ .Values.sysdigSecureUrl }}"
   SCANNER_URL: https://{{ include "admission-controller.scanner.fullname" . }}:{{ .Values.scanner.service.port }}
   CLUSTER_NAME: {{ required "value 'clusterName' is required, but is not set"  .Values.clusterName }}
-  {{- if .Values.clusterId }}
-  CLUSTER_ID: {{ .Values.clusterId }}
-  {{- end }}

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -7,9 +7,6 @@ sysdigSecureUrl: "https://app.sysdigcloud.com"
 sysdigAgentKey: ""
 clusterName: ""
 
-# Set to override the clusterID, auto detected as the the kube-system namespace UID
-clusterId: ""
-
 serviceAccounts:
   webhook:
     create: true

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -6,6 +6,8 @@ sysdigSecureToken: ""
 sysdigSecureUrl: "https://app.sysdigcloud.com"
 sysdigAgentKey: ""
 clusterName: ""
+
+# Set to override the clusterID, auto detected as the the kube-system namespace UID
 clusterId: ""
 
 serviceAccounts:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Release Admission Controller app 0.1.1 (supporting cluster ID auto detection) - see https://github.com/sysdiglabs/admission-controller/pull/41
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
