### PR TITLE
[sysdig-deploy] initial sysdig-deploy chart

### DIFF
--- a/charts/sysdig-deploy/.helmignore
+++ b/charts/sysdig-deploy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -13,6 +13,6 @@ dependencies:
 - name: agent
   # repository: https://artifactory.internal.sysdig.com/artifactory/helm
   repository: file://../agent
-  version: 1.0.0
+  version: ~1.0.0
   alias: agent
   condition: agent.enabled

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: sysdig-deploy
+description: A chart with various Sysdig components for Kubernetes
+
+type: application
+
+version: 0.1.0
+
+maintainers:
+  - name: achandras
+    email: ashwin.chandrasekar@sysdig.com
+dependencies:
+- name: agent
+  # repository: https://artifactory.internal.sysdig.com/artifactory/helm
+  repository: file://../agent
+  version: 1.0.0
+  alias: agent
+  condition: agent.enabled

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -9,6 +9,10 @@ version: 0.1.0
 maintainers:
   - name: achandras
     email: ashwin.chandrasekar@sysdig.com
+
+home: https://www.sysdig.com/
+icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+
 dependencies:
 - name: agent
   # repository: https://artifactory.internal.sysdig.com/artifactory/helm

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -1,0 +1,25 @@
+# Sysdig
+
+[Sysdig](https://sysdig.com/) is a unified platform for container and microservices monitoring, troubleshooting,
+security and forensics. Sysdig platform has been built on top of [Sysdig tool](https://sysdig.com/opensource/sysdig/)
+and [Sysdig Inspect](https://sysdig.com/blog/sysdig-inspect/) open-source technologies.
+
+## Introduction
+
+This chart deploys various Sysdig components into your Kubernetes cluster.
+
+Currently included components:
+- [Sysdig agent](https://github.com/sysdiglabs/charts/tree/master/charts/agent)
+
+## Configuration
+
+| Parameter                       | Description                                                       | Default   |
+|---------------------------------|-------------------------------------------------------------------|-----------|
+| `global.clusterConfig.name`     | Identifier for this cluster                                       | `""`      |
+| `global.sysdig.accessKey`       | Sysdig Agent Access Key                                           | `""`      |
+| `global.sysdig.accessKeySecret` | The name of a Kubernetes secret containing an 'access-key' entry. | `""`      |
+| `global.image.registry`         | Container image registry                                          | `quay.io` |
+| `agent`                         | Config specific to the Sysdig Agent                               | ``        |
+| `agent.enabled`                 | Enable the agent component in this chart                          | `true`    |
+
+For possible configuration values of the Agent, please refer to the Agent chart [README](https://github.com/sysdiglabs/charts/tree/master/charts/agent/README.md)

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -1,5 +1,12 @@
 # Sysdig
 
+---
+**WARNING**
+
+This chart is still experimental and may have issues! Please use the [supported chart](https://github.com/sysdiglabs/charts/tree/master/charts/sysdig) for production deployments.
+
+---
+
 [Sysdig](https://sysdig.com/) is a unified platform for container and microservices monitoring, troubleshooting,
 security and forensics. Sysdig platform has been built on top of [Sysdig tool](https://sysdig.com/opensource/sysdig/)
 and [Sysdig Inspect](https://sysdig.com/blog/sysdig-inspect/) open-source technologies.

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -20,13 +20,16 @@ Currently included components:
 
 ## Configuration
 
-| Parameter                       | Description                                                       | Default   |
-|---------------------------------|-------------------------------------------------------------------|-----------|
-| `global.clusterConfig.name`     | Identifier for this cluster                                       | `""`      |
-| `global.sysdig.accessKey`       | Sysdig Agent Access Key                                           | `""`      |
-| `global.sysdig.accessKeySecret` | The name of a Kubernetes secret containing an 'access-key' entry. | `""`      |
-| `global.image.registry`         | Container image registry                                          | `quay.io` |
-| `agent`                         | Config specific to the Sysdig Agent                               | ``        |
-| `agent.enabled`                 | Enable the agent component in this chart                          | `true`    |
+| Parameter                        | Description                                                       | Default        |
+| -------------------------------- | ----------------------------------------------------------------- | -------------- |
+| `global.clusterConfig.name`      | Identifier for this cluster                                       | `""`           |
+| `global.clusterConfig.namespace` | Default namespace for all components                              | `sysdig-agent` |
+| `global.sysdig.accessKey`        | Sysdig Agent Access Key                                           | `""`           |
+| `global.sysdig.accessKeySecret`  | The name of a Kubernetes secret containing an 'access-key' entry. | `""`           |
+| `global.image.registry`          | Container image registry                                          | `quay.io`      |
+| `agent`                          | Config specific to the [Sysdig Agent](#agent)                     | ``             |
+| `agent.enabled`                  | Enable the agent component in this chart                          | `true`         |
+
+## Agent
 
 For possible configuration values of the Agent, please refer to the Agent chart [README](https://github.com/sysdiglabs/charts/tree/master/charts/agent/README.md)

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -26,6 +26,7 @@ Currently included components:
 | `global.clusterConfig.namespace` | Default namespace for all components                              | `sysdig-agent` |
 | `global.sysdig.accessKey`        | Sysdig Agent Access Key                                           | `""`           |
 | `global.sysdig.accessKeySecret`  | The name of a Kubernetes secret containing an 'access-key' entry. | `""`           |
+| `global.sysdig.region`           | The SaaS region for these agents                                  | `"us1"`        |
 | `global.image.registry`          | Container image registry                                          | `quay.io`      |
 | `agent`                          | Config specific to the [Sysdig Agent](#agent)                     | ``             |
 | `agent.enabled`                  | Enable the agent component in this chart                          | `true`         |

--- a/charts/sysdig-deploy/ci/test-values.yaml.template
+++ b/charts/sysdig-deploy/ci/test-values.yaml.template
@@ -1,0 +1,3 @@
+agent:
+  sysdig:
+    accessKey: ${SECURE_AGENT_TOKEN}

--- a/charts/sysdig-deploy/values.yaml
+++ b/charts/sysdig-deploy/values.yaml
@@ -5,6 +5,7 @@ global:
   sysdig:
     accessKey: ""
     accessKeySecret: ""
+    region: "us1"
   image:
     registry: quay.io
 

--- a/charts/sysdig-deploy/values.yaml
+++ b/charts/sysdig-deploy/values.yaml
@@ -1,7 +1,7 @@
 global:
   clusterConfig:
     name: ""  # name to identify this cluster for events and metrics
-    namespace: ""  # namespace to install all components; can be overridden by components
+    namespace: "sysdig-agent"  # namespace to install all components; can be overridden by components
   sysdig:
     accessKey: ""
     accessKeySecret: ""

--- a/charts/sysdig-deploy/values.yaml
+++ b/charts/sysdig-deploy/values.yaml
@@ -1,0 +1,12 @@
+global:
+  clusterConfig:
+    name: ""  # name to identify this cluster for events and metrics
+    namespace: ""  # namespace to install all components; can be overridden by components
+  sysdig:
+    accessKey: ""
+    accessKeySecret: ""
+  image:
+    registry: quay.io
+
+agent:
+  enabled: true


### PR DESCRIPTION
## What this PR does / why we need it:

Adds the initial stub of the sysdig-deploy umbrella chart. Currently it only has the agent chart as a dependency.

Depends on #359 first

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
