### PR TITLE
[cloud-bench] Fix --name in helm install

### DIFF
--- a/charts/cloud-bench/Chart.yaml
+++ b/charts/cloud-bench/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-bench
 description: Sysdig Cloud Bench
 
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 home: https://sysdig.com
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/cloud-bench/README.md
+++ b/charts/cloud-bench/README.md
@@ -51,7 +51,7 @@ Sysdig Secure chart and their default values:
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name my-release \
+$ helm install my-release \
     --set sysdig.secureApiToken=YOUR-KEY-HERE \
     sysdig/cloud-bench
 ```
@@ -59,5 +59,5 @@ $ helm install --name my-release \
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml sysdig/cloud-bench
+$ helm install my-release -f values.yaml sysdig/cloud-bench
 ```


### PR DESCRIPTION
## What this PR does / why we need it:

Remove the --name option which does not exist in helm 3.x

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
