### PR TITLE
[admission-controller] Don't let istio to instrument the webhook

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.4.21
+version: 0.4.22
 appVersion: 3.5.2
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -53,6 +53,7 @@ webhook:
     prometheus.io/path: "/metrics"
     prometheus.io/port: "5000"
     prometheus.io/scheme: "https"
+    sidecar.istio.io/inject: "false"
 
   podSecurityContext: {}
 


### PR DESCRIPTION
Istio and the api-server does not play pretty well together, like pizza
and pineapple:

* https://github.com/istio/istio/issues/8696
* https://github.com/istio/istio/issues/12187

Chart is open enough for the users to set the podAnnotation with the
api-server instead of not deploying the sidecar in the webhook, but by
default we offer an option that works on most possible scenarios.

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
