### PR TITLE
fix: Don't fail release action if no modified README files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,5 @@ jobs:
           cp -r charts ${tmp_folder}/
           pushd ${tmp_folder}
           git add -A "charts/**/README.md"
-          git commit -m "Updating README.md files"
-          git push
+          git commit -m "Updating README.md files" && git push || true
           popd


### PR DESCRIPTION
## What this PR does / why we need it

The release action would have a step to copy the modified README.md files to the gh-pages branch, so they can be linked and displayed in the https://charts.sysdig.com/ page. However, if there are no modifications in the READMEs, the git commit fails, and the action is marked as failed. Fix it.
