### PR TITLE
[sysdig-agent] Include the configmap for new runtime scanner

### DIFF
--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -54,7 +54,11 @@ spec:
           configMap:
             name: {{ template "sysdig.fullname" . }}-image-analyzer
             optional: true
-        # Needed to run Benchmarks. This mount is read-only.
+        - name: sysdig-agent-runtime-scanner
+          configMap:
+            name: {{ template "sysdig.fullname" . }}-runtime-scanner
+            optional: true
+         # Needed to run Benchmarks. This mount is read-only.
         # Benchmarks include numerous checks that run tests against config files in the host filesystem. There are also
         # checks that test various host configurations such as loaded modules and enabled security features.
         - name: root-vol


### PR DESCRIPTION
The configmap for the new runtime scanner needs to be mounted in the daemonset for it to function.

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ x] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ x] PR only contains changes for one chart
