### PR TITLE
[registry-scanner] feat: allow specify existing or external secrets instead of creating a new one

### DIFF
--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -5,6 +5,12 @@
 This file documents all notable changes to Sysdig Registry Scanner. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.0.7
+
+### Minor changes
+
+* New option `existingSecretName` to use existing or external secret
+
 ## v0.0.5
 
 ### Minor changes

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.0.6
+version: 0.0.7
 appVersion: 0.0.1
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the Sysdig Registry Sca
 | `imagePullSecrets`                    | The image pull secrets                                                                                                 | `[]`                                          |
 | `nameOverride`                        | Chart name override                                                                                                    | ` `                                           |
 | `fullnameOverride`                    | Chart full name override                                                                                               | ` `                                           |
+| `existingSecretName`                  | Name of a Kubernetes secret containing an 'secureAPIToken', 'registryUser', and 'registryPassword' entries             | ` `                                           |
 | `podAnnotations`                      | Registry scanner pod annotations                                                                                       | `{}`                                          |
 | `podSecurityContext`                  | Security context for Registry Scanner pod                                                                              | `{}`                                          |
 | `securityContext`                     | Security context for Registry Scanner container                                                                        | `{}`                                          |

--- a/charts/registry-scanner/templates/cronjob.yaml
+++ b/charts/registry-scanner/templates/cronjob.yaml
@@ -47,7 +47,11 @@ spec:
               - name: SECURE_API_TOKEN
                 valueFrom:
                   secretKeyRef:
+                    {{- if not .Values.existingSecretName }}
                     name: {{ include "registry-scanner.fullname" . }}
+                    {{- else }}
+                    name: {{ .Values.existingSecretName }}
+                    {{- end }}
                     key: secureAPIToken
               {{- if .Values.proxy.httpProxy }}
               - name: http_proxy
@@ -64,12 +68,20 @@ spec:
               - name: REGISTRYSCANNER_REGISTRY_USER
                 valueFrom:
                   secretKeyRef:
+                    {{- if not .Values.existingSecretName }}
                     name: {{ include "registry-scanner.fullname" . }}
+                    {{- else }}
+                    name: {{ .Values.existingSecretName }}
+                    {{- end }}
                     key: registryUser
               - name: REGISTRYSCANNER_REGISTRY_PASSWORD
                 valueFrom:
                   secretKeyRef:
+                    {{- if not .Values.existingSecretName }}
                     name: {{ include "registry-scanner.fullname" . }}
+                    {{- else }}
+                    name: {{ .Values.existingSecretName }}
+                    {{- end }}
                     key: registryPassword
           restartPolicy: {{ .Values.cronjob.restartPolicy }}
           {{- with .Values.nodeSelector }}

--- a/charts/registry-scanner/templates/secret.yaml
+++ b/charts/registry-scanner/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ data:
   secureAPIToken: {{ .Values.config.secureAPIToken | b64enc | quote }}
   registryUser: {{ .Values.config.registryUser | b64enc | quote }}
   registryPassword: {{ .Values.config.registryPassword | b64enc | quote }}
+{{- end }}

--- a/charts/registry-scanner/values.yaml
+++ b/charts/registry-scanner/values.yaml
@@ -46,6 +46,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Specify the name of a Kubernetes secret containing an 'secureAPIToken', 'registryUser', and 'registryPassword' entries
+existingSecretName: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
## What this PR does / why we need it:
Allow specifying an existing secret name instead of creating a new one for storing the 'secureAPIToken',  'registryUser' and 'registryPassword' entries. This allows using [Bitnami Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) or similar.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
