### PR TITLE
[harbor-scanner-sysdig-secure] Bump Harbor adapter version to 0.5.0

### DIFF
--- a/charts/harbor-scanner-sysdig-secure/Chart.yaml
+++ b/charts/harbor-scanner-sysdig-secure/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: harbor-scanner-sysdig-secure
 description: Harbor Scanner for Sysdig Secure
 type: application
-version: 0.2.8
-appVersion: 0.4.1
+version: 0.3.0
+appVersion: 0.5.0
 home: https://github.com/sysdiglabs/harbor-scanner-sysdig-secure
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
 maintainers:

--- a/charts/harbor-scanner-sysdig-secure/templates/tests/test-connection.yaml
+++ b/charts/harbor-scanner-sysdig-secure/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "harbor-scanner-sysdig-secure.fullname" . }}:{{ .Values.service.port }}/health']
+      args: ['{{ include "harbor-scanner-sysdig-secure.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/health']
   restartPolicy: Never


### PR DESCRIPTION
## What this PR does / why we need it:

Bump version of harbor-scanner to 0.5.0

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
