### PR TITLE
[admission-controller] allow read/write filesystem for the inline-scan service

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.1.25
+version: 0.1.26
 appVersion: 0.1.0
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -109,7 +109,6 @@ scanner:
     capabilities:
       drop:
         - ALL
-    readOnlyRootFilesystem: true
     runAsNonRoot: true
 
   imagePullSecrets: []


### PR DESCRIPTION
## What this PR does / why we need it:

Inline scan service won't work with a read-only filesystem. Fix that in the securityContext

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
