### PR TITLE
[sysdig] Pass namespace name and and pod name to the agent container

### DIFF
--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.13
+version: 1.12.14
 description: Sysdig Monitor and Secure agent
 keywords:
   - monitoring

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -195,6 +195,8 @@ spec:
             {{- if .Values.extraVolumes.mounts }}
 {{ toYaml .Values.extraVolumes.mounts | indent 12 }}
             {{- end }}
+            - mountPath: /etc/podinfo
+              name: podinfo
       volumes:
         - name: modprobe-d
           hostPath:
@@ -258,5 +260,17 @@ spec:
         {{- if .Values.extraVolumes.volumes }}
 {{ toYaml .Values.extraVolumes.volumes | indent 8 }}
         {{- end }}
+        - name: podinfo
+          downwardAPI:
+            defaultMode: 420
+            items:
+            - fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+              path: namespace
+            - fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+              path: name
   updateStrategy:
 {{ toYaml .Values.daemonset.updateStrategy | indent 4 }}


### PR DESCRIPTION
## What this PR does / why we need it:

With this PR the agent will be able to read its namespace and pod name from the local filesystem
This is useful in the leader election mechanism

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
