### PR TITLE
[sysdig] fix typo in node analyzer volumes

### DIFF
--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.37
+version: 1.12.38
 appVersion: 12.1.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -59,8 +59,8 @@ spec:
             path: /
         - name: tmp-vol
           emptyDir: {}
-        {{- if .Values.nodeAnalyzer.imageAnalyzer.extraVolumes.volumes }}
-{{ toYaml .Values.nodeAnalyzer.imageAnalyzer.extraVolumesvolumes | indent 8 }}
+        {{- with .Values.nodeAnalyzer.imageAnalyzer.extraVolumes.volumes }}
+{{ toYaml . | indent 8 }}
         {{- end }}
       tolerations:
 {{ toYaml .Values.nodeAnalyzer.tolerations | indent 8 }}


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes a typo for node analyzer volumes, as found here: https://sysdig.atlassian.net/browse/SMAGENT-3264

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
