### PR TITLE
[sysdig] Fix --name in helm install

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.11.15
+
+### Minor changes
+
+* Remove --name installation parameter for `helm install` in README.aws
+
 ## v1.11.14
 
 ### Minor changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.11.14
+version: 1.11.15
 appVersion: 11.2.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README-AWS.md
+++ b/charts/sysdig/README-AWS.md
@@ -40,6 +40,6 @@ Finally, set the accessKey value and you are ready to deploy the Sysdig agent
 using the Helm chart:
 
 ```bash
-helm install --name sysdig-agent -f aws-marketplace-values.yaml stable/sysdig
+helm install sysdig-agent -f aws-marketplace-values.yaml stable/sysdig
 ```
 

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -297,7 +297,7 @@ The first section dumps the AppCheck in a Kubernetes configmap and makes it avai
 Once the values YAML file is ready, we will deploy the Chart like before:
 
 ```bash
-$ helm install --namespace sysdig-agent --name sysdig-agent -f values.yaml sysdig/sysdig
+$ helm install --namespace sysdig-agent sysdig-agent -f values.yaml sysdig/sysdig
 ```
 
 ### Automating the generation of custom-app-checks.yaml file


### PR DESCRIPTION
## What this PR does / why we need it:

Remove the --name option which does not exist in helm 3.x

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
