### PR TITLE
[admission-controller] Reduce default webhook timeout to 5s

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.5.19
+version: 0.5.20
 appVersion: 3.8.7
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -22,7 +22,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.5.19  \
+      --create-namespace -n sysdig-admission-controller --version=0.5.20  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
 ```
@@ -53,7 +53,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.5.19
+$ helm install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.5.20
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -110,7 +110,7 @@ The following table lists the configurable parameters of the `admission-controll
 | webhook.hostNetwork                 | Specifies if the webhook should be started in hostNetwork mode. <br/>This is required if using a custom CNI where the managed control plane nodes are unable to initiate network connections to the pods, for example using Calico CNI plugin on EKS. <br/>This is not required or recommended in most contexts.                                                                                                                                                    | <code>false</code>                                                                                                                                                                                 |
 | webhook.imagePullSecrets            | The image pull secrets for webhook                                                                                                                                                                                                                                                                                                                                                                                                                                  | <code>[]</code>                                                                                                                                                                                    |
 | webhook.resources                   | Resource request and limits for webhook                                                                                                                                                                                                                                                                                                                                                                                                                             | <code>{}</code>                                                                                                                                                                                    |
-| webhook.timeoutSeconds              | Number of seconds for the request to time out                                                                                                                                                                                                                                                                                                                                                                                                                       | <code>10</code>                                                                                                                                                                                    |
+| webhook.timeoutSeconds              | Number of seconds for the request to time out                                                                                                                                                                                                                                                                                                                                                                                                                       | <code>5</code>                                                                                                                                                                                     |
 | webhook.nodeSelector                | Configure nodeSelector for scheduling for webhook                                                                                                                                                                                                                                                                                                                                                                                                                   | <code>{}</code>                                                                                                                                                                                    |
 | webhook.tolerations                 | Tolerations for scheduling for webhook                                                                                                                                                                                                                                                                                                                                                                                                                              | <code>[]</code>                                                                                                                                                                                    |
 | webhook.affinity                    | Configure affinity rules for webhook                                                                                                                                                                                                                                                                                                                                                                                                                                | <code>{}</code>                                                                                                                                                                                    |
@@ -152,7 +152,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n admission-controller  --version=0.5.19 \
+    --create-namespace -n admission-controller  --version=0.5.20 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -161,7 +161,7 @@ installing the chart. For example:
 
 ```console
 $ helm install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.5.19 \
+    --create-namespace -n sysdig-admission-controller --version=0.5.20 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -141,7 +141,7 @@ webhook:
 #      memory: 256Mi
 
   # Number of seconds for the request to time out
-  timeoutSeconds: 10
+  timeoutSeconds: 5
 
   # Configure nodeSelector for scheduling for webhook
   nodeSelector: {}


### PR DESCRIPTION
## What this PR does / why we need it:

Reduces the default webhook timeout to 5 seconds, so we can avoid undefined behavior in GKE Preemptive nodes with workload peaks when a node is being replaced.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
