### PR TITLE
[registry-scanner] Fix chart registry, docker.io was preprended

### DIFF
--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -5,6 +5,15 @@
 This file documents all notable changes to Sysdig Registry Scanner. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.0.12
+
+### Fixes
+
+* Fix docker.io always preprended to inage name
+
+### Minor changes
+
+* Report required values with an error message using `required`
 
 ## v0.0.11
 

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.0.11
+version: 0.0.12
 appVersion: 0.0.1
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -43,8 +43,9 @@ The following table lists the configurable parameters of the Sysdig Registry Sca
 | `proxy.httpProxy`                    | URL of the proxy for HTTP connections, or empty if not using proxy (sets the http_proxy environment variable)          | ` `                               |
 | `proxy.httpsProxy`                   | URL of the proxy for HTTPS connections, or empty if not using proxy (sets the https_proxy environment variable)        | ` `                               |
 | `proxy.noProxy`                      | Comma-separated list of domain extensions proxy should not be used for. Include the internal IP of the kubeapi server. | ` `                               |
-| `image.repository`                   | Registry Scanner image repository                                                                                      | `quay.io/sysdig/registry-scanner` |
-| `image.tag`                          | Registry Scanner image tag                                                                                             | `master`                          |
+| `image.registry`                     | Registry Scanner image registry                                                                                        | `quay.io`                         |
+| `image.repository`                   | Registry Scanner image repository                                                                                      | `sysdig/registry-scanner`         |
+| `image.tag`                          | Registry Scanner image tag                                                                                             | `latest`                          |
 | `image.pullPolicy`                   | PullPolicy for Registry Scanner image                                                                                  | `Always`                          |
 | `serviceAccount.scanner.create`      | Create the service account                                                                                             | `true`                            |
 | `serviceAccount.scanner.annotations` | Extra annotations for serviceAccount                                                                                   | `{}`                              |

--- a/charts/registry-scanner/templates/_helpers.tpl
+++ b/charts/registry-scanner/templates/_helpers.tpl
@@ -72,6 +72,6 @@ Allow overriding registry and repository for air-gapped environments
     {{- $imageRepository := .Values.image.repository -}}
     {{- $imageTag := .Values.image.tag -}}
     {{- $globalRegistry := (default .Values.global dict).imageRegistry -}}
-    {{- $globalRegistry | default $imageRegistry | default "docker.io" -}} / {{- $imageRepository -}} : {{- $imageTag -}}
+    {{- $globalRegistry | default $imageRegistry | default "quay.io" -}} / {{- $imageRepository -}} : {{- $imageTag -}}
 {{- end -}}
 {{- end -}}

--- a/charts/registry-scanner/templates/secret.yaml
+++ b/charts/registry-scanner/templates/secret.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "registry-scanner.labels" . | indent 4 }}
 type: Opaque
 data:
-  secureAPIToken: {{ .Values.config.secureAPIToken | b64enc | quote }}
-  registryUser: {{ .Values.config.registryUser | b64enc | quote }}
-  registryPassword: {{ .Values.config.registryPassword | b64enc | quote }}
+  secureAPIToken: {{ required "A valid .Values.config.secureAPIToken is required" .Values.config.secureAPIToken | b64enc | quote }}
+  registryUser: {{ required "A valid .Values.config.registryUser is required" .Values.config.registryUser | b64enc | quote }}
+  registryPassword: {{ required "A valid .Values.config.registryPassword is required" .Values.config.registryPassword | b64enc | quote }}
 {{- end }}

--- a/charts/registry-scanner/values.yaml
+++ b/charts/registry-scanner/values.yaml
@@ -31,7 +31,8 @@ proxy:
   noProxy:
 
 image:
-  repository: quay.io/sysdig/registry-scanner
+  registry: quay.io
+  repository: sysdig/registry-scanner
   tag: latest
   pullPolicy: Always
 


### PR DESCRIPTION
## What this PR does / why we need it:

Fix missing registry entry in values.yaml that caused docker.io/ to be prepended to the image.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
