### PR TITLE
[sysdig] trim whitespace around else clause for image tags

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.12.47
+### Bugfixes
+
+* Trim whitespace around image tag
+
 ## v1.12.46
 ### Minor changes
 

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.46
+version: 1.12.47
 appVersion: 12.2.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/_helpers.tpl
+++ b/charts/sysdig/templates/_helpers.tpl
@@ -68,7 +68,7 @@ Return the proper Sysdig Agent image name
 {{- if .Values.image.overrideValue }}
     {{- printf .Values.image.overrideValue -}}
 {{- else -}}
-    {{- include "sysdig.imageRegistry" . -}} / {{- include "sysdig.repositoryName" . -}} {{- if .Values.image.digest -}} @ {{- .Values.image.digest -}} {{ else }} : {{- .Values.image.tag -}} {{- end -}}
+    {{- include "sysdig.imageRegistry" . -}} / {{- include "sysdig.repositoryName" . -}} {{- if .Values.image.digest -}} @ {{- .Values.image.digest -}} {{- else -}} : {{- .Values.image.tag -}} {{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -98,35 +98,35 @@ Sysdig Agent resources
 Return the proper Sysdig Agent image name for module building
 */}}
 {{- define "sysdig.image.kmodule" -}}
-    {{- include "sysdig.imageRegistry" . -}} / {{- .Values.slim.kmoduleImage.repository -}} {{- if .Values.slim.kmoduleImage.digest -}} @ {{- .Values.slim.kmoduleImage.digest -}} {{ else }} : {{- .Values.image.tag -}} {{- end -}}
+    {{- include "sysdig.imageRegistry" . -}} / {{- .Values.slim.kmoduleImage.repository -}} {{- if .Values.slim.kmoduleImage.digest -}} @ {{- .Values.slim.kmoduleImage.digest -}} {{- else -}} : {{- .Values.image.tag -}} {{- end -}}
 {{- end -}}
 
 {{/*
 Return the proper Sysdig Agent image name for the Node Image Analyzer
 */}}
 {{- define "sysdig.image.nodeImageAnalyzer" -}}
-    {{- include "sysdig.imageRegistry" . -}} / {{- .Values.nodeImageAnalyzer.image.repository -}} {{- if .Values.nodeImageAnalyzer.image.digest -}} @ {{- .Values.nodeImageAnalyzer.image.digest -}} {{ else }} : {{- .Values.nodeImageAnalyzer.image.tag -}} {{- end -}}
+    {{- include "sysdig.imageRegistry" . -}} / {{- .Values.nodeImageAnalyzer.image.repository -}} {{- if .Values.nodeImageAnalyzer.image.digest -}} @ {{- .Values.nodeImageAnalyzer.image.digest -}} {{- else -}} : {{- .Values.nodeImageAnalyzer.image.tag -}} {{- end -}}
 {{- end -}}
 
 {{/*
 Return the proper image name for the Image Analyzer
 */}}
 {{- define "sysdig.image.imageAnalyzer" -}}
-    {{- include "sysdig.imageRegistry" . -}} / {{- .Values.nodeAnalyzer.imageAnalyzer.image.repository -}} {{- if .Values.nodeAnalyzer.imageAnalyzer.image.digest -}} @ {{- .Values.nodeAnalyzer.imageAnalyzer.image.digest -}} {{ else }} : {{- .Values.nodeAnalyzer.imageAnalyzer.image.tag -}} {{- end -}}
+    {{- include "sysdig.imageRegistry" . -}} / {{- .Values.nodeAnalyzer.imageAnalyzer.image.repository -}} {{- if .Values.nodeAnalyzer.imageAnalyzer.image.digest -}} @ {{- .Values.nodeAnalyzer.imageAnalyzer.image.digest -}} {{- else -}} : {{- .Values.nodeAnalyzer.imageAnalyzer.image.tag -}} {{- end -}}
 {{- end -}}
 
 {{/*
 Return the proper image name for the Host Analyzer
 */}}
 {{- define "sysdig.image.hostAnalyzer" -}}
-    {{- include "sysdig.imageRegistry" . -}} / {{- .Values.nodeAnalyzer.hostAnalyzer.image.repository -}} {{- if .Values.nodeAnalyzer.hostAnalyzer.image.digest -}} @ {{- .Values.nodeAnalyzer.hostAnalyzer.image.digest -}} {{ else }} : {{- .Values.nodeAnalyzer.hostAnalyzer.image.tag -}} {{- end -}}
+    {{- include "sysdig.imageRegistry" . -}} / {{- .Values.nodeAnalyzer.hostAnalyzer.image.repository -}} {{- if .Values.nodeAnalyzer.hostAnalyzer.image.digest -}} @ {{- .Values.nodeAnalyzer.hostAnalyzer.image.digest -}} {{- else -}} : {{- .Values.nodeAnalyzer.hostAnalyzer.image.tag -}} {{- end -}}
 {{- end -}}
 
 {{/*
 Return the proper image name for the Benchmark Runner
 */}}
 {{- define "sysdig.image.benchmarkRunner" -}}
-    {{- include "sysdig.imageRegistry" . -}} / {{- .Values.nodeAnalyzer.benchmarkRunner.image.repository -}} {{- if .Values.nodeAnalyzer.benchmarkRunner.image.digest -}} @ {{- .Values.nodeAnalyzer.benchmarkRunner.image.digest -}} {{ else }} : {{- .Values.nodeAnalyzer.benchmarkRunner.image.tag -}} {{- end -}}
+    {{- include "sysdig.imageRegistry" . -}} / {{- .Values.nodeAnalyzer.benchmarkRunner.image.repository -}} {{- if .Values.nodeAnalyzer.benchmarkRunner.image.digest -}} @ {{- .Values.nodeAnalyzer.benchmarkRunner.image.digest -}} {{- else -}} : {{- .Values.nodeAnalyzer.benchmarkRunner.image.tag -}} {{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes issue where there is whitespace separating a tag from the image.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
