### PR TITLE
[sysdig] fix: restore appVersion

### DIFF
--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 name: sysdig
 version: 1.12.16
+appVersion: 11.4.1
 description: Sysdig Monitor and Secure agent
 keywords:
   - monitoring

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.16
+version: 1.12.17
 appVersion: 11.4.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/scripts/sysdig/image-version-bump.sh
+++ b/scripts/sysdig/image-version-bump.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/sysdig/image-version-bump.sh
+++ b/scripts/sysdig/image-version-bump.sh
@@ -39,5 +39,20 @@ BEGIN {
     print
 }
 ' values.yaml > values.yaml.2
-
 mv values.yaml.2 values.yaml
+
+
+awk $@ '
+BEGIN {
+    if (!AGENT_VERSION)
+        exit 1
+}
+
+{
+    if ($1 ~ /^appVersion:/)
+        sub(/:.*/, ": "AGENT_VERSION)
+
+    print
+}
+' Chart.yaml > Chart.yaml.2
+mv Chart.yaml.2 Chart.yaml


### PR DESCRIPTION
## What this PR does / why we need it:
People like to have appVersion, even if optional. Restore it and enhance the tooling.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
