### PR TITLE
[agent] Fix/labels

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.12.56
-version: 1.0.0
+version: 1.0.1
 
 appVersion: "12.3.1"
 

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -3,7 +3,6 @@ kind: DaemonSet
 metadata:
   name: {{ template "agent.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "agent.name" . }}
 {{ include "agent.labels" . | indent 4 }}
 {{ include "daemonset.labels" . | indent 4 }}
 spec:
@@ -15,7 +14,6 @@ spec:
     metadata:
       name: {{ template "agent.fullname" .}}
       labels:
-        app.kubernetes.io/name: {{ include "agent.name" . }}
 {{ include "agent.labels" . | indent 8 }}
 {{ include "daemonset.labels" . | indent 8 }}
       {{- if .Values.daemonset.annotations }}


### PR DESCRIPTION
## What this PR does / why we need it:

fixed error caused by duplicated labels
https://github.com/sysdiglabs/charts/blob/master/charts/agent/templates/_helpers.tpl#L110-L121
yaml: unmarshal errors:\n  line 9: mapping key \"app.kubernetes.io/name\" already defined at line 7\n  line 26: mapping key \"app.kubernetes.io/name\" already defined at line 24"

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
