### PR TITLE
[harbor-scanner-sysdig-secure] Fix --name in helm install

### DIFF
--- a/charts/harbor-scanner-sysdig-secure/Chart.yaml
+++ b/charts/harbor-scanner-sysdig-secure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: harbor-scanner-sysdig-secure
 description: Harbor Scanner for Sysdig Secure
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: 0.3.1
 home: https://github.com/sysdiglabs/harbor-scanner-sysdig-secure
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/harbor-scanner-sysdig-secure/README.md
+++ b/charts/harbor-scanner-sysdig-secure/README.md
@@ -60,7 +60,7 @@ Sysdig Secure chart and their default values:
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name my-release \
+$ helm install my-release \
     --set sysdig.secure.apiToken=YOUR-KEY-HERE \
     sysdig/harbor-scanner-sysdig-secure
 ```
@@ -68,7 +68,7 @@ $ helm install --name my-release \
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml sysdig/harbor-scanner-sysdig-secure
+$ helm install my-release -f values.yaml sysdig/harbor-scanner-sysdig-secure
 ```
 
 > **Tip**: You can use the default [values.yaml](https://raw.githubusercontent.com/sysdiglabs/charts/master/charts/harbor-scanner-sysdig-secure/values.yaml)


### PR DESCRIPTION
## What this PR does / why we need it:

Remove the --name option which does not exist in helm 3.x

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
