### PR TITLE
Removed invalid pull secret from initContainers

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.12.35
+### Minor changes
+
+- Removed invalid imagePullSecrets from initContainers
+
 ## v1.12.31
 
 ### Minor changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.34
+version: 1.12.35
 appVersion: 12.0.4
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -48,10 +48,6 @@ spec:
         - name: sysdig-agent-kmodule
           image: {{ template "sysdig.image.kmodule" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.image.pullSecrets }}
-          imagePullSecrets:
-{{ toYaml .Values.image.pullSecrets | indent 12 }}
-          {{- end }}
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION
## What this PR does / why we need it:

Clone of https://github.com/sysdiglabs/charts/pull/286 to trigger workflow

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
