### PR TITLE
[sysdig] Add affinity for nodeImageAnalyzer

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.12.27
+
+### Minor changes
+
+- Add affinity to nodeImageAnalyzer DaemonSet
+
 ## v1.12.26
 
 ### Minor changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.26
+version: 1.12.27
 appVersion: 12.0.2
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -154,6 +154,7 @@ Node Image Analyzer parameters (deprecated by nodeAnalyzer)
 | `nodeImageAnalyzer.extraVolumes.volumes`                   | Additional volumes to mount in the Node Image Analyzer (i.e. for docker socket)          | `[]`                                                                          |
 | `nodeImageAnalyzer.extraVolumes.mounts`                    | Mount points for additional volumes                                                      | `[]`                                                                          |
 | `nodeImageAnalyzer.priorityClassName`                      | Priority class name variable                                                             |                                                                               |
+| `nodeImageAnalyzer.affinity`                               | Node affinities                                                                          | `schedule on amd64 and linux`                                                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/sysdig/templates/daemonset-image-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-image-analyzer.yaml
@@ -57,6 +57,10 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.nodeImageAnalyzer.image.pullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.nodeImageAnalyzer.affinity }}
+      affinity:
+{{ toYaml .Values.nodeImageAnalyzer.affinity | indent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 5
       containers:
       - name: sysdig-image-analyzer

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -285,6 +285,31 @@ nodeImageAnalyzer:
   # Set daemonset priorityClassName
   priorityClassName:
 
+  # Allow the DaemonSet to schedule using affinity rules
+  # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+          - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+              - key: beta.kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+
 nodeAnalyzer:
   deploy: true
 


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds node affinity for nodeImageAnalyzer deamonset. This is helpful for environments with more than one arch.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
