### PR TITLE
[sysdig] Fix NodeImageAnalyzer extraVolumes definition

### DIFF
--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.11.16
+version: 1.11.17
 appVersion: 11.2.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -85,8 +85,8 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `tolerations`                                     | The tolerations for scheduling                                                           | `node-role.kubernetes.io/master:NoSchedule` |
 | `prometheus.file`                                 | Use file to configure promscrape                                                         | `false`                                     |
 | `prometheus.yaml`                                 | prometheus.yaml content to configure metric collection: relabelling and filtering        | ` `                                         |
-| `extraVolume.volumes`                             | Additional volumes to mount in the sysdig agent to pass new secrets or configmaps        | `[]`                                        |
-| `extraVolume.mounts`                              | Mount points for additional volumes                                                      | `[]`                                        |
+| `extraVolumes.volumes`                            | Additional volumes to mount in the sysdig agent to pass new secrets or configmaps        | `[]`                                        |
+| `extraVolumes.mounts`                             | Mount points for additional volumes                                                      | `[]`                                        |
 | `nodeImageAnalyzer.deploy`                        | Deploy the Node Image Analyzer (See https://docs.sysdig.com/en/scan-running-images.html) | `true`                                      |
 | `nodeImageAnalyzer.settings.dockerSocketPath`     | The Docker socket path                                                                   |                                             |
 | `nodeImageAnalyzer.settings.criSocketPath`        | The socket path to a CRI compatible runtime, such as CRI-O                               |                                             |
@@ -105,8 +105,8 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `nodeImageAnalyzer.resources.requests.memory`     | Node Image Analyzer Memory requests per node                                             | `512Mi`                                     |
 | `nodeImageAnalyzer.resources.limits.cpu`          | Node Image Analyzer CPU limit per node                                                   | `500m`                                      |
 | `nodeImageAnalyzer.resources.limits.memory`       | Node Image Analyzer Memory limit per node                                                | `1024Mi`                                    |
-| `nodeImageAnalyzer.extraVolume.volumes`           | Additional volumes to mount in the Node Image Analyzer (i.e. for docker socket)          | `[]`                                        |
-| `nodeImageAnalyzer.extraVolume.mounts`            | Mount points for additional volumes                                                      | `[]`                                        |
+| `nodeImageAnalyzer.extraVolumes.volumes`          | Additional volumes to mount in the Node Image Analyzer (i.e. for docker socket)          | `[]`                                        |
+| `nodeImageAnalyzer.extraVolumes.mounts`           | Mount points for additional volumes                                                      | `[]`                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/sysdig/templates/daemonset-image-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-image-analyzer.yaml
@@ -44,7 +44,7 @@ spec:
             name: {{ template "sysdig.fullname" . }}-image-analyzer
             optional: true
         {{- if .Values.nodeImageAnalyzer.extraVolumes.volumes }}
-{{ toYaml .Values.nodeImageAnalyzer.extraVolumesvolumes | indent 8 }}
+{{ toYaml .Values.nodeImageAnalyzer.extraVolumes.volumes | indent 8 }}
         {{- end }}
       tolerations:
 {{ toYaml .Values.nodeImageAnalyzer.tolerations | indent 8 }}


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes the usage of the value `nodeImageAnalyzer.extraVolumes.volumes`

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
