### PR TITLE
[cloud-bench] feat: add option for using an external secret

### DIFF
--- a/charts/cloud-bench/Chart.yaml
+++ b/charts/cloud-bench/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-bench
 description: Sysdig Cloud Bench
 
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.1.0
 home: https://sysdig.com
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/cloud-bench/README.md
+++ b/charts/cloud-bench/README.md
@@ -17,35 +17,36 @@ $ helm install --create-namespace -n cloud-bench cloud-bench -f values.yaml sysd
 The following table lists the configurable parameters of the Harbor Scanner
 Sysdig Secure chart and their default values:
 
-| Parameter                    | Description                                          | Default                                                                         |
-| ---------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `replicaCount`               | Amount of replicas for Cloud Bench                   | `1`                                                                             |
-| `image.repository`           | The image repository to pull from                    | `sysdiglabs/cloud-bench`                                                        |
-| `image.pullPolicy`           | The image pull policy                                | `IfNotPresent`                                                                  |
-| `image.tag`                  | The image tag                                        | `latest`                                                                        |
-| `imagePullSecrets`           | The image pull secrets                               | `[]`                                                                            |
-| `nameOverride`               | Chart name override                                  | ` `                                                                             |
-| `fullnameOverride`           | Chart full name override                             | ` `                                                                             |
-| `serviceAccount.create`      | Create the service account                           | `true`                                                                          |
-| `serviceAccount.annotations` | Extra annotations for serviceAccount                 | `{}`                                                                            |
-| `serviceAccount.name`        | Use this value as serviceAccount Name                | ` `                                                                             |
-| `podAnnotations`             | Dictionary of additional pod annotations             | `{prometheus.io/scrape: "true", prometheus.io/path: "/metrics", prometheus.io/port: "7000"}`|
-| `podSecurityContext`         | Configure deployment PSP's                           | `{}`                                                                            |
-| `securityContext`            | Configure securityContext                            | `{}`                                                                            |
-| `service.type`               | Use this type as service                             | `ClusterIP`                                                                     |
-| `service.port`               | Configure port for the service                       | `80`                                                                            |
-| `tolerations`                | Tolerations for scheduling                           | `[]`                                                                            |
-| `affinity`                   | Configure affinity rules                             | `{}`                                                                            |
-| `aws.access_key_id`          | AWS Credentials AccessKeyID                          | ` `                                                                             |
-| `aws.secret_access_key`      | AWS Credentials: SecretAccessKey                     | ` `                                                                             |
-| `aws.region`                 | AWS Region                                           | ` `                                                                             |
-| `sysdig.secureApiToken`      | API Token to access Sysdig Secure                    | ` `                                                                             |
-| `secureURL`                  | Sysdig Secure URL                                    | `https://secure.sysdig.com`                                                     |
-| `logLevel`                   | Log Level                                            | `debug`                                                                         |
-| `schedule`                   | Schedule                                             | `24h`                                                                           |
-| `bechmarkType`               | Benchmark Type                                       | `aws`                                                                           |
-| `outputDir`                  | Output dir                                           | `/tmp/cloud-custodian`                                                          |
-| `policyFile`                 | Policy fil                                           | `/home/custodian/aws-benchmarks.yml`                                            |
+| Parameter                    | Description                                                                                                     | Default                                                                                      |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `replicaCount`               | Amount of replicas for Cloud Bench                                                                              | `1`                                                                                          |
+| `image.repository`           | The image repository to pull from                                                                               | `sysdiglabs/cloud-bench`                                                                     |
+| `image.pullPolicy`           | The image pull policy                                                                                           | `IfNotPresent`                                                                               |
+| `image.tag`                  | The image tag                                                                                                   | `latest`                                                                                     |
+| `imagePullSecrets`           | The image pull secrets                                                                                          | `[]`                                                                                         |
+| `nameOverride`               | Chart name override                                                                                             | ` `                                                                                          |
+| `fullnameOverride`           | Chart full name override                                                                                        | ` `                                                                                          |
+| `serviceAccount.create`      | Create the service account                                                                                      | `true`                                                                                       |
+| `serviceAccount.annotations` | Extra annotations for serviceAccount                                                                            | `{}`                                                                                         |
+| `serviceAccount.name`        | Use this value as serviceAccount Name                                                                           | ` `                                                                                          |
+| `podAnnotations`             | Dictionary of additional pod annotations                                                                        | `{prometheus.io/scrape: "true", prometheus.io/path: "/metrics", prometheus.io/port: "7000"}` |
+| `podSecurityContext`         | Configure deployment PSP's                                                                                      | `{}`                                                                                         |
+| `securityContext`            | Configure securityContext                                                                                       | `{}`                                                                                         |
+| `service.type`               | Use this type as service                                                                                        | `ClusterIP`                                                                                  |
+| `service.port`               | Configure port for the service                                                                                  | `80`                                                                                         |
+| `tolerations`                | Tolerations for scheduling                                                                                      | `[]`                                                                                         |
+| `affinity`                   | Configure affinity rules                                                                                        | `{}`                                                                                         |
+| `aws.access_key_id`          | AWS Credentials AccessKeyID                                                                                     | ` `                                                                                          |
+| `aws.secret_access_key`      | AWS Credentials: SecretAccessKey                                                                                | ` `                                                                                          |
+| `aws.region`                 | AWS Region                                                                                                      | ` `                                                                                          |
+| `sysdig.secureApiToken`      | API Token to access Sysdig Secure                                                                               | ` `                                                                                          |
+| `existingSecretName`         | Provide an existing secret name (see details in values.yaml) instead of creating a new one from provided values | ` `                                                                                          |
+| `secureURL`                  | Sysdig Secure URL                                                                                               | `https://secure.sysdig.com`                                                                  |
+| `logLevel`                   | Log Level                                                                                                       | `debug`                                                                                      |
+| `schedule`                   | Schedule                                                                                                        | `24h`                                                                                        |
+| `bechmarkType`               | Benchmark Type                                                                                                  | `aws`                                                                                        |
+| `outputDir`                  | Output dir                                                                                                      | `/tmp/cloud-custodian`                                                                       |
+| `policyFile`                 | Policy fil                                                                                                      | `/home/custodian/aws-benchmarks.yml`                                                         |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/charts/cloud-bench/README.md
+++ b/charts/cloud-bench/README.md
@@ -14,8 +14,8 @@ $ helm install --create-namespace -n cloud-bench cloud-bench -f values.yaml sysd
 
 ## Configuration
 
-The following table lists the configurable parameters of the Harbor Scanner
-Sysdig Secure chart and their default values:
+The following table lists the configurable parameters of the Sysdig Cloud Bench
+chart and their default values:
 
 | Parameter                    | Description                                                                                                     | Default                                                                                      |
 | ---------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |

--- a/charts/cloud-bench/templates/_helpers.tpl
+++ b/charts/cloud-bench/templates/_helpers.tpl
@@ -24,6 +24,14 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+{{- define "cloud-bench.secretname" -}}
+{{- if not .Values.existingSecretName }}
+{{- include "cloud-bench.fullname" . }}
+{{- else }}
+{{- .Values.existingSecretName }}
+{{- end }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/cloud-bench/templates/deployment.yaml
+++ b/charts/cloud-bench/templates/deployment.yaml
@@ -51,22 +51,22 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cloud-bench.fullname" . }}
+                  name: {{ include "cloud-bench.secretname" . }}
                   key: aws_access_key_id
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cloud-bench.fullname" . }}
+                  name: {{ include "cloud-bench.secretname" . }}
                   key: aws_secret_access_key
             - name: AWS_DEFAULT_REGION
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cloud-bench.fullname" . }}
+                  name: {{ include "cloud-bench.secretname" . }}
                   key: aws_region
             - name: SECURE_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cloud-bench.fullname" . }}
+                  name: {{ include "cloud-bench.secretname" . }}
                   key: secure_api_token
           volumeMounts:
             - mountPath: /etc/cloud-bench

--- a/charts/cloud-bench/templates/secret.yaml
+++ b/charts/cloud-bench/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ data:
   aws_secret_access_key: {{ required "A valid .Values.aws.secret_access_key is required" .Values.aws.secret_access_key | b64enc | quote }}
   aws_region: {{ required "A valid .Values.aws.region is required" .Values.aws.region | b64enc | quote }}
   secure_api_token: {{ .Values.sysdig.secureApiToken | b64enc | quote }}
+{{- end }}

--- a/charts/cloud-bench/values.yaml
+++ b/charts/cloud-bench/values.yaml
@@ -81,6 +81,8 @@ tolerations: []
 
 affinity: {}
 
+## Secret values
+
 aws:
   access_key_id: ""
   secret_access_key: ""
@@ -88,6 +90,17 @@ aws:
 
 sysdig:
   secureApiToken: ""
+
+# Alternatively, you can provide the name of an existing secret. It will be used
+# See example secret in 'templates/secret.yaml'
+# The existing secret must provide the following entries:
+#  aws_access_key_id
+#  aws_secret_access_key
+#  aws_region
+#  secure_api_token
+existingSecretName: ""
+
+## Cloud Bench configuration
 
 secureURL: "https://secure.sysdig.com"
 logLevel: "debug"


### PR DESCRIPTION
## What this PR does / why we need it:

Add an optional existingSecretName value to get credential values from, instead of creating a new one.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
