### PR TITLE
[admission-controller] Use :master for inline-scan-service by default

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.1.24
+version: 0.1.25
 appVersion: 0.1.0
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -85,7 +85,7 @@ scanner:
     repository: sysdiglabs/inline-scan-service
     pullPolicy: Always
     # Override the default image tag. If not specified, it defaults to appVersion in Chart.yaml
-    tag: 0.0.6
+    tag: master
 
   service:
     port: 8080


### PR DESCRIPTION
## What this PR does / why we need it:

Until we end with all QA tests and there are official releases of the Admission Controller, let's use the :master tag for the inline-scan-service too for faster updates without changes in the Helm charts.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
