### PR TITLE
[registry-scanner] Fix inverted logic in deprecated batch/v1beta1 API

### DIFF
--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -5,6 +5,12 @@
 This file documents all notable changes to Sysdig Registry Scanner. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.0.17
+
+### Minor changes
+
+* Use batch/v1 API for kubernetes 1.21 or higher
+
 ## v0.0.16
 
 ### Minor changes

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.0.16
+version: 0.0.17
 appVersion: 0.0.3
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/templates/cronjob.yaml
+++ b/charts/registry-scanner/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if or (gt  (.Capabilities.KubeVersion.Major | atoi) 1 ) (gt (.Capabilities.KubeVersion.Minor | atoi) 21) }}
+{{- if or (gt  (.Capabilities.KubeVersion.Major | atoi) 1 ) (ge (.Capabilities.KubeVersion.Minor | atoi) 21) }}
 apiVersion: batch/v1
 {{- else }}
 apiVersion: batch/v1beta1

--- a/charts/registry-scanner/templates/cronjob.yaml
+++ b/charts/registry-scanner/templates/cronjob.yaml
@@ -1,7 +1,7 @@
 {{- if or (gt  (.Capabilities.KubeVersion.Major | atoi) 1 ) (gt (.Capabilities.KubeVersion.Minor | atoi) 21) }}
-apiVersion: batch/v1beta1
-{{- else }}
 apiVersion: batch/v1
+{{- else }}
+apiVersion: batch/v1beta1
 {{- end }}
 kind: CronJob
 metadata:


### PR DESCRIPTION
## What this PR does / why we need it:

The logic to check if kubernetes version was >= 1.21 and use batch/v1 instead of batch/v1beta1 was reversed. Fix it.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
