### PR TITLE
[registry-scanner] feat: Enable scan support for Artifactory registries 

### DIFF
--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -5,6 +5,12 @@
 This file documents all notable changes to Sysdig Registry Scanner. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.0.8
+
+### Minor changes
+
+* New option `config.registryApiUrl` to define the Artifactory API URL as the docker API is exposed at a different point
+
 ## v0.0.7
 
 ### Minor changes

--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -9,7 +9,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 ### Minor changes
 
-* New option `config.registryApiUrl` to define the Artifactory API URL as the docker API is exposed at a different point
+* New option `config.registryApiUrl` to define the Artifactory docker API as it is exposed at a different endpoint
 
 ## v0.0.7
 

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.0.7
+version: 0.0.8
 appVersion: 0.0.1
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -27,6 +27,7 @@ The following table lists the configurable parameters of the Sysdig Registry Sca
 | `cronjob.successfulJobsHistoryLimit`  | Number of successful job history to keep on the cluster                                                                | `2`                                           |
 | `cronjob.restartPolicy`               | Restart policy for a failed registry-scan execution                                                                    | `Never`                                       |
 | `config.registryURL`                  | URL of the registry to scan                                                                                            | `http://my-docker-registry.com`               |
+| `config.registryApiUrl`               | API URL of the registry to scan. This is required if your registry type is Artifactory                                 |                                               |
 | `config.registryUser`                 | Username for registry authentication                                                                                   | ` `                                           |
 | `config.registryPassword`             | Password for registry authentication                                                                                   | ` `                                           |
 | `config.registrySkipTLS`              | Ignore registry TLS certificate errors (self-signed, etc.)                                                             | `false`                                       |

--- a/charts/registry-scanner/templates/configmap.yaml
+++ b/charts/registry-scanner/templates/configmap.yaml
@@ -12,6 +12,9 @@ data:
       user: from-secret
       pass: from-secret
       skipTLS: {{ .Values.config.registrySkipTLS }}
+      {{- if .Values.config.registryApiUrl }}
+      api: {{ .Values.config.registryApiUrl }}
+      {{- end }}
 
     secure:
       baseUrl: {{ default "https://secure.sysdig.com" .Values.config.secureBaseURL }}

--- a/charts/registry-scanner/values.yaml
+++ b/charts/registry-scanner/values.yaml
@@ -6,6 +6,7 @@ cronjob:
 
 config:
   registryURL: http://my-docker-registry.com
+  registryApiUrl:
   registryUser:
   registryPassword:
   registrySkipTLS: false


### PR DESCRIPTION
## What this PR does / why we need it:
Exposing the registry API URL option.
For Artifactory the docker API is exposed at a different endpoint, so this option need to be exposed so that it can be set. 


## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
