### PR TITLE
chore(lint): checkout pull request HEAD commit

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v1


### PR DESCRIPTION
## What this PR does / why we need it:
Change lint workflow to checkout the pull request latest commit.