### PR TITLE
[cloud-connector] Fix --name in helm install

### DIFF
--- a/charts/cloud-connector/Chart.yaml
+++ b/charts/cloud-connector/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-connector
 description: Sysdig Cloud Connector
 
 type: application
-version: 0.2.10
+version: 0.2.11
 appVersion: 0.6.6
 home: https://sysdiglabs.github.io/cloud-connector
 

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -52,7 +52,7 @@ Sysdig Secure chart and their default values:
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name my-release \
+$ helm install my-release \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE \
     sysdig/cloud-connector
 ```
@@ -60,7 +60,7 @@ $ helm install --name my-release \
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml sysdig/cloud-connector
+$ helm install my-release -f values.yaml sysdig/cloud-connector
 ```
 
 You have more details about Rules, Ingestors and Notifiers on [Cloud Connector documentation](https://sysdiglabs.github.io/cloud-connector/config-file.html)


### PR DESCRIPTION
## What this PR does / why we need it:

Remove the --name option which does not exist in helm 3.x

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
