### PR TITLE
[sysdig] feat: allow specify existing or external secrets instead of creating a new one

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.11.16
+
+### Minor changes
+
+* New option `sysdig.existingAccessKeySecret` to use existing or external secrets
+
 ## v1.11.15
 
 ### Minor changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.11.15
+version: 1.11.16
 appVersion: 11.2.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -63,7 +63,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `daemonset.nodeSelector`                          | Node Selector                                                                            | `{}`                                        |
 | `daemonset.affinity`                              | Node affinities                                                                          | `schedule on amd64 and linux`               |
 | `daemonset.annotations`                           | Custom annotations for daemonset                                                         | `{}`                                        |
-| `daemonset.probes.initialDelay`                   | Initial delay for liveness and readiness probes. daemonset                                                         | `{}`                                        |
+| `daemonset.probes.initialDelay`                   | Initial delay for liveness and readiness probes. daemonset                               | `{}`                                        |
 | `slim.enabled`                                    | Use the slim based Sysdig Agent image                                                    | `false`                                     |
 | `slim.kmoduleImage.repository`                    | The kernel module image builder repository to pull from                                  | `sysdig/agent-kmodule`                      |
 | `slim.resources.requests.cpu`                     | CPU requested for building the kernel module                                             | `1000m`                                     |
@@ -72,7 +72,8 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `ebpf.enabled`                                    | Enable eBPF support for Sysdig instead of `sysdig-probe` kernel module                   | `false`                                     |
 | `ebpf.settings.mountEtcVolume`                    | Needed to detect which kernel version are running in Google COS                          | `true`                                      |
 | `clusterName`                                     | Set a cluster name to identify events using *kubernetes.cluster.name* tag                | ` `                                         |
-| `sysdig.accessKey`                                | Your Sysdig Monitor Access Key                                                           | `Nil` You must provide your own key         |
+| `sysdig.accessKey`                                | Your Sysdig Monitor Access Key                                                           | `` Either accessKey or existingAccessKeySecret is required |
+| `sysdig.existingAccessKeySecret`                  | Alternatively, specify the name of a Kubernetes secret containing an 'access-key' entry  | `` Either accessKey or existingAccessKeySecret is required |
 | `sysdig.disableCaptures`                          | Disable capture functionality (see https://docs.sysdig.com/en/disable-captures.html)     | `false`                                     |
 | `sysdig.settings`                                 | Additional settings, directly included in the agent's configuration file `dragent.yaml`  | `{}`                                        |
 | `secure.enabled`                                  | Enable Sysdig Secure                                                                     | `true`                                      |

--- a/charts/sysdig/templates/daemonset-image-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-image-analyzer.yaml
@@ -81,7 +81,11 @@ spec:
         - name: ACCESS_KEY
           valueFrom:
             secretKeyRef:
+              {{- if not .Values.sysdig.existingAccessKeySecret }}
               name: {{ template "sysdig.fullname" . }}
+              {{- else }}
+              name: {{ .Values.sysdig.existingAccessKeySecret }}
+              {{- end }}
               key: access-key
         - name: IMAGE_PERIOD
           valueFrom:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.sysdig.accessKey }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -217,7 +216,11 @@ spec:
             optional: true
         - name: sysdig-agent-secrets
           secret:
+            {{- if not .Values.sysdig.existingAccessKeySecret }}
             secretName: {{ template "sysdig.fullname" . }}
+            {{- else }}
+            secretName: {{ .Values.sysdig.existingAccessKeySecret }}
+            {{- end -}}
         {{- if .Values.customAppChecks }}
         - name: custom-app-checks-volume
           configMap:
@@ -228,4 +231,3 @@ spec:
         {{- end }}
   updateStrategy:
 {{ toYaml .Values.daemonset.updateStrategy | indent 4 }}
-{{- end }}

--- a/charts/sysdig/templates/secrets.yaml
+++ b/charts/sysdig/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.sysdig.existingAccessKeySecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 data:
  access-key : {{ required "A valid .Values.sysdig.accessKey is required" .Values.sysdig.accessKey | b64enc | quote }}
+{{- end }}

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -145,6 +145,8 @@ clusterName: ""
 sysdig:
   # Required: You need your Sysdig Agent access key before running agents.
   accessKey: ""
+  # Alternatively, specify the name of a Kubernetes secret containing an 'access-key' entry
+  existingAccessKeySecret: ""
 
   # Disable capture functionality (see https://docs.sysdig.com/en/disable-captures.html)
   disableCaptures: false


### PR DESCRIPTION
## What this PR does / why we need it:

Allow specifying an existing secret name instead of creating a new one for storing the access-key entry. This allows using [Bitnami Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) or similar.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
