### PR TITLE
Add /sys/kernel/debug VolumeMount to helm chart, when eBPF is in use

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.12.12
+
+### Bugfixes
+
+* Add mountPath /sys/kernel/debug for eBPF
+
+## v1.12.11
+
+### Minor changes
+
+- Change the default agent container resources
+
 ## v1.12.10
 
 ### Minor changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.11
+version: 1.12.12
 appVersion: 11.3.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -84,6 +84,9 @@ spec:
             {{- if .Values.ebpf.enabled }}
             - mountPath: /root/.sysdig
               name: bpf-probes
+            - mountPath: /sys/kernel/debug
+              name: sys-tracing
+              readOnly: true
             {{- end }}
             - mountPath: /host/etc/os-release
               name: osrel
@@ -178,6 +181,9 @@ spec:
             {{- if (and .Values.ebpf.enabled .Values.slim.enabled) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
+            - mountPath: /sys/kernel/debug
+              name: sys-tracing
+              readOnly: true
             {{- end }}
             {{- if .Values.customAppChecks }}
             - mountPath: /opt/draios/lib/python/checks.custom.d
@@ -229,6 +235,9 @@ spec:
         {{- if (and .Values.ebpf.enabled .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}
+        - name: sys-tracing
+          hostPath:
+            path: /sys/kernel/debug
         {{- end }}
         - name: sysdig-agent-config
           configMap:


### PR DESCRIPTION
Agent eBPF code requires access to the /sys/kernel/debug filesystem.
For certain kernel versions, this filesystem is not accessible by default
from within docker containers, so add a VolumeMount in the helm chart.

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] PR only contains changes for one chart
