### PR TITLE
[sysdig] fix: remove livenessProbe

### DIFF
--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.17
+version: 1.12.18
 appVersion: 11.4.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -136,10 +136,6 @@ spec:
             exec:
               command: [ "test", "-e", "/opt/draios/logs/running" ]
             initialDelaySeconds: {{ .Values.daemonset.probes.initialDelay }}
-          livenessProbe:
-            exec:
-              command: [ "test", "-e", "/opt/draios/logs/running" ]
-            initialDelaySeconds: {{ .Values.daemonset.probes.initialDelay }}
           volumeMounts:
             {{- if not .Values.slim.enabled }}
             - mountPath: /etc/modprobe.d


### PR DESCRIPTION
## What this PR does / why we need it:
- Align with other installation methods
- Avoid false negatives
## Checklist
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
