### PR TITLE
[sysdig] Support eBPF with slim image

### DIFF
--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.1
+version: 1.12.2
 appVersion: 11.2.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -63,6 +63,11 @@ spec:
             allowPrivilegeEscalation: true
           resources:
 {{ toYaml .Values.slim.resources | indent 12 }}
+          {{- if .Values.ebpf.enabled }}
+          env:
+            - name: SYSDIG_BPF_PROBE
+              value:
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/modprobe.d
               name: modprobe-d
@@ -76,6 +81,10 @@ spec:
             - mountPath: /host/usr
               name: usr-vol
               readOnly: true
+            {{- if .Values.ebpf.enabled }}
+            - mountPath: /root/.sysdig
+              name: bpf-probes
+            {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -163,6 +172,10 @@ spec:
               name: etc-fs
               readOnly: true
             {{- end }}
+            {{- if (and .Values.ebpf.enabled .Values.slim.enabled) }}
+            - mountPath: /root/.sysdig
+              name: bpf-probes
+            {{- end }}
             {{- if .Values.customAppChecks }}
             - mountPath: /opt/draios/lib/python/checks.custom.d
               name: custom-app-checks-volume
@@ -209,6 +222,10 @@ spec:
         - name: etc-fs
           hostPath:
             path: /etc
+        {{- end }}
+        {{- if (and .Values.ebpf.enabled .Values.slim.enabled) }}
+        - name: bpf-probes
+          emptyDir: {}
         {{- end }}
         - name: sysdig-agent-config
           configMap:


### PR DESCRIPTION
## What this PR does / why we need it:

With this PR the combination of slim.enabled and ebpf.enabled works (agent-kmodule and agent-slim share a volume for the compiled eBPF probe).

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart

There are no new variables to document.