### PR TITLE
[admission-controller] Add registry SSL verification flag

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.4.12
+version: 0.4.13
 appVersion: 3.4.0
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -70,7 +70,7 @@ Controller chart and their default values:
 | `scanner.podAnnotations`              | Scanner pod annotations                                      | `{"prometheus.io/scrape": "true", "prometheus.io/path": "/metrics", "prometheus.io/port": "5000", "prometheus.io/scheme": "https"}` |
 | `scanner.psp.create`                  | Whether to create a psp policy and role / role-binding       | `false`                                                                                                                             |
 | `scanner.resources`                   | Resource requests and limits for scanner                     | `{}`                                                                                                                                |
-| `scanner.verifyRegistrySSL`           | Verify SSL on image pull from registries                     | `true`                                                                                                                              |
+| `scanner.verifyRegistryTLS`           | Verify TLS on image pull from registries                     | `true`                                                                                                                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -70,6 +70,7 @@ Controller chart and their default values:
 | `scanner.podAnnotations`              | Scanner pod annotations                                      | `{"prometheus.io/scrape": "true", "prometheus.io/path": "/metrics", "prometheus.io/port": "5000", "prometheus.io/scheme": "https"}` |
 | `scanner.psp.create`                  | Whether to create a psp policy and role / role-binding       | `false`                                                                                                                             |
 | `scanner.resources`                   | Resource requests and limits for scanner                     | `{}`                                                                                                                                |
+| `scanner.verifyRegistrySSL`           | Verify SSL on image pull from registries                     | `true`                                                                                                                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/admission-controller/templates/scanner/configmap.yaml
+++ b/charts/admission-controller/templates/scanner/configmap.yaml
@@ -8,4 +8,5 @@ metadata:
 data:
   SECURE_BASE_URL: "{{ .Values.sysdig.url }}"
   SECURE_SKIP_TLS: "{{ not .Values.verifySSL }}"
+  REGISTRY_SKIP_TLS: "{{ not .Values.scanner.verifyRegistrySSL }}"
 {{- end -}}

--- a/charts/admission-controller/templates/scanner/configmap.yaml
+++ b/charts/admission-controller/templates/scanner/configmap.yaml
@@ -8,5 +8,5 @@ metadata:
 data:
   SECURE_BASE_URL: "{{ .Values.sysdig.url }}"
   SECURE_SKIP_TLS: "{{ not .Values.verifySSL }}"
-  REGISTRY_SKIP_TLS: "{{ not .Values.scanner.verifyRegistrySSL }}"
+  REGISTRY_SKIP_TLS: "{{ not .Values.scanner.verifyRegistryTLS }}"
 {{- end -}}

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -115,7 +115,7 @@ scanner:
 
   podSecurityContext: {}
 
-  verifyRegistrySSL: true
+  verifyRegistryTLS: true
 
   securityContext:
     capabilities:

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -92,7 +92,7 @@ scanner:
     repository: sysdig/inline-scan-service
     pullPolicy: IfNotPresent
     # Override the default image tag. If not specified, it defaults to appVersion in Chart.yaml
-    tag: 0.0.7
+    tag: 0.0.8
 
   service:
     port: 8080
@@ -114,6 +114,8 @@ scanner:
     create: false
 
   podSecurityContext: {}
+
+  verifyRegistrySSL: true
 
   securityContext:
     capabilities:


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a SSL verification flag for registries in the scanning service.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
