### PR TITLE
[cloud-connector] feat: add option for using an external secret

### DIFF
--- a/charts/cloud-connector/Chart.yaml
+++ b/charts/cloud-connector/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-connector
 description: Sysdig Cloud Connector
 
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.7.0
 home: https://sysdiglabs.github.io/cloud-connector
 

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -14,8 +14,8 @@ $ helm install --create-namespace -n cloud-connector cloud-connector -f values.y
 
 ## Configuration
 
-The following table lists the configurable parameters of the Harbor Scanner
-Sysdig Secure chart and their default values:
+The following table lists the configurable parameters of the Sysdig Cloud connector
+chart and their default values:
 
 | Parameter                    | Description                                                                                                     | Default                                                                         |
 | ---------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -17,41 +17,42 @@ $ helm install --create-namespace -n cloud-connector cloud-connector -f values.y
 The following table lists the configurable parameters of the Harbor Scanner
 Sysdig Secure chart and their default values:
 
-| Parameter                    | Description                                          | Default                                                                         |
-| ---------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `replicaCount`               | Amount of replicas for Cloud Connector               | `1`                                                                             |
-| `image.repository`           | The image repository to pull from                    | `sysdiglabs/cloud-connector`                                                    |
-| `image.pullPolicy`           | The image pull policy                                | `IfNotPresent`                                                                  |
-| `imagePullSecrets`           | The image pull secrets                               | `[]`                                                                            |
-| `nameOverride`               | Chart name override                                  | ` `                                                                             |
-| `fullnameOverride`           | Chart full name override                             | ` `                                                                             |
-| `serviceAccount.create`      | Create the service account                           | `true`                                                                          |
-| `serviceAccount.annotations` | Extra annotations for serviceAccount                 | `{}`                                                                            |
-| `serviceAccount.name`        | Use this value as serviceAccount Name                | ` `                                                                             |
-| `rbac.create`                | Create and use RBAC resources                        | `true`                                                                          |
-| `podSecurityContext`         | Configure deployment PSP's                           | `{ capabilities: drop: - ALL readOnlyRootFileSystem: true runAsNonRoot: true }` |
-| `securityContext`            | Configure securityContext                            | `{}`                                                                            |
-| `service.type`               | Use this type as service                             | `ClusterIP`                                                                     |
-| `service.port`               | Configure port for the service                       | `5000`                                                                          |
-| `resources.limits.cpu`       | Configure resource limits for cpu                    | `256m`                                                                          |
-| `resources.limits.memory`    | Configure resource limits for memory                 | `512Mi`                                                                         |
-| `resources.requests.cpu`     | Configure resource requests for cpu                  | `256m`                                                                          |
-| `resources.requests.memory`  | Configure resource requests for memory               | `512Mi`                                                                         |
-| `nodeSelector`               | Configure nodeSelector for scheduling                | `{}`                                                                            |
-| `nodeSelector`               | Configure nodeSelector for scheduling                | `{}`                                                                            |
-| `tolerations`                | Tolerations for scheduling                           | `[]`                                                                            |
-| `affinity`                   | Configure affinity rules                             | `{}`                                                                            |
-| `extraEnvVars`               | Extra environment variables to be set                | `[]`                                                                            |
-| `aws.accessKeyId`            | AWS Credentials AccessKeyID                          | ` `                                                                             |
-| `aws.secretAccessKey`        | AWS Credentials: SecretAccessKey                     | ` `                                                                             |
-| `aws.region`                 | AWS Region                                           | ` `                                                                             |
-| `gcp.credentials`            | GCP Credentials JSON                                 | ` `                                                                             |
-| `sysdig.url`                 | Sysdig Secure URL                                    | `https://secure.sysdig.com`                                                     |
-| `sysdig.secureAPIToken`      | API Token to access Sysdig Secure                    | ` `                                                                             |
-| `sysdig.verifySSL`           | Verify SSL certificate                               | `true`                                                                          |
-| `rules`                      | Rules Section for Cloud Connector                    | `[]`                                                                            |
-| `ingestors`                  | Ingestors Section for Cloud Connector                | `[]`                                                                            |
-| `notifiers`                  | Notifiers Section for Cloud Connector                | `[]`                                                                            |
+| Parameter                    | Description                                                                                                     | Default                                                                         |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `replicaCount`               | Amount of replicas for Cloud Connector                                                                          | `1`                                                                             |
+| `image.repository`           | The image repository to pull from                                                                               | `sysdiglabs/cloud-connector`                                                    |
+| `image.pullPolicy`           | The image pull policy                                                                                           | `IfNotPresent`                                                                  |
+| `imagePullSecrets`           | The image pull secrets                                                                                          | `[]`                                                                            |
+| `nameOverride`               | Chart name override                                                                                             | ` `                                                                             |
+| `fullnameOverride`           | Chart full name override                                                                                        | ` `                                                                             |
+| `serviceAccount.create`      | Create the service account                                                                                      | `true`                                                                          |
+| `serviceAccount.annotations` | Extra annotations for serviceAccount                                                                            | `{}`                                                                            |
+| `serviceAccount.name`        | Use this value as serviceAccount Name                                                                           | ` `                                                                             |
+| `rbac.create`                | Create and use RBAC resources                                                                                   | `true`                                                                          |
+| `podSecurityContext`         | Configure deployment PSP's                                                                                      | `{ capabilities: drop: - ALL readOnlyRootFileSystem: true runAsNonRoot: true }` |
+| `securityContext`            | Configure securityContext                                                                                       | `{}`                                                                            |
+| `service.type`               | Use this type as service                                                                                        | `ClusterIP`                                                                     |
+| `service.port`               | Configure port for the service                                                                                  | `5000`                                                                          |
+| `resources.limits.cpu`       | Configure resource limits for cpu                                                                               | `256m`                                                                          |
+| `resources.limits.memory`    | Configure resource limits for memory                                                                            | `512Mi`                                                                         |
+| `resources.requests.cpu`     | Configure resource requests for cpu                                                                             | `256m`                                                                          |
+| `resources.requests.memory`  | Configure resource requests for memory                                                                          | `512Mi`                                                                         |
+| `nodeSelector`               | Configure nodeSelector for scheduling                                                                           | `{}`                                                                            |
+| `nodeSelector`               | Configure nodeSelector for scheduling                                                                           | `{}`                                                                            |
+| `tolerations`                | Tolerations for scheduling                                                                                      | `[]`                                                                            |
+| `affinity`                   | Configure affinity rules                                                                                        | `{}`                                                                            |
+| `extraEnvVars`               | Extra environment variables to be set                                                                           | `[]`                                                                            |
+| `aws.accessKeyId`            | AWS Credentials AccessKeyID                                                                                     | ` `                                                                             |
+| `aws.secretAccessKey`        | AWS Credentials: SecretAccessKey                                                                                | ` `                                                                             |
+| `aws.region`                 | AWS Region                                                                                                      | ` `                                                                             |
+| `gcp.credentials`            | GCP Credentials JSON                                                                                            | ` `                                                                             |
+| `sysdig.url`                 | Sysdig Secure URL                                                                                               | `https://secure.sysdig.com`                                                     |
+| `sysdig.secureAPIToken`      | API Token to access Sysdig Secure                                                                               | ` `                                                                             |
+| `sysdig.verifySSL`           | Verify SSL certificate                                                                                          | `true`                                                                          |
+| `existingSecretName`         | Provide an existing secret name (see details in values.yaml) instead of creating a new one from provided values | ` `                                                                             |
+| `rules`                      | Rules Section for Cloud Connector                                                                               | `[]`                                                                            |
+| `ingestors`                  | Ingestors Section for Cloud Connector                                                                           | `[]`                                                                            |
+| `notifiers`                  | Notifiers Section for Cloud Connector                                                                           | `[]`                                                                            |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/charts/cloud-connector/templates/_helpers.tpl
+++ b/charts/cloud-connector/templates/_helpers.tpl
@@ -24,6 +24,14 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+{{- define "cloud-connector.secretname" -}}
+{{- if not .Values.existingSecretName }}
+{{- include "cloud-connector.fullname" . }}
+{{- else }}
+{{- .Values.existingSecretName }}
+{{- end }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/cloud-connector/templates/deployment.yaml
+++ b/charts/cloud-connector/templates/deployment.yaml
@@ -51,24 +51,24 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cloud-connector.fullname" . }}
+                  name: {{ include "cloud-connector.secretname" . }}
                   key: aws_access_key_id
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cloud-connector.fullname" . }}
+                  name: {{ include "cloud-connector.secretname" . }}
                   key: aws_secret_access_key
             - name: AWS_REGION
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cloud-connector.fullname" . }}
+                  name: {{ include "cloud-connector.secretname" . }}
                   key: aws_region
             - name: SECURE_URL
               value: {{ .Values.sysdig.url }}
             - name: SECURE_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cloud-connector.fullname" . }}
+                  name: {{ include "cloud-connector.secretname" . }}
                   key: secure_api_token
             - name: VERIFY_SSL
               value: {{ .Values.sysdig.verifySSL | quote }}
@@ -106,7 +106,7 @@ spec:
             name: {{ include "cloud-connector.fullname" . }}
         - name: google-application-credentials
           secret:
-            secretName: {{ include "cloud-connector.fullname" . }}
+            secretName: {{ include "cloud-connector.secretname" . }}
             items:
               - key: gcp_credentials
                 path: gcp_credentials

--- a/charts/cloud-connector/templates/secret.yaml
+++ b/charts/cloud-connector/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,3 +12,4 @@ data:
   aws_region: {{ .Values.aws.region | b64enc | quote }}
   gcp_credentials: {{ .Values.gcpCredentials | b64enc | quote }}
   secure_api_token: {{ required "value 'sysdig.secureAPIToken' is required, but is not set" .Values.sysdig.secureAPIToken | b64enc | quote }}
+{{- end }}

--- a/charts/cloud-connector/values.yaml
+++ b/charts/cloud-connector/values.yaml
@@ -67,6 +67,8 @@ affinity: {}
 ##
 extraEnvVars: []
 
+## Secret values
+
 aws:
   accessKeyId: ""
   secretAccessKey: ""
@@ -78,6 +80,18 @@ sysdig:
   url: "https://secure.sysdig.com"
   secureAPIToken: ""
   verifySSL: true
+
+# Alternatively, you can provide the name of an existing secret. It will be used
+# See example secret in 'templates/secret.yaml'
+# The existing secret must provide the following entries:
+#  aws_access_key_id
+#  aws_secret_access_key
+#  aws_region
+#  gcp_credentials
+#  secure_api_token
+existingSecretName: ""
+
+## Cloud Connector configuration
 
 rules: []
 


### PR DESCRIPTION
## What this PR does / why we need it:

Add an optional `existingSecretName` value to get credential values from, instead of creating a new one.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
