### PR TITLE
[registry-scanner] fix: secureAPIToken in README.md and --name parameter

### DIFF
--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.0.5
+version: 0.0.6
 appVersion: 0.0.1
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -62,8 +62,8 @@ The following table lists the configurable parameters of the Sysdig Registry Sca
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name my-release \
-    --set config.secureApiToken=YOUR-KEY-HERE \
+$ helm install my-release-name \
+    --set config.secureAPIToken=YOUR-KEY-HERE \
     --set config.registryUser=admin \
     --set config.registryPassword=REGISTRY-PASSWORD-HERE \
     sysdig/registry-scanner
@@ -72,7 +72,7 @@ $ helm install --name my-release \
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml sysdig/registry-scanner
+$ helm install my-release-name -f values.yaml sysdig/registry-scanner
 ```
 
 ### On-Prem deployment
@@ -80,8 +80,8 @@ $ helm install --name my-release -f values.yaml sysdig/registry-scanner
 Use the following command to deploy in an on-prem:
 
 ```
-$ helm install --name my-release \
-    --set config.secureApiToken=YOUR-KEY-HERE \
+$ helm install my-release-name \
+    --set config.secureAPIToken=YOUR-KEY-HERE \
     --set config.registryUser=admin \
     --set config.registryPassword=REGISTRY-PASSWORD-HERE \
     --set config.secureBaseURL=SECURE_URL \


### PR DESCRIPTION
## What this PR does / why we need it:

Fix DOC-1868 and --name in READMe (SSPROD-7226)

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
