### PR TITLE
[PDM-202] Use appVersion for image instead of latest

### DIFF
--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -5,6 +5,12 @@
 This file documents all notable changes to Sysdig Registry Scanner. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.0.13
+
+### Minor changes
+
+* Use a fixed registry-scanner version (appVersion in chart.yaml) instead of latest
+
 ## v0.0.12
 
 ### Fixes

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.0.12
+version: 0.0.13
 appVersion: 0.0.1
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -45,7 +45,7 @@ The following table lists the configurable parameters of the Sysdig Registry Sca
 | `proxy.noProxy`                      | Comma-separated list of domain extensions proxy should not be used for. Include the internal IP of the kubeapi server. | ` `                               |
 | `image.registry`                     | Registry Scanner image registry                                                                                        | `quay.io`                         |
 | `image.repository`                   | Registry Scanner image repository                                                                                      | `sysdig/registry-scanner`         |
-| `image.tag`                          | Registry Scanner image tag                                                                                             | `latest`                          |
+| `image.tag`                          | Registry Scanner image tag. If empty, default to appVersion in Chart.yaml                                              | ``                                |
 | `image.pullPolicy`                   | PullPolicy for Registry Scanner image                                                                                  | `Always`                          |
 | `serviceAccount.scanner.create`      | Create the service account                                                                                             | `true`                            |
 | `serviceAccount.scanner.annotations` | Extra annotations for serviceAccount                                                                                   | `{}`                              |

--- a/charts/registry-scanner/templates/_helpers.tpl
+++ b/charts/registry-scanner/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Allow overriding registry and repository for air-gapped environments
 {{- else -}}
     {{- $imageRegistry := .Values.image.registry -}}
     {{- $imageRepository := .Values.image.repository -}}
-    {{- $imageTag := .Values.image.tag -}}
+    {{- $imageTag := ( .Values.image.tag | default .Chart.AppVersion) -}}
     {{- $globalRegistry := (default .Values.global dict).imageRegistry -}}
     {{- $globalRegistry | default $imageRegistry | default "quay.io" -}} / {{- $imageRepository -}} : {{- $imageTag -}}
 {{- end -}}

--- a/charts/registry-scanner/values.yaml
+++ b/charts/registry-scanner/values.yaml
@@ -33,7 +33,8 @@ proxy:
 image:
   registry: quay.io
   repository: sysdig/registry-scanner
-  tag: latest
+  # Empty to defaul to the chart.yaml appVersion
+  tag:
   pullPolicy: Always
 
 serviceAccount:


### PR DESCRIPTION
## What this PR does / why we need it:

Use appVersion from chart.yaml instead of "latest" for image tag.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
