### PR TITLE
Have image-version-bump.sh work both when AGENT_VERSION is provided or not

### DIFF
--- a/scripts/sysdig/image-version-bump.sh
+++ b/scripts/sysdig/image-version-bump.sh
@@ -43,14 +43,8 @@ mv values.yaml.2 values.yaml
 
 
 awk $@ '
-BEGIN {
-    if (!AGENT_VERSION)
-        print
-        exit 0
-}
-
 {
-    if ($1 ~ /^appVersion:/)
+    if (AGENT_VERSION && $1 ~ /^appVersion:/)
         sub(/:.*/, ": "AGENT_VERSION)
 
     print


### PR DESCRIPTION
image-version-bump.sh was tailored too much on agent bump.
Deal properly with both the cases when AGENT_VERSION is passed to the script or not.