### PR TITLE
[cloud-connector] Add extra env vars

### DIFF
--- a/charts/cloud-connector/Chart.yaml
+++ b/charts/cloud-connector/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-connector
 description: Sysdig Cloud Connector
 
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: 0.5.5
 home: https://sysdiglabs.github.io/cloud-connector
 

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -17,35 +17,38 @@ $ helm install --create-namespace -n cloud-connector cloud-connector -f values.y
 The following table lists the configurable parameters of the Harbor Scanner
 Sysdig Secure chart and their default values:
 
-| Parameter                    | Description                            | Default                                                                         |
-| ---                          | ---                                    | ---                                                                             |
-| `replicaCount`               | Amount of replicas for Cloud Connector | `1`                                                                             |
-| `image.repository`           | The image repository to pull from      | `sysdiglabs/cloud-connector`                                                    |
-| `image.pullPolicy`           | The image pull policy                  | `IfNotPresent`                                                                  |
-| `imagePullSecrets`           | The image pull secrets                 | `[]`                                                                            |
-| `nameOverride`               | Chart name override                    | ` `                                                                             |
-| `fullnameOverride`           | Chart full name override               | ` `                                                                             |
-| `serviceAccount.create`      | Create the service account             | `true`                                                                          |
-| `serviceAccount.annotations` | Extra annotations for serviceAccount   | `{}`                                                                            |
-| `serviceAccount.name`        | Use this value as serviceAccount Name  | ` `                                                                             |
-| `rbac.create`                | Create and use RBAC resources          | `true`                                                                          |
-| `podSecurityContext`         | Configure deployment PSP's             | `{ capabilities: drop: - ALL readOnlyRootFileSystem: true runAsNonRoot: true }` |
-| `securityContext`            | Configure securityContext              | `{}`                                                                            |
-| `service.type`               | Use this type as service               | `ClusterIP`                                                                     |
-| `service.port`               | Configure port for the service         | `5000`                                                                          |
-| `nodeSelector`               | Configure nodeSelector for scheduling  | `{}`                                                                            |
-| `tolerations`                | Tolerations for scheduling             | `[]`                                                                            |
-| `affinity`                   | Configure affinity rules               | `{}`                                                                            |
-| `aws.accessKeyId`            | AWS Credentials AccessKeyID            | ` `                                                                             |
-| `aws.secretAccessKey`        | AWS Credentials: SecretAccessKey       | ` `                                                                             |
-| `aws.region`                 | AWS Region                             | ` `                                                                             |
-| `gcp.credentials`            | GCP Credentials JSON                   | ` `                                                                             |
-| `sysdig.url`                 | Sysdig Secure URL                      | `https://secure.sysdig.com`                                                     |
-| `sysdig.secureAPIToken`      | API Token to access Sysdig Secure      | ` `                                                                             |
-| `sysdig.verifySSL`           | Verify SSL certificate                 | `true`                                                                          |
-| `rules`                      | Rules Section for Cloud Connector      | `{ - directory: path: /rules }`                                                 |
-| `ingestors`                  | Ingestors Section for Cloud Connector  | `{}`                                                                            |
-| `notifiers`                  | Notifiers Section for Cloud Connector  | `{}`                                                                            |
+| Parameter                    | Description                                          | Default                                                                         |
+| ---------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `replicaCount`               | Amount of replicas for Cloud Connector               | `1`                                                                             |
+| `image.repository`           | The image repository to pull from                    | `sysdiglabs/cloud-connector`                                                    |
+| `image.pullPolicy`           | The image pull policy                                | `IfNotPresent`                                                                  |
+| `imagePullSecrets`           | The image pull secrets                               | `[]`                                                                            |
+| `nameOverride`               | Chart name override                                  | ` `                                                                             |
+| `fullnameOverride`           | Chart full name override                             | ` `                                                                             |
+| `serviceAccount.create`      | Create the service account                           | `true`                                                                          |
+| `serviceAccount.annotations` | Extra annotations for serviceAccount                 | `{}`                                                                            |
+| `serviceAccount.name`        | Use this value as serviceAccount Name                | ` `                                                                             |
+| `rbac.create`                | Create and use RBAC resources                        | `true`                                                                          |
+| `podSecurityContext`         | Configure deployment PSP's                           | `{ capabilities: drop: - ALL readOnlyRootFileSystem: true runAsNonRoot: true }` |
+| `securityContext`            | Configure securityContext                            | `{}`                                                                            |
+| `service.type`               | Use this type as service                             | `ClusterIP`                                                                     |
+| `service.port`               | Configure port for the service                       | `5000`                                                                          |
+| `nodeSelector`               | Configure nodeSelector for scheduling                | `{}`                                                                            |
+| `tolerations`                | Tolerations for scheduling                           | `[]`                                                                            |
+| `affinity`                   | Configure affinity rules                             | `{}`                                                                            |
+| `extraEnvVars`               | Extra environment variables to be set                | `[]`                                                                            |
+| `extraEnvVarsCM`             | Name of existing ConfigMap containing extra env vars | `nil`                                                                           |
+| `extraEnvVarsSecret`         | Name of existing Secret containing extra env vars    | `nil`                                                                           |
+| `aws.accessKeyId`            | AWS Credentials AccessKeyID                          | ` `                                                                             |
+| `aws.secretAccessKey`        | AWS Credentials: SecretAccessKey                     | ` `                                                                             |
+| `aws.region`                 | AWS Region                                           | ` `                                                                             |
+| `gcp.credentials`            | GCP Credentials JSON                                 | ` `                                                                             |
+| `sysdig.url`                 | Sysdig Secure URL                                    | `https://secure.sysdig.com`                                                     |
+| `sysdig.secureAPIToken`      | API Token to access Sysdig Secure                    | ` `                                                                             |
+| `sysdig.verifySSL`           | Verify SSL certificate                               | `true`                                                                          |
+| `rules`                      | Rules Section for Cloud Connector                    | `{ - directory: path: /rules }`                                                 |
+| `ingestors`                  | Ingestors Section for Cloud Connector                | `{}`                                                                            |
+| `notifiers`                  | Notifiers Section for Cloud Connector                | `{}`                                                                            |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -37,8 +37,6 @@ Sysdig Secure chart and their default values:
 | `tolerations`                | Tolerations for scheduling                           | `[]`                                                                            |
 | `affinity`                   | Configure affinity rules                             | `{}`                                                                            |
 | `extraEnvVars`               | Extra environment variables to be set                | `[]`                                                                            |
-| `extraEnvVarsCM`             | Name of existing ConfigMap containing extra env vars | `nil`                                                                           |
-| `extraEnvVarsSecret`         | Name of existing Secret containing extra env vars    | `nil`                                                                           |
 | `aws.accessKeyId`            | AWS Credentials AccessKeyID                          | ` `                                                                             |
 | `aws.secretAccessKey`        | AWS Credentials: SecretAccessKey                     | ` `                                                                             |
 | `aws.region`                 | AWS Region                                           | ` `                                                                             |

--- a/charts/cloud-connector/templates/deployment.yaml
+++ b/charts/cloud-connector/templates/deployment.yaml
@@ -79,17 +79,6 @@ spec:
           {{- if .Values.extraEnvVars }}
           {{- toYaml .Values.extraEnvVars | nindent 12}}
           {{- end }}
-          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
-          envFrom:
-            {{- if .Values.extraEnvVarsCM }}
-            - configMapRef:
-                name: {{ .Values.extraEnvVarsCM }}
-            {{- end }}
-            {{- if .Values.extraEnvVarsSecret }}
-            - secretRef:
-                name: {{ .Values.extraEnvVarsSecret }}
-            {{- end }}
-          {{- end }}
           volumeMounts:
             - mountPath: /etc/cloud-connector
               name: cloud-connector-config

--- a/charts/cloud-connector/templates/deployment.yaml
+++ b/charts/cloud-connector/templates/deployment.yaml
@@ -76,6 +76,20 @@ spec:
               value: /var/secrets/gcp/gcp_credentials
             - name: TELEMETRY_DEPLOYMENT_METHOD
               value: helm
+          {{- if .Values.extraEnvVars }}
+          {{- toYaml .Values.extraEnvVars | nindent 12}}
+          {{- end }}
+          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+            {{- end }}
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/cloud-connector
               name: cloud-connector-config

--- a/charts/cloud-connector/values.yaml
+++ b/charts/cloud-connector/values.yaml
@@ -59,6 +59,26 @@ tolerations: []
 
 affinity: {}
 
+## Additional environment variables to set
+## Example:
+## extraEnvVars:
+##   - name: HTTP_PROXY
+##     value: http://user:password@host:port/
+##   - name: HTTPS_PROXY
+##     value: https://user:password@host:port/
+##   - name: NO_PROXY
+##     value: foo.com,bar.net:4000
+##
+extraEnvVars: []
+
+## ConfigMap with extra environment variables
+##
+extraEnvVarsCM:
+
+## Secret with extra environment variables
+##
+extraEnvVarsSecret:
+
 aws:
   accessKeyId: ""
   secretAccessKey: ""

--- a/charts/cloud-connector/values.yaml
+++ b/charts/cloud-connector/values.yaml
@@ -71,14 +71,6 @@ affinity: {}
 ##
 extraEnvVars: []
 
-## ConfigMap with extra environment variables
-##
-extraEnvVarsCM:
-
-## Secret with extra environment variables
-##
-extraEnvVarsSecret:
-
 aws:
   accessKeyId: ""
   secretAccessKey: ""


### PR DESCRIPTION
## What this PR does / why we need it:

Adds the extra env vars configuration to the chart values.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [X] PR only contains changes for one chart
