### PR TITLE
Update daemonset.yaml to add the https_proxy and http_proxy in the env section of the sysdig-agent-kmodule container

### DIFF
--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -67,6 +67,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          {{- if .Values.proxy.httpProxy }}
+            - name: http_proxy
+              value: {{ .Values.proxy.httpProxy }}
+          {{- end }}
+          {{- if .Values.proxy.httpsProxy }}
+            - name: https_proxy
+              value: {{ .Values.proxy.httpsProxy }}
+          {{- end }}
           {{- if .Values.ebpf.enabled }}
             - name: SYSDIG_BPF_PROBE
               value:


### PR DESCRIPTION
## What this PR does / why we need it:

Added the missing https_proxy and http_proxy in the env section of the sysdig-agent-kmodule container.
We need it since it is missing in the chart but it is supported by the container (we tested it).

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
