### PR TITLE
[sysdig] Grant the agent permissions for listing storageclass resources

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.12.30
+### Minor changes
+
+- Add strorageclass resource in clusterrole
+
 ## v1.12.27
 
 ### Minor changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.29
+version: 1.12.30
 appVersion: 12.0.3
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/clusterrole.yaml
+++ b/charts/sysdig/templates/clusterrole.yaml
@@ -87,6 +87,14 @@ rules:
     - /metrics
     verbs:
     - get
+  - apiGroups:
+    - storage.k8s.io
+    resources:
+    - storageclasses
+    verbs:
+    - get
+    - list
+    - watch
 {{- if .Values.psp.create  }}
   - apiGroups:
       - "policy"


### PR DESCRIPTION
## What this PR does / why we need it:

This PR gives the agent RBAC permissions for handling `storageclass` kubernetes resources

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
