### PR TITLE
[registry-scanner] Bump registry-scanner to 0.1.1

### DIFF
--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -5,6 +5,12 @@
 This file documents all notable changes to Sysdig Registry Scanner. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.0.25
+
+### Minor changes
+
+* Bump registry-scanner version to 0.1.1
+
 ## v0.0.24
 
 ### Minor changes

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,8 +4,8 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.0.24
-appVersion: 0.1.0
+version: 0.0.25
+appVersion: 0.1.1
 maintainers:
   - name: airadier
     email: alvaro.iradier@sysdig.com


### PR DESCRIPTION
## What this PR does / why we need it:

Bump registry-scanner to v0.1.1 to update the inline-scanner base image version.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
