### PR TITLE
[sysdig] Grant the agent read access to networkpolicy resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When a commit to master includes a new version of a _chart_, a GitHub action wil
 
 ### Detailed explanation of publish procedure
 
-With each commit to _master_, a GitHub action will compare all charts versions at the `charts` folder on _master_ branch with published versions at the `index.yaml` chart list on _gh-pages_ branch. 
+With each commit to _master_, a GitHub action will compare all charts versions at the `charts` folder on _master_ branch with published versions at the `index.yaml` chart list on _gh-pages_ branch.
 
 When it detects that the version in the folder doesn't exist in  `index.yaml`, it will create a release with the packaged chart content on the _GitHub repository_, and update `index.yaml` to include it on the `charts repository`.
 
@@ -35,7 +35,7 @@ and the list of all charts at `index.yaml` on _gh-pages_ branch will be updated 
 ## More information
 
 You can find more information at:
-* [charts.sysdig.com/](https://charts.sysdig.com/) / [sysdiglabs.github.io/charts](https://sysdiglabs.github.io/charts) 
+* [charts.sysdig.com/](https://charts.sysdig.com/) / [sysdiglabs.github.io/charts](https://sysdiglabs.github.io/charts)
 * [The Helm package manager](https://helm.sh/)
 * [Chart Releaser](https://github.com/helm/chart-releaser)
 * [Chart Releaser GitHub Action](https://github.com/helm/chart-releaser-action)

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.27
+version: 1.12.28
 appVersion: 12.0.2
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -213,7 +213,7 @@ The Node Analyzer is deployed by default unless you set the value `nodeAnalyzer.
 The Node Analyzer daemonset contains three containers, each providing a specific functionality. This daemonset replaces
 the (deprecated) Node Image Analyzer daemonset.
 
-See the [Node Analyzer installation documentation](https://docs.sysdig.com/en/node-analyzer--multi-feature-installation.html) for details about installation, and 
+See the [Node Analyzer installation documentation](https://docs.sysdig.com/en/node-analyzer--multi-feature-installation.html) for details about installation, and
 [Running Node Analyzer Behind a Proxy](https://docs.sysdig.com/en/node-analyzer--multi-feature-installation.html#UUID-35c14c46-b327-c2a8-ed9c-82a2af995218_section-idm51621039128136) for proxy settings.
 
 ### Node Image Analyzer
@@ -226,7 +226,7 @@ On container start-up, the analyzer scans all pre-existing running images presen
 
 ### Host Analyzer
 See the [Host Scanning Configuration Options](https://docs.sysdig.com/en/node-analyzer--multi-feature-installation.html#UUID-35c14c46-b327-c2a8-ed9c-82a2af995218_UUID-6666385b-c550-0660-f563-956f3a4fe093) for details about installation options, and
-the [Host Scanning documentation](https://docs.sysdig.com/en/host-scanning.html) for details about the Host Scanning feature. 
+the [Host Scanning documentation](https://docs.sysdig.com/en/host-scanning.html) for details about the Host Scanning feature.
 
 The host analyzer provides the capability to scan packages installed on the host operating system to identify potential vulnerabilities. It is typically installed as part of the Node Analyzer which in turn is installed alongside the Sysdig Agent.
 

--- a/charts/sysdig/templates/_helpers.tpl
+++ b/charts/sysdig/templates/_helpers.tpl
@@ -50,7 +50,7 @@ Define the proper imageRegistry to use for agent and kmodule image
     {{- .Values.global.imageRegistry -}}
 {{- else -}}
     {{- .Values.image.registry -}}
-{{- end -}} 
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -138,10 +138,10 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 
-{{/* 
+{{/*
 Use like: {{ include "get_or_fail_if_in_settings" (dict "root" . "key" "<mypath.key>" "setting" "<agent_setting>") }}
 Return the value of key "<mypath.key>" and if "<agent_setting>" is also defined in sysdig.settings.<agent_setting>, and error is thrown
-NOTE: I don't like the error message! Too much information. 
+NOTE: I don't like the error message! Too much information.
 */}}
 {{- define "get_or_fail_if_in_settings" -}}
 {{- $keyValue := tpl (printf "{{- .Values.%s -}}" .key) .root }}

--- a/charts/sysdig/templates/clusterrole.yaml
+++ b/charts/sysdig/templates/clusterrole.yaml
@@ -90,11 +90,11 @@ rules:
 {{- if .Values.psp.create  }}
   - apiGroups:
       - "policy"
-    resources: 
+    resources:
       - "podsecuritypolicies"
     resourceNames:
       - "{{ template "sysdig.fullname" . }}"
-    verbs: 
+    verbs:
       - "use"
 {{- end }}
 {{- end }}

--- a/charts/sysdig/templates/clusterrole.yaml
+++ b/charts/sysdig/templates/clusterrole.yaml
@@ -55,6 +55,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - extensions
     resources:
       - daemonsets

--- a/charts/sysdig/templates/configmap.yaml
+++ b/charts/sysdig/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
 {{- end }}
 {{- $disableCaptures := include "get_or_fail_if_in_settings" (dict "root" . "key" "sysdig.disableCaptures" "setting" "sysdig_capture_enabled")}}
 {{- if eq $disableCaptures "true" }}
-    sysdig_capture_enabled: false 
+    sysdig_capture_enabled: false
 {{- end }}
 {{- $collectorHost := include "get_or_fail_if_in_settings" (dict "root" . "key" "collectorSettings.collectorHost" "setting" "collector")}}
 {{- if $collectorHost }}


### PR DESCRIPTION
## What this PR does / why we need it:
[sysdig] This PR grants the sysdig agent read access to networkpolicy resources.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
