### PR TITLE
[sysdig] Removed invalid image pull secret reference from initContainers

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.12.35
+### Minor changes
+
+- Removed invalid imagePullSecrets from initContainers
+
 ## v1.12.31
 
 ### Minor changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.34
+version: 1.12.35
 appVersion: 12.0.4
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -48,10 +48,6 @@ spec:
         - name: sysdig-agent-kmodule
           image: {{ template "sysdig.image.kmodule" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.image.pullSecrets }}
-          imagePullSecrets:
-{{ toYaml .Values.image.pullSecrets | indent 12 }}
-          {{- end }}
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION
## What this PR does / why we need it:
Helm: v3.5.3
K8s: 1.19.13

When trying to install the latest version of the helm module using the "slim" container option you get the following error:
**Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(DaemonSet.spec.template.spec.initContainers[0]): unknown field "imagePullSecrets" in io.k8s.api.core.v1.Container**

After debugging and doing some research, it appears that imagePullSecrets is not part of the containers or initcontainers objects.. 
https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#containers

In testing, after removing imagePullSecrets from under "initContainers" the Chat was able to be validated, and installed correctly with a private registry using an image pull secret that was already defined higher in the manifest.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
