### PR TITLE
[sysdig] Version bump scripts update

### DIFF
--- a/scripts/sysdig/image-version-bump.sh
+++ b/scripts/sysdig/image-version-bump.sh
@@ -45,7 +45,7 @@ mv values.yaml.2 values.yaml
 awk $@ '
 BEGIN {
     if (!AGENT_VERSION)
-        exit 1
+        exit 0
 }
 
 {


### PR DESCRIPTION
## What this PR does / why we need it:
Related to https://sysdig.atlassian.net/browse/SSPROD-9633, currently the script fails when not bumping the agent version, but we want to implement this for the benchmark runner as well

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
