### PR TITLE
[cloud-connector]: Add emptyDir for home path that allows RW

### DIFF
--- a/charts/cloud-connector/Chart.yaml
+++ b/charts/cloud-connector/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-connector
 description: Sysdig Cloud Connector
 
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: 0.6.6
 home: https://sysdiglabs.github.io/cloud-connector
 

--- a/charts/cloud-connector/templates/deployment.yaml
+++ b/charts/cloud-connector/templates/deployment.yaml
@@ -80,6 +80,8 @@ spec:
           {{- toYaml .Values.extraEnvVars | nindent 12}}
           {{- end }}
           volumeMounts:
+            - mountPath: /home/sysdig
+              name: home-dir
             - mountPath: /etc/cloud-connector
               name: cloud-connector-config
             - mountPath: /var/secrets/gcp
@@ -97,6 +99,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: home-dir
+          emptyDir: {}
         - name: cloud-connector-config
           configMap:
             name: {{ include "cloud-connector.fullname" . }}


### PR DESCRIPTION
## What this PR does / why we need it:

Allows read-write access to `/home/sysdig` through an emptyDir.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [X] PR only contains changes for one chart
