### PR TITLE
[Sysdig] ESC-941 - wrong Configmap reference and hostBase fix

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -9,6 +9,7 @@ This file documents all notable changes to Sysdig Helm Chart. The release number
 ### Bugfixes
 
 * Node analyzer configuration options not being honored due to invalid Configmap name
+* Fix `hostBase` for Host Analyzer
 
 ## v1.12.3
 

--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.12.4
+
+### Bugfixes
+
+* Node analyzer configuration options not being honored due to invalid Configmap name
+
 ## v1.12.3
 
 ### Minor changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.3
+version: 1.12.4
 appVersion: 11.2.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/configmap-host-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-host-analyzer.yaml
@@ -22,9 +22,6 @@ data:
   {{- if .Values.nodeAnalyzer.hostAnalyzer.analyzeAtStartup }}
   analyze_at_startup: {{ .Values.nodeAnalyzer.hostAnalyzer.analyzeAtStartup }}
   {{- end }}
-  {{- if .Values.nodeAnalyzer.hostAnalyzer.hostBase }}
-  host_base: {{ .Values.nodeAnalyzer.hostAnalyzer.hostBase }}
-  {{- end }}
   {{- if .Values.nodeAnalyzer.hostAnalyzer.dirsToScan }}
   dirs_to_scan: {{ .Values.nodeAnalyzer.hostAnalyzer.dirsToScan }}
   {{- end }}

--- a/charts/sysdig/templates/configmap-image-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-image-analyzer.yaml
@@ -45,8 +45,8 @@ data:
   {{- if .Values.nodeImageAnalyzer.settings.noProxy }}
   no_proxy: {{ .Values.nodeImageAnalyzer.settings.noProxy }}
   {{- end -}}
-  {{- end }}
-  {{- if and (not .Values.nodeImageAnalyzer.deploy) .Values.nodeAnalyzer.deploy}}
+{{- end }}
+{{- if and (not .Values.nodeImageAnalyzer.deploy) .Values.nodeAnalyzer.deploy}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -91,4 +91,4 @@ data:
   {{- if .Values.nodeAnalyzer.noProxy }}
   no_proxy: {{ .Values.nodeAnalyzer.noProxy }}
   {{- end -}}
-  {{- end }}
+{{- end }}

--- a/charts/sysdig/templates/configmap-image-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-image-analyzer.yaml
@@ -50,7 +50,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "sysdig.fullname" . }}-node-analyzer
+  name: {{ template "sysdig.fullname" . }}-image-analyzer
   labels:
 {{ include "sysdig.labels" . | indent 4 }}
 data:
@@ -91,4 +91,4 @@ data:
   {{- if .Values.nodeAnalyzer.noProxy }}
   no_proxy: {{ .Values.nodeAnalyzer.noProxy }}
   {{- end -}}
-{{- end }}
+  {{- end }}

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -248,11 +248,7 @@ spec:
               key: analyze_at_startup
               optional: true
         - name: HOST_BASE
-          valueFrom:
-            configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-host-analyzer
-              key: host_base
-              optional: true
+          value: /host
         - name: DIRS_TO_SCAN
           valueFrom:
             configMapKeyRef:

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -47,9 +47,9 @@ spec:
           hostPath:
             path: /var/run
         # Add custom volume here
-        - name: sysdig-image-analyzer-config #Unused??
+        - name: sysdig-image-analyzer-config
           configMap:
-            name: {{ template "sysdig.fullname" . }}-node-analyzer
+            name: {{ template "sysdig.fullname" . }}-image-analyzer
             optional: true
         # Needed to run Benchmarks. This mount is read-only.
         # Benchmarks include numerous checks that run tests against config files in the host filesystem. There are also
@@ -113,55 +113,55 @@ spec:
         - name: IMAGE_PERIOD
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: image_period
               optional: true
         - name: IMAGE_CACHE_TTL
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: image_cache_ttl
               optional: true
         - name: REPORT_PERIOD
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: report_period
               optional: true
         - name: DOCKER_SOCKET_PATH
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: docker_socket_path
               optional: true
         - name: CRI_SOCKET_PATH
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: cri_socket_path
               optional: true
         - name: CONTAINERD_SOCKET_PATH
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: containerd_socket_path
               optional: true
         - name: AM_COLLECTOR_ENDPOINT
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: collector_endpoint
               optional: true
         - name: AM_COLLECTOR_TIMEOUT
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: collector_timeout
               optional: true
         - name: VERIFY_CERTIFICATE
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: ssl_verify_certificate
               optional: true
         - name: K8S_NODE_NAME
@@ -179,25 +179,25 @@ spec:
         - name: DEBUG
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: debug
               optional: true
         - name: HTTP_PROXY
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: http_proxy
               optional: true
         - name: HTTPS_PROXY
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: https_proxy
               optional: true
         - name: NO_PROXY
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-node-analyzer
+              name: {{ template "sysdig.fullname" . }}-image-analyzer
               key: no_proxy
               optional: true
       - name: sysdig-host-analyzer

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -47,9 +47,9 @@ spec:
           hostPath:
             path: /var/run
         # Add custom volume here
-        - name: sysdig-image-analyzer-config
+        - name: sysdig-image-analyzer-config #Unused??
           configMap:
-            name: {{ template "sysdig.fullname" . }}-image-analyzer
+            name: {{ template "sysdig.fullname" . }}-node-analyzer
             optional: true
         # Needed to run Benchmarks. This mount is read-only.
         # Benchmarks include numerous checks that run tests against config files in the host filesystem. There are also
@@ -113,55 +113,55 @@ spec:
         - name: IMAGE_PERIOD
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: image_period
               optional: true
         - name: IMAGE_CACHE_TTL
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: image_cache_ttl
               optional: true
         - name: REPORT_PERIOD
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: report_period
               optional: true
         - name: DOCKER_SOCKET_PATH
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: docker_socket_path
               optional: true
         - name: CRI_SOCKET_PATH
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: cri_socket_path
               optional: true
         - name: CONTAINERD_SOCKET_PATH
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: containerd_socket_path
               optional: true
         - name: AM_COLLECTOR_ENDPOINT
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: collector_endpoint
               optional: true
         - name: AM_COLLECTOR_TIMEOUT
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: collector_timeout
               optional: true
         - name: VERIFY_CERTIFICATE
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: ssl_verify_certificate
               optional: true
         - name: K8S_NODE_NAME
@@ -179,25 +179,25 @@ spec:
         - name: DEBUG
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: debug
               optional: true
         - name: HTTP_PROXY
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: http_proxy
               optional: true
         - name: HTTPS_PROXY
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: https_proxy
               optional: true
         - name: NO_PROXY
           valueFrom:
             configMapKeyRef:
-              name: {{ template "sysdig.fullname" . }}-image-analyzer
+              name: {{ template "sysdig.fullname" . }}-node-analyzer
               key: no_proxy
               optional: true
       - name: sysdig-host-analyzer


### PR DESCRIPTION
## What this PR does / why we need it:

 * Fix reference to non-existing CM when deploying NA instead of the old NIA.
 * Fix hostBase configuration

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
