### PR TITLE
[sysdig] Add deploy option for benchmark runner

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.12.28
+
+### Minor changes
+
+- Add option to deploy Benchmark Runner
+
 ## v1.12.27
 
 ### Minor changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.27
+version: 1.12.28
 appVersion: 12.0.2
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -121,6 +121,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `nodeAnalyzer.hostAnalyzer.resources.requests.memory`      | Host Analyzer Memory requests per node                                                   | `512Mi`                                                                       |
 | `nodeAnalyzer.hostAnalyzer.resources.limits.cpu`           | Host Analyzer CPU limit per node                                                         | `500m`                                                                        |
 | `nodeAnalyzer.hostAnalyzer.resources.limits.memory`        | Host Analyzer Memory limit per node                                                      | `1536Mi`                                                                      |
+| `nodeAnalyzer.benchmarkRunner.deploy`                      | Deploy the Benchmark Runner                                                              | `true`                                                                        |
 | `nodeAnalyzer.benchmarkRunner.image.repository`            | The image repository to pull the Benchmark Runner from                                   | `sysdig/compliance-benchmark-runner`                                          |
 | `nodeAnalyzer.benchmarkRunner.image.tag`                   | The image tag to pull the Benchmark Runner                                               | `1.0.6.0`                                                                     |
 | `nodeAnalyzer.benchmarkRunner.image.pullPolicy`            | The Image pull policy for the Benchmark Runner                                           | `IfNotPresent`                                                                |
@@ -234,7 +235,7 @@ The host analyzer works by inspecting the files on the host root filesystem look
 
 ### Benchmark Runner
 See the [Benchmarks documentation](https://docs.sysdig.com/en/benchmarks.html) for details on the Benchmark feature.
-The Benchmark Runner provides the capability to run CIS inspired benchmarks against your infrastructure. Benchmark tasks are configured in the UI, and the runner automatically runs these benchmarks on the configured scope and schedule.
+The Benchmark Runner provides the capability to run CIS inspired benchmarks against your infrastructure. Benchmark tasks are configured in the UI, and the runner automatically runs these benchmarks on the configured scope and schedule. The Benchmarks portion of the Node Analyzer install is currently available on Sysdig Secure SaaS only.
 
 ## On-Premise backend deployment settings
 

--- a/charts/sysdig/templates/_helpers.tpl
+++ b/charts/sysdig/templates/_helpers.tpl
@@ -156,3 +156,9 @@ NOTE: I don't like the error message! Too much information.
 true
 {{- end -}}
 {{- end -}}
+
+{{- define "deploy-br" -}}
+{{- if .Values.nodeAnalyzer.benchmarkRunner.deploy -}}
+true
+{{- end -}}
+{{- end -}}

--- a/charts/sysdig/templates/configmap-benchmark-runner.yaml
+++ b/charts/sysdig/templates/configmap-benchmark-runner.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy}}
+{{- if and (not (include "deploy-nia" .)) (include "deploy-br" .) .Values.nodeAnalyzer.deploy}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -291,6 +291,7 @@ spec:
               key: no_proxy
               name: {{ template "sysdig.fullname" . }}-host-analyzer
               optional: true
+  {{- if (include "deploy-br" .) }}
       - name: sysdig-benchmark-runner
         image: {{ template "sysdig.image.benchmarkRunner" . }}
         imagePullPolicy: {{ .Values.nodeAnalyzer.benchmarkRunner.image.pullPolicy }}
@@ -357,4 +358,5 @@ spec:
               key: no_proxy
               name: {{ template "sysdig.fullname" . }}-benchmark-runner
               optional: true
+  {{- end }}
   {{- end }}

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -406,6 +406,7 @@ nodeAnalyzer:
         cpu: 500m
         memory: 1536Mi
   benchmarkRunner:
+    deploy: true
     image:
       repository: sysdig/compliance-benchmark-runner
       tag: 1.0.6.0


### PR DESCRIPTION
## What this PR does / why we need it:
The Benchmark Runner only works for Secure SaaS. For on-prem the container continually restarts. This creates the option to deploy it (or not).

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
