### PR TITLE
[admission-controller] Fix --name in helm install

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 2.0.0
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -69,7 +69,7 @@ Controller chart and their default values:
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name my-release \
+$ helm install my-release \
     --set sysdig.secureApiToken=YOUR-KEY-HERE \
     sysdig/admission-controller
 ```
@@ -77,7 +77,7 @@ $ helm install --name my-release \
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml sysdig/admission-controller
+$ helm install my-release -f values.yaml sysdig/admission-controller
 ```
 
 ### On Prem deployment


### PR DESCRIPTION
## What this PR does / why we need it:

Remove the --name option which does not exist in helm 3.x

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
