### PR TITLE
[sysdig] Fix eBPF+slim on GKE

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.12.5
+
+### Bugfixes
+
+* eBPF with Agent slim image did not work on GKE (Google COS)
+
 ## v1.12.4
 
 ### Bugfixes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.4
+version: 1.12.5
 appVersion: 11.2.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -85,6 +85,9 @@ spec:
             - mountPath: /root/.sysdig
               name: bpf-probes
             {{- end }}
+            - mountPath: /host/etc/os-release
+              name: osrel
+              readOnly: true
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
We need /etc/os-release mounted to detect Google COS

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] PR only contains changes for one chart
