### PR TITLE
[registry-scanner] Propagate pull secrets and bump version

### DIFF
--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -5,6 +5,13 @@
 This file documents all notable changes to Sysdig Registry Scanner. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.0.23
+
+### Minor changes
+
+* Bump registry-scanner version to 0.0.9
+* Propagate imagePullSecrets to the scan.pullSecrets option for inline-scanner
+
 ## v0.0.22
 
 ### Minor changes
@@ -16,6 +23,7 @@ numbering uses [semantic versioning](http://semver.org).
 ### Minor changes
 
 * Bump registry-scanner version to 0.0.7
+* Add options `config.registryType` and `config.registryAccountId` for ICR
 
 ## v0.0.20
 

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,8 +4,8 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.0.22
-appVersion: 0.0.8
+version: 0.0.23
+appVersion: 0.0.9
 maintainers:
   - name: airadier
     email: alvaro.iradier@sysdig.com

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -33,6 +33,8 @@ The following table lists the configurable parameters of the Sysdig Registry Sca
 | `config.registryPassword`            | Password for registry authentication                                                                                   | ` `                               |
 | `config.registryType`                | Registry Type. Optional. dockerv2 (default if not specified), icr                                                      | ` `                               |
 | `config.registryAccountId`           | AccountID - Only for ICR registry type                                                                                 | ` `                               |
+| `config.icrIamApi`                   | IAM API Endpoint - Only for ICR registry type                                                                          | ` `                               |
+| `config.icrIamApiSkipTLS`            | Ignore TLS certificate for IAM API - Only for ICR registry type                                                        | `false`                           |
 | `config.registrySkipTLS`             | Ignore registry TLS certificate errors (self-signed, etc.)                                                             | `false`                           |
 | `config.secureBaseURL`               | Sysdig Secure Base URL                                                                                                 | `https://secure.sysdig.com`       |
 | `config.secureAPIToken`              | API Token to access Sysdig Secure                                                                                      | ` `                               |

--- a/charts/registry-scanner/templates/_helpers.tpl
+++ b/charts/registry-scanner/templates/_helpers.tpl
@@ -78,3 +78,10 @@ Allow overriding registry and repository for air-gapped environments
     {{- $globalRegistry | default $imageRegistry | default "quay.io" -}} / {{- $imageRepository -}} : {{- $imageTag -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "registry-scanner.rawPullSecretList" -}}
+{{- range .Values.imagePullSecrets }}{{- if . }}{{- .name}},{{- end}}{{- end}}
+{{- end -}}
+{{- define "registry-scanner.pullSecretList" -}}
+{{ trimSuffix "," (include "registry-scanner.rawPullSecretList" .) }}
+{{- end -}}

--- a/charts/registry-scanner/templates/configmap.yaml
+++ b/charts/registry-scanner/templates/configmap.yaml
@@ -17,6 +17,12 @@ data:
       {{- if .Values.config.registryAccountId }}
       accountId: {{ .Values.config.registryAccountId }}
       {{- end }}
+      {{- if .Values.config.icrIamApi }}
+      icrIamApi: {{ .Values.config.icrIamApi }}
+      {{- end }}
+      {{- if .Values.config.icrIamApiSkipTLS }}
+      icrIamApiSkipTLS: {{ .Values.config.icrIamApiSkipTLS }}
+      {{- end }}
       skipTLS: {{ .Values.config.registrySkipTLS }}
       {{- if .Values.config.registryApiUrl }}
       api: {{ .Values.config.registryApiUrl }}
@@ -35,6 +41,9 @@ data:
       workers: {{ default 1 .Values.config.maxWorkers }}
       {{- if .Values.config.scan.inlineScanImage }}
       inlineScanImage: {{ .Values.config.scan.inlineScanImage }}
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      pullSecrets: {{ include "registry-scanner.pullSecretList" . }}
       {{- end }}
 
     filter:

--- a/charts/registry-scanner/values.yaml
+++ b/charts/registry-scanner/values.yaml
@@ -16,7 +16,11 @@ config:
   # Defaults to "dockerv2" if not specified. Available options: dockerv2, icr
   registryType:
   # AccountID - Only for ICR registry type
-  registryAccountId:
+  # registryAccountId:
+  # ICR IAM API - Only for ICR registry type
+  # icrIamApi:
+  # ICR IAM API Skip TLS - Only for ICR registry type
+  # icrIamApiSkipTLS:
   registrySkipTLS: false
   secureBaseURL: https://secure.sysdig.com
   secureAPIToken:


### PR DESCRIPTION
## What this PR does / why we need it:

* Bump registry-scanner version to 0.0.9
* When imagePullSecrets are specified, propagate the names to the config.yaml so the inline-scanner job is created with the same imagePullSecrets
* Update changelog

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
