### PR TITLE
[registry-scanner] Use image from quay.io

### DIFF
--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -5,6 +5,13 @@
 This file documents all notable changes to Sysdig Registry Scanner. The release
 numbering uses [semantic versioning](http://semver.org).
 
+
+## v0.0.11
+
+### Minor changes
+
+* Use image from quay.io/sysdig/registry-scanner and tag `latest` instead of `master`
+
 ## v0.0.10
 
 ### Minor changes

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.0.10
+version: 0.0.11
 appVersion: 0.0.1
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -20,46 +20,46 @@ $ helm install --create-namespace -n registry-scanner registry-scanner -f values
 
 The following table lists the configurable parameters of the Sysdig Registry Scanner chart and their default values:
 
-| Parameter                            | Description                                                                                                            | Default                         |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| `cronjob.schedule`                   | Cronjob expression for registry scan scheduling                                                                        | `"0 6 * * *"`                   |
-| `cronjob.failedJobsHistoryLimit`     | Number of failed job history to keep on the cluster                                                                    | `5`                             |
-| `cronjob.successfulJobsHistoryLimit` | Number of successful job history to keep on the cluster                                                                | `2`                             |
-| `cronjob.restartPolicy`              | Restart policy for a failed registry-scan execution                                                                    | `Never`                         |
-| `config.registryURL`                 | URL of the registry to scan                                                                                            | `http://my-docker-registry.com` |
-| `config.registryApiUrl`              | API URL of the registry to scan. This is required if your registry type is Artifactory                                 | ` `                             |
-| `config.registryUser`                | Username for registry authentication                                                                                   | ` `                             |
-| `config.registryPassword`            | Password for registry authentication                                                                                   | ` `                             |
-| `config.registrySkipTLS`             | Ignore registry TLS certificate errors (self-signed, etc.)                                                             | `false`                         |
-| `config.secureBaseURL`               | Sysdig Secure Base URL                                                                                                 | `https://secure.sysdig.com`     |
-| `config.secureAPIToken`              | API Token to access Sysdig Secure                                                                                      | ` `                             |
-| `config.secureOnPrem`                | Sysdig Secure is on-prem installation (vs SaaS)                                                                        | `false`                         |
-| `config.secureSkipTLS`               | Ignore Sysdig Secure TLS certificate errors                                                                            | `false`                         |
-| `config.maxWorkers`                  | Max number of parallel inline scanner workers to spawn in cluster                                                      | `1`                             |
-| `config.filter.include`              | List of regular expressions. Images matching any of these expressions are *always* included when scanning.             | `[]`                            |
-| `config.filter.exclude`              | List of regular expressions. Images matching any of these expressions are excluded when scanning.                      | `[]`                            |
-| `config.filter.maxAgeDays`           | Exclude images with creation date older than specified number of days.                                                 | ` `                             |
-| `config.filter.maxTagsPerRepository` | Only scan a maximum number of tags per repository, excluding older images by creation date                             | ` `                             |
-| `proxy.httpProxy`                    | URL of the proxy for HTTP connections, or empty if not using proxy (sets the http_proxy environment variable)          | ` `                             |
-| `proxy.httpsProxy`                   | URL of the proxy for HTTPS connections, or empty if not using proxy (sets the https_proxy environment variable)        | ` `                             |
-| `proxy.noProxy`                      | Comma-separated list of domain extensions proxy should not be used for. Include the internal IP of the kubeapi server. | ` `                             |
-| `image.repository`                   | Registry Scanner image repository                                                                                      | `sysdiglabs/registry-scanner`   |
-| `image.tag`                          | Registry Scanner image tag                                                                                             | `master`                        |
-| `image.pullPolicy`                   | PullPolicy for Registry Scanner image                                                                                  | `Always`                        |
-| `serviceAccount.scanner.create`      | Create the service account                                                                                             | `true`                          |
-| `serviceAccount.scanner.annotations` | Extra annotations for serviceAccount                                                                                   | `{}`                            |
-| `serviceAccount.scanner.name`        | Use this value as serviceAccount Name                                                                                  | ` `                             |
-| `imagePullSecrets`                   | The image pull secrets                                                                                                 | `[]`                            |
-| `nameOverride`                       | Chart name override                                                                                                    | ` `                             |
-| `fullnameOverride`                   | Chart full name override                                                                                               | ` `                             |
-| `existingSecretName`                 | Name of a Kubernetes secret containing 'secureAPIToken', 'registryUser', and 'registryPassword' entries                | ` `                             |
-| `podAnnotations`                     | Registry scanner pod annotations                                                                                       | `{}`                            |
-| `podSecurityContext`                 | Security context for Registry Scanner pod                                                                              | `{}`                            |
-| `securityContext`                    | Security context for Registry Scanner container                                                                        | `{}`                            |
-| `resources`                          | Resource limits for registry scanner container                                                                         | `{}`                            |
-| `nodeSelector`                       | Configure nodeSelector for scheduling                                                                                  | `{}`                            |
-| `tolerations`                        | Tolerations for scheduling                                                                                             | `[]`                            |
-| `affinity`                           | Configure affinity rules                                                                                               | `{}`                            |
+| Parameter                            | Description                                                                                                            | Default                           |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `cronjob.schedule`                   | Cronjob expression for registry scan scheduling                                                                        | `"0 6 * * *"`                     |
+| `cronjob.failedJobsHistoryLimit`     | Number of failed job history to keep on the cluster                                                                    | `5`                               |
+| `cronjob.successfulJobsHistoryLimit` | Number of successful job history to keep on the cluster                                                                | `2`                               |
+| `cronjob.restartPolicy`              | Restart policy for a failed registry-scan execution                                                                    | `Never`                           |
+| `config.registryURL`                 | URL of the registry to scan                                                                                            | `http://my-docker-registry.com`   |
+| `config.registryApiUrl`              | API URL of the registry to scan. This is required if your registry type is Artifactory                                 | ` `                               |
+| `config.registryUser`                | Username for registry authentication                                                                                   | ` `                               |
+| `config.registryPassword`            | Password for registry authentication                                                                                   | ` `                               |
+| `config.registrySkipTLS`             | Ignore registry TLS certificate errors (self-signed, etc.)                                                             | `false`                           |
+| `config.secureBaseURL`               | Sysdig Secure Base URL                                                                                                 | `https://secure.sysdig.com`       |
+| `config.secureAPIToken`              | API Token to access Sysdig Secure                                                                                      | ` `                               |
+| `config.secureOnPrem`                | Sysdig Secure is on-prem installation (vs SaaS)                                                                        | `false`                           |
+| `config.secureSkipTLS`               | Ignore Sysdig Secure TLS certificate errors                                                                            | `false`                           |
+| `config.maxWorkers`                  | Max number of parallel inline scanner workers to spawn in cluster                                                      | `1`                               |
+| `config.filter.include`              | List of regular expressions. Images matching any of these expressions are *always* included when scanning.             | `[]`                              |
+| `config.filter.exclude`              | List of regular expressions. Images matching any of these expressions are excluded when scanning.                      | `[]`                              |
+| `config.filter.maxAgeDays`           | Exclude images with creation date older than specified number of days.                                                 | ` `                               |
+| `config.filter.maxTagsPerRepository` | Only scan a maximum number of tags per repository, excluding older images by creation date                             | ` `                               |
+| `proxy.httpProxy`                    | URL of the proxy for HTTP connections, or empty if not using proxy (sets the http_proxy environment variable)          | ` `                               |
+| `proxy.httpsProxy`                   | URL of the proxy for HTTPS connections, or empty if not using proxy (sets the https_proxy environment variable)        | ` `                               |
+| `proxy.noProxy`                      | Comma-separated list of domain extensions proxy should not be used for. Include the internal IP of the kubeapi server. | ` `                               |
+| `image.repository`                   | Registry Scanner image repository                                                                                      | `quay.io/sysdig/registry-scanner` |
+| `image.tag`                          | Registry Scanner image tag                                                                                             | `master`                          |
+| `image.pullPolicy`                   | PullPolicy for Registry Scanner image                                                                                  | `Always`                          |
+| `serviceAccount.scanner.create`      | Create the service account                                                                                             | `true`                            |
+| `serviceAccount.scanner.annotations` | Extra annotations for serviceAccount                                                                                   | `{}`                              |
+| `serviceAccount.scanner.name`        | Use this value as serviceAccount Name                                                                                  | ` `                               |
+| `imagePullSecrets`                   | The image pull secrets                                                                                                 | `[]`                              |
+| `nameOverride`                       | Chart name override                                                                                                    | ` `                               |
+| `fullnameOverride`                   | Chart full name override                                                                                               | ` `                               |
+| `existingSecretName`                 | Name of a Kubernetes secret containing 'secureAPIToken', 'registryUser', and 'registryPassword' entries                | ` `                               |
+| `podAnnotations`                     | Registry scanner pod annotations                                                                                       | `{}`                              |
+| `podSecurityContext`                 | Security context for Registry Scanner pod                                                                              | `{}`                              |
+| `securityContext`                    | Security context for Registry Scanner container                                                                        | `{}`                              |
+| `resources`                          | Resource limits for registry scanner container                                                                         | `{}`                              |
+| `nodeSelector`                       | Configure nodeSelector for scheduling                                                                                  | `{}`                              |
+| `tolerations`                        | Tolerations for scheduling                                                                                             | `[]`                              |
+| `affinity`                           | Configure affinity rules                                                                                               | `{}`                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/registry-scanner/values.yaml
+++ b/charts/registry-scanner/values.yaml
@@ -31,8 +31,8 @@ proxy:
   noProxy:
 
 image:
-  repository: sysdiglabs/registry-scanner
-  tag: master
+  repository: quay.io/sysdig/registry-scanner
+  tag: latest
   pullPolicy: Always
 
 serviceAccount:


### PR DESCRIPTION
## What this PR does / why we need it:

Update image to use quay.io instead of Docker hub

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
