### PR TITLE
[runtime-scanner]: Release version 0.2.3 with CRIO support

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
-## v1.12.62
+## v1.12.63
 ### Minor changes
 
 * Added CRI-O support for runtime-scanner

--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.12.62
+### Minor changes
+
+* Added CRI-O support for runtime-scanner
+* Improved runtime-scanner memory usage
+* Updated runtime-scanner to the latest version
+
 ## v1.12.61
 ### Minor changes
 

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.62
+version: 1.12.63
 appVersion: 12.3.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/clusterrole-node-analyzer.yaml
+++ b/charts/sysdig/templates/clusterrole-node-analyzer.yaml
@@ -20,6 +20,7 @@ rules:
     - "pods"
     - "cronjobs"
     - "jobs"
+    - "nodes"
   verbs:
     - get
     - list

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -462,6 +462,11 @@ spec:
         volumeMounts:
           - mountPath: /var/run
             name: varrun-vol
+          - mountPath: /etc/containers/storage.conf
+            name: etc-containers-storage-vol
+            readOnly: true
+          - mountPath: /var/lib/containers
+            name: var-lib-containers-vol
           - mountPath: /tmp
             name: tmp-vol
 # Runtime Scanner #

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -467,7 +467,7 @@ nodeAnalyzer:
     deploy: false
     image:
       repository: sysdig/vuln-runtime-scanner
-      tag: 0.2.1
+      tag: 0.2.3
       digest:
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What this PR does / why we need it:
Mount volumes for containers-storage data to allow the `runtimescanner` to load image data from the cri-o clusters.
## Checklist
- [X] PR only contains changes for one chart
