### PR TITLE
[sysdig] Expose k8s node name to agent pods using downward API

### DIFF
--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.41
+version: 1.12.42
 appVersion: 12.1.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -61,8 +61,12 @@ spec:
             allowPrivilegeEscalation: true
           resources:
 {{ toYaml .Values.slim.resources | indent 12 }}
-          {{- if .Values.ebpf.enabled }}
           env:
+            - name: K8S_NODE
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          {{- if .Values.ebpf.enabled }}
             - name: SYSDIG_BPF_PROBE
               value:
           {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:

This PR exposes the node name to the agent through an environment variable using downward API, so that it does not try to resolve it by matching node IP or hostname, which does not result to be always reliable.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [X] PR only contains changes for one chart
