### PR TITLE
[sysdig] add nodeSelector and affinity to nodeAnalyzer daemonset

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.12.45
+### Minor changes
+
+- Add ability to configure affinity and nodeSelector on imageAnalyzer daemonset
+
 ## v1.12.43
 ### Minor changes
 

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.44
+version: 1.12.45
 appVersion: 12.2.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -133,6 +133,8 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `nodeAnalyzer.benchmarkRunner.resources.requests.memory`   | Benchmark Runner Memory requests per node                                                | `128Mi`                                                                       |
 | `nodeAnalyzer.benchmarkRunner.resources.limits.cpu`        | Benchmark Runner CPU limit per node                                                      | `500m`                                                                        |
 | `nodeAnalyzer.benchmarkRunner.resources.limits.memory`     | Benchmark Runnerr Memory limit per node                                                  | `256Mi`                                                                       |
+| `nodeAnalyzer.nodeSelector`                                | Node Selector                                                                            | `{}`                                                                          |
+| `nodeAnalyzer.affinity`                                    | Node affinities                                                                          | `schedule on amd64 and linux`                                                 |
 
 Node Image Analyzer parameters (deprecated by nodeAnalyzer)
 

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -362,4 +362,10 @@ spec:
               key: no_proxy
               name: {{ template "sysdig.fullname" . }}-benchmark-runner
               optional: true
+      {{- with .Values.nodeAnalyzer.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeAnalyzer.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
   {{- end }}

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -354,6 +354,33 @@ nodeAnalyzer:
   # pullSecrets:
   #   - name: myRegistryKeySecretName
 
+  nodeSelector: {}
+
+  # Allow the DaemonSet to schedule using affinity rules
+  # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+          - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+              - key: beta.kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+
   imageAnalyzer:
     image:
       repository: sysdig/node-image-analyzer


### PR DESCRIPTION
## What this PR does / why we need it:

Adds ability to configure nodeSelector and nodeAnalyzer, similar to the agent daemonset and the deprecated nodeImageAnalyzer daemonset

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
