### PR TITLE
chore: Update lint action to use pull_request_target

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,6 +1,6 @@
 name: Lint and Test Charts
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   lint-test:
@@ -10,6 +10,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Set up Helm
         uses: azure/setup-helm@v1


### PR DESCRIPTION
## What this PR does / why we need it:

This is one possible solution to the issue of PRs from forks not being able to access secrets. There is a potential [security risk](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) to this event, but other than helm charts, nothing is really built and run that could pose a threat.

Alternatively, we could use completely fake values for the tokens in `ci/*.yaml.template`, which works for the sysdig chart, but I have not tested for the other charts.
