### PR TITLE
[cloud-connector]: Fix naming for secure.url in README

### DIFF
--- a/charts/cloud-connector/Chart.yaml
+++ b/charts/cloud-connector/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-connector
 description: Sysdig Cloud Connector
 
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.5.0
 home: https://sysdiglabs.github.io/cloud-connector
 

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -40,7 +40,7 @@ Sysdig Secure chart and their default values:
 | `aws.secretAccessKey`        | AWS Credentials: SecretAccessKey       | ` `                                       |
 | `aws.region`                 | AWS Region                             | ` `                                       |
 | `gcp.credentials`            | GCP Credentials JSON                   | ` `                                       |
-| `sysdig.secureUrl`           | Sysdig Secure URL                      | `https://secure.sysdig.com`               |
+| `sysdig.url`                 | Sysdig Secure URL                      | `https://secure.sysdig.com`               |
 | `sysdig.secureAPIToken`      | API Token to access Sysdig Secure      | ` `                                       |
 | `sysdig.verifySSL`           | Verify SSL certificate                 | `true`                                    |
 | `rules`                      | Rules Section for Cloud Connector      | `{ - directory: path: /rules }`           |


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
