### PR TITLE
feat: support the deployment on GKE Autopilot clusters

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.12.58
+### Minor changes
+
+Add the flag `gke.autopilot` to support the deployment on GKE Autopilot clusters.
+
 ## v1.12.57
 ### Minor changes
 

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.57
+version: 1.12.58
 appVersion: 12.3.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -4,6 +4,24 @@
 security and forensics. Sysdig platform has been built on top of [Sysdig tool](https://sysdig.com/opensource/sysdig/)
 and [Sysdig Inspect](https://sysdig.com/blog/sysdig-inspect/) open-source technologies.
 
+
+## Table of Contents
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Installing the Chart](#installing-the-chart)
+- [Uninstalling the Chart](#uninstalling-the-chart)
+- [Configuration](#configuration)
+- [Resource profiles](#resource-profiles)
+- [Node Analyzer](#node-analyzer)
+- [GKE Autopilot](#gke-autopilot)
+- [On-Premise backend deployment settings](#on-premise-backend-deployment-settings)
+- [Using private Docker image registry](#using-private-docker-image-registry)
+- [Modifying Sysdig agent configuration](#modifying-sysdig-agent-configuration)
+- [Upgrading Sysdig agent configuration](#upgrading-sysdig-agent-configuration)
+- [How to upgrade to the latest version](#how-to-upgrade-to-the-last-version)
+- [Adding custom AppChecks](#adding-custom-appchecks)
+- [Support](#support)
+
 ## Introduction
 
 This chart adds the Sysdig agent for [Sysdig Monitor](https://sysdig.com/product/monitor/)
@@ -57,7 +75,7 @@ The command removes all the Kubernetes components associated with the chart and 
 The following table lists the configurable parameters of the Sysdig chart and their default values.
 
 | Parameter                                                            | Description                                                                              | Default                                                                        |
-| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+|----------------------------------------------------------------------|------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
 | `image.registry`                                                     | Sysdig Agent image registry                                                              | `quay.io`                                                                      |
 | `image.repository`                                                   | The image repository to pull from                                                        | `sysdig/agent`                                                                 |
 | `image.tag`                                                          | The image tag to pull                                                                    | `12.3.1`                                                                       |
@@ -69,6 +87,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `resources.requests.memory`                                          | Memory requested for being run in a node                                                 | ` `                                                                            |
 | `resources.limits.cpu`                                               | CPU limit                                                                                | ` `                                                                            |
 | `resources.limits.memory`                                            | Memory limit                                                                             | ` `                                                                            |
+| `gke.autopilot`                                                      | If true, overrides the agent configuration to run on GKE Autopilot clusters              | `false`                                                                        |
 | `rbac.create`                                                        | If true, create & use RBAC resources                                                     | `true`                                                                         |
 | `scc.create`                                                         | Create OpenShift's Security Context Constraint                                           | `true`                                                                         |
 | `psp.create`                                                         | Create Pod Security Policy to allow the agent running in clusters with PSP enabled       | `true`                                                                         |
@@ -144,24 +163,24 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `nodeAnalyzer.hostAnalyzer.resources.limits.cpu`                     | Host Analyzer CPU limit per node                                                         | `500m`                                                                         |
 | `nodeAnalyzer.hostAnalyzer.resources.limits.memory`                  | Host Analyzer Memory limit per node                                                      | `1536Mi`                                                                       |
 | `nodeAnalyzer.benchmarkRunner.image.repository`                      | The image repository to pull the Benchmark Runner from                                   | `sysdig/compliance-benchmark-runner`                                           |
-| `nodeAnalyzer.benchmarkRunner.image.tag`                             | The image tag to pull the Benchmark Runner                                               | `1.0.17.0`                                                                      |
+| `nodeAnalyzer.benchmarkRunner.image.tag`                             | The image tag to pull the Benchmark Runner                                               | `1.0.17.0`                                                                     |
 | `nodeAnalyzer.benchmarkRunner.image.digest`                          | The image digest to pull                                                                 | ` `                                                                            |
 | `nodeAnalyzer.benchmarkRunner.image.pullPolicy`                      | The Image pull policy for the Benchmark Runner                                           | `IfNotPresent`                                                                 |
-| `nodeAnalyzer.benchmarkRunner.includeSensitivePermissions`           | Grant the service account elevated permissions to run CIS Benchmark for OS4              | `false`                                                                 |
+| `nodeAnalyzer.benchmarkRunner.includeSensitivePermissions`           | Grant the service account elevated permissions to run CIS Benchmark for OS4              | `false`                                                                        |
 | `nodeAnalyzer.benchmarkRunner.resources.requests.cpu`                | Benchmark Runner CPU requests per node                                                   | `150m`                                                                         |
 | `nodeAnalyzer.benchmarkRunner.resources.requests.memory`             | Benchmark Runner Memory requests per node                                                | `128Mi`                                                                        |
 | `nodeAnalyzer.benchmarkRunner.resources.limits.cpu`                  | Benchmark Runner CPU limit per node                                                      | `500m`                                                                         |
 | `nodeAnalyzer.benchmarkRunner.resources.limits.memory`               | Benchmark Runner Memory limit per node                                                   | `256Mi`                                                                        |
-| `nodeAnalyzer.runtimeScanner.deploy`                                 | Deploy the Runtime Scanner                                                               | `false`                                                         |
+| `nodeAnalyzer.runtimeScanner.deploy`                                 | Deploy the Runtime Scanner                                                               | `false`                                                                        |
 | `nodeAnalyzer.runtimeScanner.image.repository`                       | The image repository to pull the Runtime Scanner from                                    | `sysdig/eveclient-api`                                                         |
 | `nodeAnalyzer.runtimeScanner.image.tag`                              | The image tag to pull the Runtime Scanner                                                | `0.1.0`                                                                        |
 | `nodeAnalyzer.runtimeScanner.image.digest`                           | The image digest to pull                                                                 | ` `                                                                            |
 | `nodeAnalyzer.runtimeScanner.image.pullPolicy`                       | The image pull policy for the Runtime Scanner                                            | `IfNotPresent`                                                                 |
 | `nodeAnalyzer.runtimeScanner.resources.requests.cpu`                 | Runtime Scanner CPU requests per node                                                    | `250m`                                                                         |
-| `nodeAnalyzer.runtimeScanner.resources.requests.memory`              | Runtime Scanner Memory requests per node                                                 | `512Mi`                                                                  |
+| `nodeAnalyzer.runtimeScanner.resources.requests.memory`              | Runtime Scanner Memory requests per node                                                 | `512Mi`                                                                        |
 | `nodeAnalyzer.runtimeScanner.resources.requests.ephemeral-storage`   | Runtime Scanner Storage requests per node                                                | `2Gi`                                                                          |
 | `nodeAnalyzer.runtimeScanner.resources.limits.cpu`                   | Runtime Scanner CPU limit per node                                                       | `500m`                                                                         |
-| `nodeAnalyzer.runtimeScanner.resources.limits.memory`                | Runtime Scanner Memory limit per node                                                    | `1536Mi`                                                                 |
+| `nodeAnalyzer.runtimeScanner.resources.limits.memory`                | Runtime Scanner Memory limit per node                                                    | `1536Mi`                                                                       |
 | `nodeAnalyzer.runtimeScanner.resources.limits.ephemeral-storage`     | Runtime Scanner Storage limit per node                                                   | `4Gi`                                                                          |
 | `nodeAnalyzer.runtimeScanner.settings.eveEnabled`                    | Enables Sysdig Eve                                                                       | `false`                                                                        |
 | `nodeAnalyzer.runtimeScanner.eveConnector.deploy`                    | Enables Sysdig Eve Connector for third-party integrations                                | `false`                                                                        |
@@ -216,7 +235,7 @@ example,
 $ helm install --namespace sysdig-agent sysdig-agent -f values.yaml sysdig/sysdig
 ```
 
-> **Tip**: You can use the default [values.yaml](values.yaml)
+> **Tip**: You can use the default [values.yaml](../../../../Desktop/sysdig/values.yaml)
 
 ## Resource profiles
 
@@ -313,6 +332,30 @@ Benchmark Runner provides the capability to run CIS inspired benchmarks against 
 configured in the UI, and the runner automatically runs these benchmarks on the configured scope and schedule.
 Note: if `nodeAnalyzer.benchmarkRunner.includeSensitivePermissions` is set to `false`, the service account will not have
 the full set of permissions needed to execute `oc` commands, which most checks in `CIS Benchmark for OS4` require.
+
+## GKE Autopilot
+Autopilot is an operation mode for creating and managing clusters in GKE. 
+With Autopilot, Google configures and manages the underlying node infrastructure for you.
+
+To deploy the Sysdig agent in GKE clusters running in Autopilot mode, run:
+
+```bash
+$ helm install --namespace sysdig-agent sysdig-agent --set sysdig.accessKey=YOUR-KEY-HERE --set sysdig.settings.collector=COLLECTOR_URL sysdig/sysdig --set gke.autopilot=true
+```
+
+When the flag `gke.autopilot=true` gets `true`, the chart configuration is overridden as follows: 
+ - `nodeAnalyzer.deploy=false`
+ - `ebpf.enabled=true`
+ - `ebpf.settings.mountEtcVolume=false`
+ - `daemonset.annotations='autopilot\.gke\.io/no-connect="true"'`
+ - `daemonset.affinity=null'`
+
+So, on GKE Autopilot clusters:
+ - The NodeAnalyzed is not deployed,
+ - The ebpf is enabled and the etcVolume is not mounted,
+ - The daemonset affinity is set to `null`,
+ - The daemonset annotation is set to enable the Agent to run on autopilot (required from GKE).
+
 
 ## On-Premise backend deployment settings
 

--- a/charts/sysdig/templates/configmap-benchmark-runner.yaml
+++ b/charts/sysdig/templates/configmap-benchmark-runner.yaml
@@ -1,4 +1,5 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy}}
+{{- if not .Values.gke.autopilot }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,3 +22,4 @@ data:
   no_proxy: {{ .Values.nodeAnalyzer.noProxy }}
   {{- end -}}
   {{- end }}
+{{- end }}

--- a/charts/sysdig/templates/configmap-host-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-host-analyzer.yaml
@@ -1,5 +1,6 @@
+{{- if not .Values.gke.autopilot }}
 {{ if not .Values.secure.vulnerabilityManagement.newEngineOnly }}
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy}}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -36,5 +37,6 @@ data:
   {{- if .Values.nodeAnalyzer.noProxy }}
   no_proxy: {{ .Values.nodeAnalyzer.noProxy }}
   {{- end -}}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sysdig/templates/configmap-image-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-image-analyzer.yaml
@@ -45,7 +45,8 @@ data:
   no_proxy: {{ .Values.nodeImageAnalyzer.settings.noProxy }}
   {{- end -}}
 {{- end }}
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy}}
+{{- if not .Values.gke.autopilot }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -89,4 +90,5 @@ data:
   no_proxy: {{ .Values.nodeAnalyzer.noProxy }}
   {{- end -}}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.gke.autopilot }}
 {{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy }}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -471,4 +472,5 @@ spec:
       {{- with .Values.nodeAnalyzer.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -19,9 +19,14 @@ spec:
         app.kubernetes.io/name: {{ include "sysdig.name" . }}
 {{ include "sysdig.labels" . | indent 8 }}
 {{ include "daemonset.labels" . | indent 8 }}
+      {{- if .Values.gke.autopilot }}
+      annotations:
+        autopilot.gke.io/no-connect: "true"
+      {{- else }}
       {{- if .Values.daemonset.annotations }}
       annotations:
 {{ toYaml .Values.daemonset.annotations | indent 8 }}
+      {{- end }}
       {{- end }}
     spec:
       serviceAccountName: {{ template "sysdig.serviceAccountName" .}}
@@ -38,6 +43,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.daemonset.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.gke.autopilot }}
+      affinity: null
+      {{- else }}
       affinity:
       {{- if .Values.daemonset.affinity }}
 {{ toYaml .Values.daemonset.affinity | indent 8 }}
@@ -59,6 +67,7 @@ spec:
               - key: beta.kubernetes.io/os
                 operator: In
                 values: {{- toYaml .Values.daemonset.os | nindent 18 }}
+      {{- end }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -85,7 +94,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          {{- if .Values.ebpf.enabled }}
+          {{- if or .Values.ebpf.enabled .Values.gke.autopilot }}
             - name: SYSDIG_BPF_PROBE
               value:
           {{- end }}
@@ -102,7 +111,7 @@ spec:
             - mountPath: /host/usr
               name: usr-vol
               readOnly: true
-            {{- if .Values.ebpf.enabled }}
+            {{- if or .Values.ebpf.enabled .Values.gke.autopilot }}
             - mountPath: /root/.sysdig
               name: bpf-probes
             - mountPath: /sys/kernel/debug
@@ -129,7 +138,7 @@ spec:
             readOnlyRootFilesystem: false
             allowPrivilegeEscalation: true
           env:
-            {{- if .Values.ebpf.enabled }}
+            {{- if or .Values.ebpf.enabled .Values.gke.autopilot }}
             - name: SYSDIG_BPF_PROBE
               value:
             {{- end }}
@@ -190,12 +199,12 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
-            {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.mountEtcVolume) }}
+            {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
             - mountPath: /host/etc
               name: etc-fs
               readOnly: true
             {{- end }}
-            {{- if (and .Values.ebpf.enabled .Values.slim.enabled) }}
+            {{- if (and (or .Values.ebpf.enabled .Values.gke.autopilot) .Values.slim.enabled) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
             - mountPath: /sys/kernel/debug
@@ -246,12 +255,12 @@ spec:
         - name: varrun-vol
           hostPath:
             path: /var/run
-        {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.mountEtcVolume) }}
+        {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
         - name: etc-fs
           hostPath:
             path: /etc
         {{- end }}
-        {{- if (and .Values.ebpf.enabled .Values.slim.enabled) }}
+        {{- if (and (or .Values.ebpf.enabled .Values.gke.autopilot) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}
         - name: sys-tracing

--- a/charts/sysdig/templates/runtimeScanner/eveconnector-api-configmap.yaml
+++ b/charts/sysdig/templates/runtimeScanner/eveconnector-api-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/eveconnector-api-deployment.yaml
+++ b/charts/sysdig/templates/runtimeScanner/eveconnector-api-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/sysdig/templates/runtimeScanner/eveconnector-api-service.yaml
+++ b/charts/sysdig/templates/runtimeScanner/eveconnector-api-service.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
+++ b/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy .Values.nodeAnalyzer.runtimeScanner.deploy) .Values.secure.vulnerabilityManagement.newEngineOnly }}
+{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy) .Values.secure.vulnerabilityManagement.newEngineOnly }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/sysdig-eve-secret.yaml
+++ b/charts/sysdig/templates/runtimeScanner/sysdig-eve-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy (not .Values.gke.autopilot) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -65,6 +65,9 @@ resourceProfile: small
 #     cpu: <cpu limits>m
 #     memory: <memory limits>Mi
 
+gke:
+  # true here enables the deployment on gke autopilot clusters
+  autopilot: false
 
 rbac:
   # true here enables creation of rbac resources


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds the flag `gke.autopilot` to support the deployment of the Sysdig Chart on GKE Autopilot clusters.

To deploy the Sysdig Chart on GKE Autopilot clusters, the customer will run the following command:

```bash
$ helm install sysdig-agent --namespace sysdig-agent \
    --set sysdig.accessKey=YOUR-KEY-HERE \
    --set sysdig.settings.collector=COLLECTOR_URL \ 
    --set gke.autopilot=true \
    sysdig/sysdig 
 ```

The new flag `gke.autopilot` defaults to `false`. In this case, nothing changes.
When the flag gets `true`, the configuration of the chart is overridden to let the agent deploys on GKE Autopilot clusters.

In particular, when the flag is gets `true`, the following configuration is applied:
 - `nodeAnalyzer.deploy=false` (does not run on GKE Autopilot)
 - `ebpf.enabled=true`
 - `ebpf.settings.mountEtcVolume=false`
 - `daemonset.affinity=null'`
 - `daemonset.annotations='autopilot\.gke\.io/no-connect="true"'` (required by GKE)


## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
