### PR TITLE
[admission-controller] feat: add readOnlyRootFilesystem to Security context

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.1.26
+version: 0.1.27
 appVersion: 0.1.0
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/templates/scanner/deployment.yaml
+++ b/charts/admission-controller/templates/scanner/deployment.yaml
@@ -28,11 +28,17 @@ spec:
       serviceAccountName: {{ include "admission-controller.scanner.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.scanner.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: tmp-dir
+          emptyDir: {}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.scanner.securityContext | nindent 12 }}
           image: "{{ include "admission-controller.scanner.image" . }}"
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
           args:
             - --server_port={{ .Values.scanner.service.port }}
             {{- if .Values.scanner.authWithSecureToken }}

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -109,6 +109,7 @@ scanner:
     capabilities:
       drop:
         - ALL
+    readOnlyRootFilesystem: true
     runAsNonRoot: true
 
   imagePullSecrets: []


### PR DESCRIPTION
## What this PR does / why we need it:

Restore readOnlyRootFilesystem in the securityContext and just mount /tmp as an emptyDir

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
