### PR TITLE
[admission-controller]: Upgrade AC to 3.2.1

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.4.1
+version: 0.4.3
 appVersion: 3.2.1
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.4.2
-appVersion: 3.2.0
+version: 0.4.1
+appVersion: 3.2.1
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
 maintainers:

--- a/charts/admission-controller/templates/webhook/clusterrole.yaml
+++ b/charts/admission-controller/templates/webhook/clusterrole.yaml
@@ -11,3 +11,9 @@ rules:
   - namespaces
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get


### PR DESCRIPTION
We need pod reading permissions to retrieve containerID and nodeName

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
