### PR TITLE
[nodeanalyzer] Creation of standalone node analyzer chart

### DIFF
--- a/charts/node-analyzer/CHANGELOG.md
+++ b/charts/node-analyzer/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Chart: Node Analyzer
+
+## Change Log
+
+This file documents all notable changes to Sysdig Node Analyzer Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+## v1.0.0
+
+### Major Changes
+
+* Deploy only the Sysdig Node Analyzer and associated resources

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: node-analyzer
+description: Sysdig Node Analyzer
+
+# currently matching Sysdig's appVersion 1.12.59
+version: 1.0.0
+appVersion: 12.3.1
+keywords:
+  - monitoring
+  - security
+  - alerting
+  - metric
+  - troubleshooting
+  - run-time
+home: https://www.sysdig.com/
+icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+sources:
+  - https://app.sysdigcloud.com/#/settings/user
+  - https://github.com/draios/sysdig
+maintainers:
+  - name: lachie83
+    email: lachlan@deis.com
+  - name: bencer
+    email: jorge.salamero@sysdig.com
+  - name: nestorsalceda
+    email: nestor.salceda@sysdig.com
+  - name: airadier
+    email: alvaro.iradier@sysdig.com
+  - name: carillan81
+    email: carlos.arilla@sysdig.com
+  - name: yashgiri
+    email: yashgiri.goswami@sysdig.com
+dependencies: []

--- a/charts/node-analyzer/README.md
+++ b/charts/node-analyzer/README.md
@@ -1,0 +1,220 @@
+# Chart: Node Analyzer
+
+The Node Analyzer (NA) provides a method for deploying the components for three different Sysdig Secure features:
+
+The Node Analyzer is deployed by default unless you set the value `nodeAnalyzer.deploy` to `false`.
+
+The Node Analyzer daemonset contains three containers, each providing a specific functionality. This daemonset replaces
+the (deprecated) Node Image Analyzer daemonset.
+
+## Table of Contents
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Installing the Chart](#installing-the-chart)
+- [Uninstalling the Chart](#uninstalling-the-chart)
+- [Configuration](#configuration)
+- [Support](#support)
+
+## Introduction
+
+This chart adds the Sysdig Node Analyzer to all nodes in your cluster via a DaemonSet.
+
+## Prerequisites
+
+- Kubernetes 1.9+ with Beta APIs enabled
+
+## Installing the Chart
+
+First of all you need to add the Sysdig Helm Charts repository:
+
+```bash
+$ helm repo add sysdig https://charts.sysdig.com/
+```
+
+To install the chart with the release name `node-analyzer`, run:
+
+```bash
+$ helm install --namespace nodeanalyzer node-analyzer --set sysdig.accessKey=YOUR-KEY-HERE --set sysdig.settings.collector=COLLECTOR_URL sysdig/node-analyzer --set nodeAnalyzer.apiEndpoint=API_ENDPOINT
+```
+
+To find the values:
+
+- YOUR-KEY-HERE: This is the sysdig access key.
+- COLLECTOR_URL: This value is region-dependent in SaaS and is auto-completed on the Get Started page in the UI. (It is
+  a custom value in on-prem installations.)
+- API_ENDPOINT: This is the base URL (region-dependent) for Sysdig Secure and is auto-completed on the Get Started page.
+  E.g. secure.sysdig.com, us2.app.sysdig.com, eu1.app.sysdig.com.
+
+After a few seconds, you should see hosts and containers appearing in Sysdig Monitor and Sysdig Secure.
+
+> **Tip**: List all releases using `helm list`
+
+See
+the [Node Analyzer installation documentation](https://docs.sysdig.com/en/node-analyzer--multi-feature-installation.html)
+for details about installation, and
+[Running Node Analyzer Behind a Proxy](https://docs.sysdig.com/en/node-analyzer--multi-feature-installation.html#UUID-35c14c46-b327-c2a8-ed9c-82a2af995218_section-idm51621039128136)
+for proxy settings.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `sysdig-agent` deployment:
+
+```bash
+$ helm delete --namespace nodeanalyzer node-analyzer
+```
+
+> **Tip**: Use `helm delete --namespace nodeanalyzer --purge node-analyzer` to completely remove the release from Helm internal storage
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Sysdig Node Analyzer chart and their default values.
+
+| Parameter                                                            | Description                                                                              | Default                                                                        |
+|----------------------------------------------------------------------|------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| `image.registry`                                                     | Sysdig Agent image registry                                                              | `quay.io`                                                                      |
+| `image.repository`                                                   | The image repository to pull from                                                        | `sysdig/agent`                                                                 |
+| `image.pullPolicy`                                                   | The Image pull policy                                                                    | `IfNotPresent`                                                                 |
+| `image.pullSecrets`                                                  | Image pull secrets                                                                       | `nil`                                                                          |
+| `gke.autopilot`                                                      | If true, overrides the agent configuration to run on GKE Autopilot clusters              | `false`                                                                        |
+| `rbac.create`                                                        | If true, create & use RBAC resources                                                     | `true`                                                                         |
+| `scc.create`                                                         | Create OpenShift's Security Context Constraint                                           | `true`                                                                         |
+| `psp.create`                                                         | Create Pod Security Policy to allow the agent running in clusters with PSP enabled       | `true`                                                                         |
+| `clusterName`                                                        | Set a cluster name to identify events using *kubernetes.cluster.name* tag                | ` `                                                                            |
+| `sysdig.accessKey`                                                   | Your Sysdig Agent Access Key                                                             | ` ` Either accessKey or existingAccessKeySecret is required                    |
+| `sysdig.existingAccessKeySecret`                                     | Alternatively, specify the name of a Kubernetes secret containing an 'access-key' entry  | ` ` Either accessKey or existingAccessKeySecret is required                    |
+| `secure.enabled`                                                     | Enable Sysdig Secure                                                                     | `true`                                                                         |
+| `nodeAnalyzer.deploy`                                                | Deploy the Node Analyzer                                                                 | `true`                                                                         |
+| `nodeAnalyzer.apiEndpoint`                                           | Sysdig secure API endpoint, without protocol (i.e. `secure.sysdig.com`)                  | ` `                                                                            |
+| `nodeAnalyzer.sslVerifyCertificate`                                  | Can be set to false to allow insecure connections to the Sysdig backend, such as On-Prem |                                                                                |
+| `nodeAnalyzer.debug`                                                 | Can be set to true to show debug logging, useful for troubleshooting                     |                                                                                |
+| `nodeAnalyzer.labels`                                                | NodeAnalyzer specific labels (as a multi-line templated string map or as YAML)           |                                                                                |
+| `nodeAnalyzer.priorityClassName`                                     | Priority class name variable                                                             |                                                                                |
+| `nodeAnalyzer.httpProxy`                                             | Proxy configuration variables                                                            |                                                                                |
+| `nodeAnalyzer.httpsProxy`                                            | Proxy configuration variables                                                            |                                                                                |
+| `nodeAnalyzer.noProxy`                                               | Proxy configuration variables                                                            |                                                                                |
+| `nodeAnalyzer.pullSecrets`                                           | Image pull secrets for the Node Analyzer containers                                      | `nil`                                                                          |
+| `nodeAnalyzer.imageAnalyzer.image.repository`                        | The image repository to pull the Node Image Analyzer from                                | `sysdig/node-image-analyzer`                                                   |
+| `nodeAnalyzer.imageAnalyzer.image.tag`                               | The image tag to pull the Node Image Analyzer                                            | `0.1.16`                                                                       |
+| `nodeAnalyzer.imageAnalyzer.image.digest`                            | The image digest to pull                                                                 | ` `                                                                            |
+| `nodeAnalyzer.imageAnalyzer.image.pullPolicy`                        | The Image pull policy for the Node Image Analyzer                                        | `IfNotPresent`                                                                 |
+| `nodeAnalyzer.imageAnalyzer.dockerSocketPath`                        | The Docker socket path                                                                   |                                                                                |
+| `nodeAnalyzer.imageAnalyzer.criSocketPath`                           | The socket path to a CRI compatible runtime, such as CRI-O                               |                                                                                |
+| `nodeAnalyzer.imageAnalyzer.containerdSocketPath`                    | The socket path to a CRI-Containerd daemon                                               |                                                                                |
+| `nodeAnalyzer.imageAnalyzer.extraVolumes.volumes`                    | Additional volumes to mount in the Node Image Analyzer (i.e. for docker socket)          | `[]`                                                                           |
+| `nodeAnalyzer.imageAnalyzer.extraVolumes.mounts`                     | Mount points for additional volumes                                                      | `[]`                                                                           |
+| `nodeAnalyzer.imageAnalyzer.resources.requests.cpu`                  | Node Image Analyzer CPU requests per node                                                | `150m`                                                                         |
+| `nodeAnalyzer.imageAnalyzer.resources.requests.memory`               | Node Image Analyzer Memory requests per node                                             | `512Mi`                                                                        |
+| `nodeAnalyzer.imageAnalyzer.resources.limits.cpu`                    | Node Image Analyzer CPU limit per node                                                   | `500m`                                                                         |
+| `nodeAnalyzer.imageAnalyzer.resources.limits.memory`                 | Node Image Analyzer Memory limit per node                                                | `1536Mi`                                                                       |
+| `nodeAnalyzer.hostAnalyzer.image.repository`                         | The image repository to pull the Host Analyzer from                                      | `sysdig/host-analyzer`                                                         |
+| `nodeAnalyzer.hostAnalyzer.image.tag`                                | The image tag to pull the Host Analyzer                                                  | `0.1.6`                                                                        |
+| `nodeAnalyzer.hostAnalyzer.image.digest`                             | The image digest to pull                                                                 | ` `                                                                            |
+| `nodeAnalyzer.hostAnalyzer.image.pullPolicy`                         | The Image pull policy for the Host Analyzer                                              | `IfNotPresent`                                                                 |
+| `nodeAnalyzer.hostAnalyzer.schedule`                                 | The scanning schedule specification for the host analyzer expressed as a crontab         | `@dailydefault`                                                                |
+| `nodeAnalyzer.hostAnalyzer.dirsToScan`                               | The list of directories to inspect during the scan                                       | `/etc,/var/lib/dpkg,/usr/local,/usr/lib/sysimage/rpm,/var/lib/rpm,/lib/apk/db` |
+| `nodeAnalyzer.hostAnalyzer.maxSendAttempts`                          | The number of times the analysis collector is allowed to retry sending results           | `3`                                                                            |
+| `nodeAnalyzer.hostAnalyzer.resources.requests.cpu`                   | Host Analyzer CPU requests per node                                                      | `150m`                                                                         |
+| `nodeAnalyzer.hostAnalyzer.resources.requests.memory`                | Host Analyzer Memory requests per node                                                   | `512Mi`                                                                        |
+| `nodeAnalyzer.hostAnalyzer.resources.limits.cpu`                     | Host Analyzer CPU limit per node                                                         | `500m`                                                                         |
+| `nodeAnalyzer.hostAnalyzer.resources.limits.memory`                  | Host Analyzer Memory limit per node                                                      | `1536Mi`                                                                       |
+| `nodeAnalyzer.benchmarkRunner.image.repository`                      | The image repository to pull the Benchmark Runner from                                   | `sysdig/compliance-benchmark-runner`                                           |
+| `nodeAnalyzer.benchmarkRunner.image.tag`                             | The image tag to pull the Benchmark Runner                                               | `1.0.17.0`                                                                     |
+| `nodeAnalyzer.benchmarkRunner.image.digest`                          | The image digest to pull                                                                 | ` `                                                                            |
+| `nodeAnalyzer.benchmarkRunner.image.pullPolicy`                      | The Image pull policy for the Benchmark Runner                                           | `IfNotPresent`                                                                 |
+| `nodeAnalyzer.benchmarkRunner.includeSensitivePermissions`           | Grant the service account elevated permissions to run CIS Benchmark for OS4              | `false`                                                                        |
+| `nodeAnalyzer.benchmarkRunner.resources.requests.cpu`                | Benchmark Runner CPU requests per node                                                   | `150m`                                                                         |
+| `nodeAnalyzer.benchmarkRunner.resources.requests.memory`             | Benchmark Runner Memory requests per node                                                | `128Mi`                                                                        |
+| `nodeAnalyzer.benchmarkRunner.resources.limits.cpu`                  | Benchmark Runner CPU limit per node                                                      | `500m`                                                                         |
+| `nodeAnalyzer.benchmarkRunner.resources.limits.memory`               | Benchmark Runner Memory limit per node                                                   | `256Mi`                                                                        |
+| `nodeAnalyzer.runtimeScanner.deploy`                                 | Deploy the Runtime Scanner                                                               | `false`                                                                        |
+| `nodeAnalyzer.runtimeScanner.image.repository`                       | The image repository to pull the Runtime Scanner from                                    | `sysdig/eveclient-api`                                                         |
+| `nodeAnalyzer.runtimeScanner.image.tag`                              | The image tag to pull the Runtime Scanner                                                | `0.1.0`                                                                        |
+| `nodeAnalyzer.runtimeScanner.image.digest`                           | The image digest to pull                                                                 | ` `                                                                            |
+| `nodeAnalyzer.runtimeScanner.image.pullPolicy`                       | The image pull policy for the Runtime Scanner                                            | `IfNotPresent`                                                                 |
+| `nodeAnalyzer.runtimeScanner.resources.requests.cpu`                 | Runtime Scanner CPU requests per node                                                    | `250m`                                                                         |
+| `nodeAnalyzer.runtimeScanner.resources.requests.memory`              | Runtime Scanner Memory requests per node                                                 | `512Mi`                                                                        |
+| `nodeAnalyzer.runtimeScanner.resources.requests.ephemeral-storage`   | Runtime Scanner Storage requests per node                                                | `2Gi`                                                                          |
+| `nodeAnalyzer.runtimeScanner.resources.limits.cpu`                   | Runtime Scanner CPU limit per node                                                       | `500m`                                                                         |
+| `nodeAnalyzer.runtimeScanner.resources.limits.memory`                | Runtime Scanner Memory limit per node                                                    | `1536Mi`                                                                       |
+| `nodeAnalyzer.runtimeScanner.resources.limits.ephemeral-storage`     | Runtime Scanner Storage limit per node                                                   | `4Gi`                                                                          |
+| `nodeAnalyzer.runtimeScanner.settings.eveEnabled`                    | Enables Sysdig Eve                                                                       | `false`                                                                        |
+| `nodeAnalyzer.runtimeScanner.eveConnector.deploy`                    | Enables Sysdig Eve Connector for third-party integrations                                | `false`                                                                        |
+| `nodeAnalyzer.runtimeScanner.eveConnector.resources.requests.cpu`    | Eve Connector CPU requests per node                                                      | `100m`                                                                         |
+| `nodeAnalyzer.runtimeScanner.eveConnector.resources.requests.memory` | Eve Connector Memory requests per node                                                   | `128Mi`                                                                        |
+| `nodeAnalyzer.runtimeScanner.eveConnector.resources.limits.cpu`      | Eve Connector CPU limits per node                                                        | `1000m`                                                                        |
+| `nodeAnalyzer.runtimeScanner.eveConnector.resources.limits.memory`   | Eve Connector Memory limits per node                                                     | `512Mi`                                                                        |
+| `nodeAnalyzer.runtimeScanner.eveConnector.settings.replicas`         | Eve Connector deployment replicas                                                        | `1`                                                                            |
+| `nodeAnalyzer.nodeSelector`                                          | Node Selector                                                                            | `{}`                                                                           |
+| `nodeAnalyzer.affinity`                                              | Node affinities                                                                          | `schedule on amd64 and linux`                                                  |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --namespace nodeanalyzer node-analyzer \
+    --set sysdig.accessKey=YOUR-KEY-HERE, \
+    sysdig/node-analyzer
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For
+example,
+
+```bash
+$ helm install --namespace nodeanalyzer node-analyzer -f values.yaml sysdig/node-analyzer
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+## Chart Components
+
+### Node Image Analyzer
+
+See
+the [Image Analyzer Configmap Options](https://docs.sysdig.com/en/node-analyzer--multi-feature-installation.html#UUID-35c14c46-b327-c2a8-ed9c-82a2af995218_section-idm514589352153208)
+for details about the available options, and
+the [Node Image Analyzer documentation](https://docs.sysdig.com/en/scan-running-images.html) for details about the Node
+Image Analyzer feature.
+
+The node image analyzer (NIA) provides the capability to scan images as soon as they start running on hosts where the
+analyzer is installed. It is typically installed alongside the Sysdig agent container.
+
+On container start-up, the analyzer scans all pre-existing running images present in the node. Additionally, it will
+scan any new image that enters a running state in the node. It will scan each image once, then forward the results to
+the Sysdig Secure scanning backend. Image metadata and the full scan report is then available in the Sysdig Secure UI.
+
+### Host Analyzer
+
+See
+the [Host Scanning Configuration Options](https://docs.sysdig.com/en/node-analyzer--multi-feature-installation.html#UUID-35c14c46-b327-c2a8-ed9c-82a2af995218_UUID-6666385b-c550-0660-f563-956f3a4fe093)
+for details about installation options, and
+the [Host Scanning documentation](https://docs.sysdig.com/en/host-scanning.html) for details about the Host Scanning
+feature.
+
+The host analyzer provides the capability to scan packages installed on the host operating system to identify potential
+vulnerabilities. It is typically installed as part of the Node Analyzer which in turn is installed alongside the Sysdig
+Agent.
+
+The host analyzer works by inspecting the files on the host root filesystem looking for installed packages and sending
+them to the Sysdig backend. It performs this operation by default once a day and its schedule can be configured as
+described below. Likewise, the list of directories to be examined during each scan can be configured.
+
+### Benchmark Runner
+
+See the [Benchmarks documentation](https://docs.sysdig.com/en/benchmarks.html) for details on the Benchmark feature. The
+Benchmark Runner provides the capability to run CIS inspired benchmarks against your infrastructure. Benchmark tasks are
+configured in the UI, and the runner automatically runs these benchmarks on the configured scope and schedule.
+Note: if `nodeAnalyzer.benchmarkRunner.includeSensitivePermissions` is set to `false`, the service account will not have
+the full set of permissions needed to execute `oc` commands, which most checks in `CIS Benchmark for OS4` require.
+
+## Support
+
+For getting support from the Sysdig team, you should refer to the official
+[Sysdig Support page](https://sysdig.com/support).
+
+In addition to this, you can browse the documentation for the different components of the Sysdig Platform:
+
+* [Sysdig Monitor](https://app.sysdigcloud.com)
+* [Sysdig Secure](https://secure.sysdig.com)
+* [Platform Documentation](https://docs.sysdig.com/en/sysdig-platform.html)
+* [Monitor Documentation](https://docs.sysdig.com/en/sysdig-monitor.html)
+* [Secure Documentation](https://docs.sysdig.com/en/sysdig-secure.html)

--- a/charts/node-analyzer/ci/test-values.yaml.template
+++ b/charts/node-analyzer/ci/test-values.yaml.template
@@ -1,0 +1,4 @@
+sysdig:
+  accessKey: ${SECURE_AGENT_TOKEN}
+nodeAnalyzer:
+  apiEndpoint: secure.sysdig.com

--- a/charts/node-analyzer/templates/NOTES.txt
+++ b/charts/node-analyzer/templates/NOTES.txt
@@ -1,0 +1,22 @@
+The node analyzer for Sysdig Secure DevOps Platform is spinning up on each node in your
+cluster.
+
+Each node analyzer pod consists of image analyzer, benchmark runner and host analyzer.
+
+After successful installation you can access the Node analyzer features as follows:
+
+Log in to Sysdig Secure and check that the features are working as expected.
+
+Confirm Image analyzer
+  1. Select Scanning > Image Results.
+  2. Check for scanned container image results that originate with the Sysdig Node Image Analyzer.
+
+Use Host Scanning
+  Check vulnerabilities in hosts or nodes, both for operation system packages (e.g. rpm, dpkg) and non-operating system packages (e.g. Java packages, Ruby gems).
+    1. Select Scanning > Hosts.
+    2. Review the Host vulnerabilities listed.
+  Your active team scope is applied when loading host scanning results. Log in with the broadest team and user credentials to see the full report.
+
+  Use Benchmarks (Legacy Feature)
+    3. Select Benchmarks, Tasks.
+    4. Either configure a new task or review your upgraded tasks. Click a line item to see the associated benchmark report.

--- a/charts/node-analyzer/templates/_helpers.tpl
+++ b/charts/node-analyzer/templates/_helpers.tpl
@@ -1,0 +1,160 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nodeAnalyzer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nodeAnalyzer.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nodeAnalyzer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the node analyzer specific service account to use
+*/}}
+{{- define "nodeAnalyzer.serviceAccountName" -}}
+{{- if .Values.nodeAnalyzer.serviceAccount.create -}}
+    {{ default (include "nodeAnalyzer.fullname" .) .Values.nodeAnalyzer.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.nodeAnalyzer.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define the proper imageRegistry to use for agent and kmodule image
+*/}}
+{{- define "nodeAnalyzer.imageRegistry" -}}
+{{- if and .Values.global (hasKey (default .Values.global dict) "imageRegistry") -}}
+    {{- .Values.global.imageRegistry -}}
+{{- else -}}
+    {{- .Values.image.registry -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Sysdig Agent image name
+*/}}
+{{- define "nodeAnalyzer.repositoryName" -}}
+{{- if .Values.slim.enabled -}}
+    {{- .Values.slim.image.repository -}}
+{{- else -}}
+    {{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper nodeAnalyzer Agent image name for the Runtime Scanner
+*/}}
+{{- define "nodeAnalyzer.image.runtimeScanner" -}}
+    {{- include "nodeAnalyzer.imageRegistry" . -}} / {{- .Values.nodeAnalyzer.runtimeScanner.image.repository -}} {{- if .Values.nodeAnalyzer.runtimeScanner.image.digest -}} @ {{- .Values.nodeAnalyzer.runtimeScanner.image.digest -}} {{- else -}} : {{- .Values.nodeAnalyzer.runtimeScanner.image.tag -}} {{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Sysdig nodeAnalyzer image name for the Eve Connector
+*/}}
+{{- define "nodeAnalyzer.image.eveConnector" -}}
+    {{- include "nodeAnalyzer.imageRegistry" . -}} / {{- .Values.nodeAnalyzer.runtimeScanner.eveConnector.image.repository -}} {{- if .Values.nodeAnalyzer.runtimeScanner.eveConnector.image.digest -}} @ {{- .Values.nodeAnalyzer.runtimeScanner.eveConnector.image.digest -}} {{- else -}} : {{- .Values.nodeAnalyzer.runtimeScanner.eveConnector.image.tag -}} {{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper image name for the Image Analyzer
+*/}}
+{{- define "nodeAnalyzer.image.imageAnalyzer" -}}
+    {{- include "nodeAnalyzer.imageRegistry" . -}} / {{- .Values.nodeAnalyzer.imageAnalyzer.image.repository -}} {{- if .Values.nodeAnalyzer.imageAnalyzer.image.digest -}} @ {{- .Values.nodeAnalyzer.imageAnalyzer.image.digest -}} {{- else -}} : {{- .Values.nodeAnalyzer.imageAnalyzer.image.tag -}} {{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper image name for the Host Analyzer
+*/}}
+{{- define "nodeAnalyzer.image.hostAnalyzer" -}}
+    {{- include "nodeAnalyzer.imageRegistry" . -}} / {{- .Values.nodeAnalyzer.hostAnalyzer.image.repository -}} {{- if .Values.nodeAnalyzer.hostAnalyzer.image.digest -}} @ {{- .Values.nodeAnalyzer.hostAnalyzer.image.digest -}} {{- else -}} : {{- .Values.nodeAnalyzer.hostAnalyzer.image.tag -}} {{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper image name for the Benchmark Runner
+*/}}
+{{- define "nodeAnalyzer.image.benchmarkRunner" -}}
+    {{- include "nodeAnalyzer.imageRegistry" . -}} / {{- .Values.nodeAnalyzer.benchmarkRunner.image.repository -}} {{- if .Values.nodeAnalyzer.benchmarkRunner.image.digest -}} @ {{- .Values.nodeAnalyzer.benchmarkRunner.image.digest -}} {{- else -}} : {{- .Values.nodeAnalyzer.benchmarkRunner.image.tag -}} {{- end -}}
+{{- end -}}
+
+{{/*
+Node Analyzer labels
+*/}}
+{{- define "nodeAnalyzer.labels" -}}
+helm.sh/chart: {{ include "nodeAnalyzer.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.nodeAnalyzer.labels }}
+    {{- $tp := typeOf .Values.nodeAnalyzer.labels }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.nodeAnalyzer.labels . }}
+    {{- else }}
+      {{- toYaml .Values.nodeAnalyzer.labels }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sysdig Eve Connector service URL
+*/}}
+{{- define "eveconnector.host" -}}
+{{ include "nodeAnalyzer.fullname" .}}-eveconnector.{{ .Release.Namespace }}
+{{- end -}}
+
+{{/*
+Sysdig Eve Connector Secret generation (if not exists)
+*/}}
+{{- define "eveconnector.token" -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace "sysdig-eve-secret" -}}
+{{- if $secret -}}
+{{ $secret.data.token }}
+{{- else -}}
+{{ randAlphaNum 32 | b64enc | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The following helper functions are all designed to use global values where
+possible, but accept overrides from the chart values.
+*/}}
+{{- define "nodeAnalyzer.accessKey" -}}
+    {{- required "A valid accessKey is required" (.Values.sysdig.accessKey | default .Values.global.sysdig.accessKey) -}}
+{{- end -}}
+
+{{- define "nodeAnalyzer.accessKeySecret" -}}
+    {{/*
+    Note: the last default function call is to avoid some weirdness when either
+    argument is nil. If .Values.global.sysdig.accessKeySecret was undefined, the
+    returned empty string does not evaluate to empty on Helm Version:"v3.8.0"
+    */}}
+    {{- .Values.sysdig.existingAccessKeySecret | default .Values.global.sysdig.accessKeySecret | default "" -}}
+{{- end -}}
+
+{{- define "nodeAnalyzer.clusterName" -}}
+    {{- .Values.clusterName | default .Values.global.clusterConfig.name | default "" -}}
+{{- end -}}

--- a/charts/node-analyzer/templates/clusterrole-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/clusterrole-node-analyzer.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nodeAnalyzer.fullname" .}}-node-analyzer
+  labels:
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+rules:
+- apiGroups:
+    - ""
+    - apps
+    - batch
+    - extensions
+  resources:
+    - "namespaces"
+    - "deployments"
+    - "replicasets"
+    - "daemonsets"
+    - "statefulsets"
+    - "pods"
+    - "cronjobs"
+    - "jobs"
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+    - endpoints
+    - nodes
+    - pods/log
+    - secrets
+    - serviceaccounts
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterrolebindings
+    - rolebindings
+    - roles
+  verbs:
+    - list
+- apiGroups:
+    - machineconfiguration.openshift.io
+  resources:
+    - machineconfigpools
+    - machineconfigs
+  verbs:
+    - get
+    - list
+- apiGroups:
+    - operator.openshift.io
+  resources:
+    - kubeapiservers
+    - openshiftapiservers
+  verbs:
+    - get
+    - list
+- apiGroups:
+    - config.openshift.io
+  resources:
+    - clusteroperators
+  verbs:
+    - get
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+  verbs:
+    - get
+    - list
+{{- if .Values.nodeAnalyzer.benchmarkRunner.includeSensitivePermissions  }}
+- apiGroups:
+    - ""
+  resources:
+    - pods/exec
+  verbs:
+    - create
+- apiGroups:
+    - ""
+  resources:
+    - pods
+  verbs:
+    - create
+    - delete
+{{- end }}
+{{- if .Values.psp.create  }}
+- apiGroups:
+    - "policy"
+  resources:
+    - "podsecuritypolicies"
+  resourceNames:
+    - "{{ template "nodeAnalyzer.fullname" . }}-node-analyzer"
+  verbs:
+    - "use"
+{{- end }}
+{{- end }}

--- a/charts/node-analyzer/templates/clusterrolebinding-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/clusterrolebinding-node-analyzer.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nodeAnalyzer.fullname" .}}-node-analyzer
+  labels:
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "nodeAnalyzer.serviceAccountName" .}}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "nodeAnalyzer.fullname" .}}-node-analyzer
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/node-analyzer/templates/configmap-benchmark-runner.yaml
+++ b/charts/node-analyzer/templates/configmap-benchmark-runner.yaml
@@ -1,0 +1,25 @@
+{{- if not .Values.gke.autopilot }}
+{{- if .Values.nodeAnalyzer.deploy }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nodeAnalyzer.fullname" . }}-benchmark-runner
+  labels:
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+data:
+  collector_endpoint: https://{{ .Values.nodeAnalyzer.apiEndpoint | default .Values.nodeAnalyzer.collectorEndpoint }}
+  {{- if hasKey .Values.nodeAnalyzer "sslVerifyCertificate" }}
+  ssl_verify_certificate: "{{ .Values.nodeAnalyzer.sslVerifyCertificate }}"
+  {{- end }}
+  debug: "{{ .Values.nodeAnalyzer.debug | default false }}"
+  {{- if .Values.nodeAnalyzer.httpProxy }}
+  http_proxy: {{ .Values.nodeAnalyzer.httpProxy }}
+  {{- end -}}
+  {{- if .Values.nodeAnalyzer.httpsProxy }}
+  https_proxy: {{ .Values.nodeAnalyzer.httpsProxy }}
+  {{- end -}}
+  {{- if .Values.nodeAnalyzer.noProxy }}
+  no_proxy: {{ .Values.nodeAnalyzer.noProxy }}
+  {{- end -}}
+  {{- end }}
+{{- end }}

--- a/charts/node-analyzer/templates/configmap-host-analyzer.yaml
+++ b/charts/node-analyzer/templates/configmap-host-analyzer.yaml
@@ -1,0 +1,42 @@
+{{- if not .Values.gke.autopilot }}
+{{ if not .Values.secure.vulnerabilityManagement.newEngineOnly }}
+{{- if .Values.nodeAnalyzer.deploy }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nodeAnalyzer.fullname" . }}-host-analyzer
+  labels:
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+data:
+  collector_endpoint: "https://{{ .Values.nodeAnalyzer.apiEndpoint | default .Values.nodeAnalyzer.collectorEndpoint }}/internal/scanning/scanning-analysis-collector"
+  {{- if .Values.nodeAnalyzer.collectorTimeout }}
+  collector_timeout: {{ .Values.nodeAnalyzer.collectorTimeout }}
+  {{- end }}
+  {{- if hasKey .Values.nodeAnalyzer "sslVerifyCertificate" }}
+  ssl_verify_certificate: "{{ .Values.nodeAnalyzer.sslVerifyCertificate }}"
+  {{- end }}
+  debug: "{{ .Values.nodeAnalyzer.debug | default false }}"
+  {{- if .Values.nodeAnalyzer.hostAnalyzer.schedule }}
+  schedule: {{ .Values.nodeAnalyzer.hostAnalyzer.schedule | quote }}
+  {{- end }}
+  {{- if .Values.nodeAnalyzer.hostAnalyzer.analyzeAtStartup }}
+  analyze_at_startup: {{ .Values.nodeAnalyzer.hostAnalyzer.analyzeAtStartup }}
+  {{- end }}
+  {{- if .Values.nodeAnalyzer.hostAnalyzer.dirsToScan }}
+  dirs_to_scan: {{ .Values.nodeAnalyzer.hostAnalyzer.dirsToScan }}
+  {{- end }}
+  {{- if .Values.nodeAnalyzer.hostAnalyzer.maxSendAttempts }}
+  max_send_attempts: {{ .Values.nodeAnalyzer.hostAnalyzer.maxSendAttempts }}
+  {{- end }}
+  {{- if .Values.nodeAnalyzer.httpProxy }}
+  http_proxy: {{ .Values.nodeAnalyzer.httpProxy }}
+  {{- end -}}
+  {{- if .Values.nodeAnalyzer.httpsProxy }}
+  https_proxy: {{ .Values.nodeAnalyzer.httpsProxy }}
+  {{- end -}}
+  {{- if .Values.nodeAnalyzer.noProxy }}
+  no_proxy: {{ .Values.nodeAnalyzer.noProxy }}
+  {{- end -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/node-analyzer/templates/configmap-image-analyzer.yaml
+++ b/charts/node-analyzer/templates/configmap-image-analyzer.yaml
@@ -1,0 +1,46 @@
+{{- if not .Values.gke.autopilot }}
+{{- if .Values.nodeAnalyzer.deploy }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+  labels:
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+data:
+  collector_endpoint: "https://{{ required "A valid .Values.nodeAnalyzer.apiEndpoint is required" (.Values.nodeAnalyzer.apiEndpoint | default .Values.nodeAnalyzer.collectorEndpoint) }}/internal/scanning/scanning-analysis-collector"
+  {{- if hasKey .Values.nodeAnalyzer "sslVerifyCertificate" }}
+  ssl_verify_certificate: "{{ .Values.nodeAnalyzer.sslVerifyCertificate }}"
+  {{- end }}
+  debug: "{{ .Values.nodeAnalyzer.debug | default false }}"
+  {{- if .Values.nodeAnalyzer.imageAnalyzer.dockerSocketPath }}
+  docker_socket_path: {{ .Values.nodeAnalyzer.imageAnalyzer.dockerSocketPath }}
+  {{- end }}
+  {{- if .Values.nodeAnalyzer.imageAnalyzer.criSocketPath }}
+  cri_socket_path: {{ .Values.nodeAnalyzer.imageAnalyzer.criSocketPath }}
+  {{- end }}
+  {{- if .Values.nodeAnalyzer.imageAnalyzer.containerdSocketPath }}
+  containerd_socket_path: {{ .Values.nodeAnalyzer.imageAnalyzer.containerdSocketPath }}
+  {{- end }}
+  {{- if .Values.nodeAnalyzer.imageAnalyzer.imagePeriod }}
+  image_period: {{ .Values.nodeAnalyzer.imageAnalyzer.imagePeriod }}
+  {{- end }}
+  {{- if .Values.nodeAnalyzer.imageAnalyzer.imageCacheTTL }}
+  image_cache_ttl: {{ .Values.nodeAnalyzer.imageAnalyzer.imageCacheTTL }}
+  {{- end }}
+  {{- if .Values.nodeAnalyzer.imageAnalyzer.reportPeriod }}
+  report_period: {{ .Values.nodeAnalyzer.imageAnalyzer.reportPeriod }}
+  {{- end }}
+  {{- if .Values.nodeAnalyzer.imageAnalyzer.collectorTimeout }}
+  collector_timeout: {{ .Values.nodeAnalyzer.imageAnalyzer.collectorTimeout }}
+  {{- end }}
+  {{- if .Values.nodeAnalyzer.httpProxy }}
+  http_proxy: {{ .Values.nodeAnalyzer.httpProxy }}
+  {{- end -}}
+  {{- if .Values.nodeAnalyzer.httpsProxy }}
+  https_proxy: {{ .Values.nodeAnalyzer.httpsProxy }}
+  {{- end -}}
+  {{- if .Values.nodeAnalyzer.noProxy }}
+  no_proxy: {{ .Values.nodeAnalyzer.noProxy }}
+  {{- end -}}
+{{- end }}
+{{- end }}

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -1,0 +1,474 @@
+{{- if not .Values.gke.autopilot }}
+{{- if .Values.nodeAnalyzer.deploy }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "nodeAnalyzer.name" . }}-node-analyzer
+  labels:
+    app.kubernetes.io/name: {{ include "nodeAnalyzer.name" . }}-node-analyzer
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nodeAnalyzer.name" . }}-node-analyzer
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: {{ template "nodeAnalyzer.name" . }}-node-analyzer
+      labels:
+        app.kubernetes.io/name: {{ include "nodeAnalyzer.name" . }}-node-analyzer
+{{ include "nodeAnalyzer.labels" . | indent 8 }}
+    spec:
+      volumes:
+        - name: sysdig-agent-config
+          configMap:
+            name: {{ template "nodeAnalyzer.fullname" . }}
+            optional: true
+        # Needed for cri-o image inspection.
+        # cri-o and especially OCP 4.x by default use containers/storage to handle images, and this makes sure that the
+        # analyzer has access to the configuration. This file is mounted read-only.
+        - name: etc-containers-storage-vol
+          hostPath:
+            path: /etc/containers/storage.conf
+        # Needed for cri-o image inspection.
+        # This is the directory where image data is stored by default when using cri-o and OCP 4.x and the analyzer
+        # uses it to get the data to scan. This directory must be mounted r/w because proper access to its files through
+        # the containers/storage library is always regulated with a lockfile.
+        - name: var-lib-containers-vol
+          hostPath:
+            path: /var/lib/containers
+        # Needed for some IBM OpenShift clusters which symlink /var/run/containers/storage to contents of /var/data by default
+        - name: vardata-vol
+          hostPath:
+            path: /var/data
+        # Needed for socket access
+        - name: varrun-vol
+          hostPath:
+            path: /var/run
+        # Add custom volume here
+        - name: sysdig-image-analyzer-config
+          configMap:
+            name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+            optional: true
+        # Needed to run Benchmarks. This mount is read-only.
+        # Benchmarks include numerous checks that run tests against config files in the host filesystem. There are also
+        # checks that test various host configurations such as loaded modules and enabled security features.
+        - name: root-vol
+          hostPath:
+            path: /
+        - name: tmp-vol
+          emptyDir: {}
+        {{- with .Values.nodeAnalyzer.imageAnalyzer.extraVolumes.volumes }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+      {{- if .Values.nodeAnalyzer.priorityClassName }}
+      priorityClassName: "{{ .Values.nodeAnalyzer.priorityClassName }}"
+      {{- end }}
+      tolerations:
+{{ toYaml .Values.nodeAnalyzer.tolerations | indent 8 }}
+      # The following line is necessary for RBAC
+      serviceAccountName: {{ template "nodeAnalyzer.serviceAccountName" .}}
+      {{- if .Values.nodeAnalyzer.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.nodeAnalyzer.pullSecrets | indent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 5
+      # Use the Host Network Namespace.
+      # This is required by the Benchmark container to determine the hostname and host mac address
+      hostNetwork: true
+      # Use the Host PID namespace.
+      # This is required for Kubernetes benchmarks, as they contain tests that check Kubernetes processes running on
+      # the host
+      hostPID: true
+      containers:
+{{ if not .Values.secure.vulnerabilityManagement.newEngineOnly }}
+      - name: sysdig-image-analyzer
+        image: {{ template "nodeAnalyzer.image.imageAnalyzer" . }}
+        securityContext:
+          # The privileged flag is necessary for OCP 4.x and other Kubernetes setups that deny host filesystem access to
+          # running containers by default regardless of volume mounts. In those cases, access to the CRI socket would fail.
+          privileged: true
+        imagePullPolicy: {{ .Values.nodeAnalyzer.imageAnalyzer.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.nodeAnalyzer.imageAnalyzer.resources | indent 10 }}
+        volumeMounts:
+          - mountPath: /var/run
+            name: varrun-vol
+          - mountPath: /etc/containers/storage.conf
+            name: etc-containers-storage-vol
+            readOnly: true
+          - mountPath: /var/lib/containers
+            name: var-lib-containers-vol
+          # Custom volume mount here
+          {{- if .Values.nodeAnalyzer.imageAnalyzer.extraVolumes.mounts }}
+{{ toYaml .Values.nodeAnalyzer.imageAnalyzer.extraVolumes.mounts | indent 10 }}
+          {{- end }}
+        env:
+        - name: ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              {{- if not ( include "nodeAnalyzer.accessKeySecret" .) }}
+              name: {{ template "nodeAnalyzer.fullname" . }}
+              {{- else }}
+              name: {{ ( include "nodeAnalyzer.accessKeySecret" .) }}
+              {{- end }}
+              key: access-key
+        - name: IMAGE_PERIOD
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: image_period
+              optional: true
+        - name: IMAGE_CACHE_TTL
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: image_cache_ttl
+              optional: true
+        - name: REPORT_PERIOD
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: report_period
+              optional: true
+        - name: DOCKER_SOCKET_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: docker_socket_path
+              optional: true
+        - name: CRI_SOCKET_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: cri_socket_path
+              optional: true
+        - name: CONTAINERD_SOCKET_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: containerd_socket_path
+              optional: true
+        - name: AM_COLLECTOR_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: collector_endpoint
+              optional: true
+        - name: AM_COLLECTOR_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: collector_timeout
+              optional: true
+        - name: VERIFY_CERTIFICATE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: ssl_verify_certificate
+              optional: true
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: DEBUG
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: debug
+              optional: true
+        - name: HTTP_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: http_proxy
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: https_proxy
+              optional: true
+        - name: NO_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-image-analyzer
+              key: no_proxy
+              optional: true
+      - name: sysdig-host-analyzer
+        image: {{ template "nodeAnalyzer.image.hostAnalyzer" . }}
+        securityContext:
+          # The privileged flag is necessary for OCP 4.x and other Kubernetes setups that deny host filesystem access to
+          # running containers by default regardless of volume mounts. In those cases, access to any host related components
+          # would fail
+          privileged: true
+        imagePullPolicy: {{ .Values.nodeAnalyzer.hostAnalyzer.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.nodeAnalyzer.hostAnalyzer.resources | indent 10 }}
+        volumeMounts:
+          - mountPath: /host
+            name: root-vol
+            readOnly: true
+        env:
+        - name: ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              {{- if not ( include "nodeAnalyzer.accessKeySecret" .) }}
+              name: {{ template "nodeAnalyzer.fullname" . }}
+              {{- else }}
+              name: {{ ( include "nodeAnalyzer.accessKeySecret" .) }}
+              {{- end }}
+              key: access-key
+        - name: AM_COLLECTOR_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-host-analyzer
+              key: collector_endpoint
+        - name: AM_COLLECTOR_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-host-analyzer
+              key: collector_timeout
+              optional: true
+        - name: SCHEDULE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-host-analyzer
+              key: schedule
+              optional: true
+        - name: ANALYZE_AT_STARTUP
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-host-analyzer
+              key: analyze_at_startup
+              optional: true
+        - name: HOST_BASE
+          value: /host
+        - name: DIRS_TO_SCAN
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-host-analyzer
+              key: dirs_to_scan
+              optional: true
+        - name: MAX_SEND_ATTEMPTS
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-host-analyzer
+              key: max_send_attempts
+              optional: true
+        - name: VERIFY_CERTIFICATE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-host-analyzer
+              key: ssl_verify_certificate
+              optional: true
+        - name: DEBUG
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-host-analyzer
+              key: debug
+              optional: true
+        - name: HTTP_PROXY
+          valueFrom:
+            configMapKeyRef:
+              key: http_proxy
+              name: {{ template "nodeAnalyzer.fullname" . }}-host-analyzer
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            configMapKeyRef:
+              key: https_proxy
+              name: {{ template "nodeAnalyzer.fullname" . }}-host-analyzer
+              optional: true
+        - name: NO_PROXY
+          valueFrom:
+            configMapKeyRef:
+              key: no_proxy
+              name: {{ template "nodeAnalyzer.fullname" . }}-host-analyzer
+              optional: true
+{{- end }}
+      - name: sysdig-benchmark-runner
+        image: {{ template "nodeAnalyzer.image.benchmarkRunner" . }}
+        imagePullPolicy: {{ .Values.nodeAnalyzer.benchmarkRunner.image.pullPolicy }}
+        securityContext:
+          # The privileged flag is necessary for OCP 4.x and other Kubernetes setups that deny host filesystem access to
+          # running containers by default regardless of volume mounts. In those cases, the benchmark process would fail.
+          privileged: true
+        resources:
+{{ toYaml .Values.nodeAnalyzer.benchmarkRunner.resources | indent 10 }}
+        volumeMounts:
+          - mountPath: /opt/draios/etc/kubernetes/config
+            name: sysdig-agent-config
+          - mountPath: /host
+            name: root-vol
+            readOnly: true
+          - mountPath: /host/tmp
+            name: tmp-vol
+        env:
+        - name: ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              {{- if not ( include "nodeAnalyzer.accessKeySecret" .) }}
+              name: {{ template "nodeAnalyzer.fullname" . }}
+              {{- else }}
+              name: {{ ( include "nodeAnalyzer.accessKeySecret" .) }}
+              {{- end }}
+              key: access-key
+        - name: BACKEND_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-benchmark-runner
+              key: collector_endpoint
+        - name: BACKEND_VERIFY_TLS
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-benchmark-runner
+              key: ssl_verify_certificate
+              optional: true
+        - name: KUBERNETES_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: DEBUG
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "nodeAnalyzer.fullname" . }}-benchmark-runner
+              key: debug
+              optional: true
+        - name: HTTP_PROXY
+          valueFrom:
+            configMapKeyRef:
+              key: http_proxy
+              name: {{ template "nodeAnalyzer.fullname" . }}-benchmark-runner
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            configMapKeyRef:
+              key: https_proxy
+              name: {{ template "nodeAnalyzer.fullname" . }}-benchmark-runner
+              optional: true
+        - name: NO_PROXY
+          valueFrom:
+            configMapKeyRef:
+              key: no_proxy
+              name: {{ template "nodeAnalyzer.fullname" . }}-benchmark-runner
+              optional: true
+{{ if or  .Values.nodeAnalyzer.runtimeScanner.deploy .Values.secure.vulnerabilityManagement.newEngineOnly }}
+      # Runtime Scanner #
+      - name: sysdig-runtime-scanner
+        image: {{ template "nodeAnalyzer.image.runtimeScanner" . }}
+        imagePullPolicy: {{ .Values.nodeAnalyzer.runtimeScanner.image.pullPolicy }}
+        securityContext:
+            privileged: true
+        resources:
+{{ toYaml .Values.nodeAnalyzer.runtimeScanner.resources | indent 10 }}
+        # Custom volume mount here
+        env:
+          - name: TMPDIR
+            value: "/tmp"
+          - name: PROM_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-runtime-scanner
+                key: prom_port
+                optional: true
+          - name: MAX_FILE_SIZE_ALLOWED
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-runtime-scanner
+                key: analyzer.maxFileSizeAllowed
+                optional: true
+          - name: SYSDIG_API_URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-runtime-scanner
+                key: api_endpoint
+          - name: SYSDIG_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                {{- if not ( include "nodeAnalyzer.accessKeySecret" .) }}
+                name: {{ template "nodeAnalyzer.fullname" . }}
+                {{- else }}
+                name: {{ ( include "nodeAnalyzer.accessKeySecret" .) }}
+                {{- end }}
+                key: access-key
+          - name: SYSDIG_API_VERIFY_CERTIFICATE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-runtime-scanner
+                key: ssl_verify_certificate
+                optional: true
+          - name: CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-runtime-scanner
+                key: cluster_name
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: DEBUG
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-runtime-scanner
+                key: debug
+                optional: true
+          - name: HTTP_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-runtime-scanner
+                key: http_proxy
+                optional: true
+          - name: HTTPS_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-runtime-scanner
+                key: https_proxy
+                optional: true
+          - name: NO_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-runtime-scanner
+                key: no_proxy
+                optional: true
+{{- if .Values.nodeAnalyzer.runtimeScanner.settings.eveEnabled }}
+          - name: EVE_ENABLED
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-runtime-scanner
+                key: eve_enabled
+                optional: true
+{{- end }}
+{{- if .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+          - name: EVE_INTEGRATION_ENABLED
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-runtime-scanner
+                key: eve_integration_enabled
+                optional: true
+{{- end }}
+        volumeMounts:
+          - mountPath: /var/run
+            name: varrun-vol
+          - mountPath: /tmp
+            name: tmp-vol
+# Runtime Scanner #
+{{- end }}
+      {{- with .Values.nodeAnalyzer.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeAnalyzer.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/node-analyzer/templates/psp.yaml
+++ b/charts/node-analyzer/templates/psp.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.psp.create  }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "nodeAnalyzer.fullname" . }}
+spec:
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65536
+    min: 1
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+{{- end }}

--- a/charts/node-analyzer/templates/runtimeScanner/eveconnector-api-configmap.yaml
+++ b/charts/node-analyzer/templates/runtimeScanner/eveconnector-api-configmap.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nodeAnalyzer.fullname" . }}-eveconnector
+  labels:
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+data:
+  api_endpoint: https://{{ required "A valid .Values.nodeAnalyzer.apiEndpoint is required" .Values.nodeAnalyzer.apiEndpoint }}
+  cluster_name: {{ required "A valid .Values.clusterName is required" (include "nodeAnalyzer.clustername" . ) }}
+  {{- if hasKey .Values.nodeAnalyzer "sslVerifyCertificate" }}
+  ssl_verify_certificate: "{{ .Values.nodeAnalyzer.sslVerifyCertificate }}"
+  {{- end }}
+  {{- if hasKey .Values.nodeAnalyzer.runtimeScanner "eveConnector" }}
+  cert_dns_name: {{ include "eveconnector.host" . | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/node-analyzer/templates/runtimeScanner/eveconnector-api-deployment.yaml
+++ b/charts/node-analyzer/templates/runtimeScanner/eveconnector-api-deployment.yaml
@@ -1,0 +1,84 @@
+{{- if and .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "nodeAnalyzer.fullname" . }}-eveconnector-api
+  labels:
+    app.kubernetes.io/name: {{ include "nodeAnalyzer.name" . }}-eveconnector
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.nodeAnalyzer.runtimeScanner.eveConnector.settings.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nodeAnalyzer.name" . }}-eveconnector
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/runtimeScanner/eveconnector-api-configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/runtimeScanner/sysdig-eve-secret.yaml") . | sha256sum }}
+      labels:
+        app.kubernetes.io/name: {{ include "nodeAnalyzer.name" . }}-eveconnector
+        app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "nodeAnalyzer.labels" . | indent 8 }}
+    spec:
+      serviceAccountName: {{ template "nodeAnalyzer.serviceAccountName" .}}
+      containers:
+      - name: {{ include "nodeAnalyzer.name" . }}-eveconnector-api
+        image: {{ template "nodeAnalyzer.image.eveConnector" . }}
+        imagePullPolicy: {{ .Values.nodeAnalyzer.runtimeScanner.eveConnector.image.pullPolicy }}
+        ports:
+          - name: api
+            containerPort: 7000
+            protocol: TCP
+        resources:
+{{ toYaml .Values.nodeAnalyzer.runtimeScanner.eveConnector.resources | indent 10 }}
+        env:
+          # authentication token for Snyk to EVE client communication taken from secret
+          - name: CLIENT_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: sysdig-eve-secret
+                key: token
+          # DNS name used in self-signed certificate
+          - name: CERT_DNS_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-eveconnector
+                key: cert_dns_name
+          # kubernetes cluster name where EVE Client and Snyk are installed
+          - name: CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-eveconnector
+                key: cluster_name
+          # agent authentication token for EVE client to Sysdig BE comm.
+          - name: SYSDIG_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                {{- if not ( include "nodeAnalyzer.accessKeySecret" . ) }}
+                name: {{ template "nodeAnalyzer.fullname" . }}
+                {{- else }}
+                name: {{ ( include "nodeAnalyzer.accessKeySecret" . ) }}
+                {{- end }}
+                key: access-key
+          # base URL for Sysdig Secure
+          - name: SYSDIG_API_URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-eveconnector
+                key: api_endpoint
+          # whether to check SSL certificate of Sysdig
+          - name: SYSDIG_API_VERIFY_CERTIFICATE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "nodeAnalyzer.fullname" . }}-eveconnector
+                key: ssl_verify_certificate
+                optional: true
+{{- end }}

--- a/charts/node-analyzer/templates/runtimeScanner/eveconnector-api-service.yaml
+++ b/charts/node-analyzer/templates/runtimeScanner/eveconnector-api-service.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nodeAnalyzer.fullname" . }}-eveconnector
+  labels:
+    app.kubernetes.io/name: {{ include "nodeAnalyzer.name" . }}-eveconnector
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "nodeAnalyzer.name" . }}-eveconnector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+  - protocol: TCP
+    port: 443
+    targetPort: 7000
+{{- end }}

--- a/charts/node-analyzer/templates/runtimeScanner/runtime-scanner-configmap.yaml
+++ b/charts/node-analyzer/templates/runtimeScanner/runtime-scanner-configmap.yaml
@@ -1,0 +1,33 @@
+{{- if or (and .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy) .Values.secure.vulnerabilityManagement.newEngineOnly }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nodeAnalyzer.fullname" . }}-runtime-scanner
+  labels:
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+data:
+  api_endpoint: https://{{ required "A valid .Values.nodeAnalyzer.apiEndpoint is required" .Values.nodeAnalyzer.apiEndpoint }}
+  cluster_name: {{ required "A valid .Values.clusterName is required" (include "nodeAnalyzer.clustername" . ) }}
+  {{- if hasKey .Values.nodeAnalyzer "sslVerifyCertificate" }}
+  ssl_verify_certificate: "{{ .Values.nodeAnalyzer.sslVerifyCertificate }}"
+  {{- end }}
+  debug: "{{ .Values.nodeAnalyzer.debug | default false }}"
+  {{- if .Values.nodeAnalyzer.httpProxy }}
+  http_proxy: {{ .Values.nodeAnalyzer.httpProxy }}
+  {{- end -}}
+  {{- if .Values.nodeAnalyzer.httpsProxy }}
+  https_proxy: {{ .Values.nodeAnalyzer.httpsProxy }}
+  {{- end -}}
+  {{- if .Values.nodeAnalyzer.noProxy }}
+  no_proxy: {{ .Values.nodeAnalyzer.noProxy }}
+  {{- end -}}
+  {{- if .Values.nodeAnalyzer.eveEnabled }}
+  eve_enabled: "true"
+  {{- end -}}
+  {{- if hasKey .Values.nodeAnalyzer.runtimeScanner "eveConnector" }}
+  eve_integration_enabled: "true"
+  {{- end -}}
+  {{- if hasKey .Values.nodeAnalyzer.runtimeScanner "settings" }}
+  prom_port: {{ .Values.nodeAnalyzer.runtimeScanner.settings.prometheusPort | default 25001 | quote }}
+  {{- end -}}
+{{- end }}

--- a/charts/node-analyzer/templates/runtimeScanner/sysdig-eve-secret.yaml
+++ b/charts/node-analyzer/templates/runtimeScanner/sysdig-eve-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy (not .Values.gke.autopilot) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sysdig-eve-secret
+  labels:
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+type: Opaque
+data:
+  endpoint: {{ include "eveconnector.host" . | printf "https://%s" | b64enc | quote }}
+  token: {{ include "eveconnector.token" . }}
+{{- end }}

--- a/charts/node-analyzer/templates/secrets.yaml
+++ b/charts/node-analyzer/templates/secrets.yaml
@@ -1,0 +1,11 @@
+{{- if not ( include "nodeAnalyzer.accessKeySecret" . ) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "nodeAnalyzer.fullname" . }}
+  labels:
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+type: Opaque
+data:
+ access-key : {{ include "nodeAnalyzer.accessKey" . | b64enc | quote }}
+{{- end }}

--- a/charts/node-analyzer/templates/securitycontextconstraint.yaml
+++ b/charts/node-analyzer/templates/securitycontextconstraint.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.scc.create (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: |
+      This provides the minimum requirements to the Sysdig nodeAnalyzer to run in the Openshift.
+  name: {{ template "nodeAnalyzer.fullname" . }}
+  labels:
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: []
+allowedUnsafeSysctls: []
+defaultAddCapabilities: []
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: 0
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ template "nodeAnalyzer.serviceAccountName" .}}
+volumes:
+- hostPath
+- emptyDir
+- secret
+- configMap
+- downwardAPI
+{{- end }}

--- a/charts/node-analyzer/templates/serviceaccount-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/serviceaccount-node-analyzer.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.nodeAnalyzer.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "nodeAnalyzer.serviceAccountName" .}}
+  labels:
+{{ include "nodeAnalyzer.labels" . | indent 4 }}
+{{- end }}

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -1,0 +1,243 @@
+# Default values for Sysdig Monitor and Secure Helm package.
+global:
+  sysdig: {}
+
+# Default values for Sysdig Monitor and Secure Helm package.
+image:
+  # This is a hack to support RELATED_IMAGE_<identifier> feature in Helm based
+  # Operators
+  #
+  # As long as I don't want to people to use this, I will keep it undocumented
+  overrideValue:
+
+  registry: quay.io
+  # Specify a imagePullPolicy
+  # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  pullPolicy: IfNotPresent
+  # Optionally specify an array of imagePullSecrets.
+  # Secrets must be manually created in the namespace.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  #
+  # pullSecrets:
+  #   - name: myRegistrKeySecretName
+
+gke:
+  # true here enables the deployment on gke autopilot clusters
+  autopilot: false
+
+rbac:
+  # true here enables creation of rbac resources
+  create: true
+
+scc:
+  # true here enables creation of Security Context Constraints in Openshift
+  create: true
+
+psp:
+  # true here enables creation of Pod Security Policy to allow the agent run with the required permissions
+  create: true
+
+# Setting a cluster name allows you to filter events from this cluster using kubernetes.cluster.name
+clusterName: ""
+
+secure:
+  # true here enables Sysdig Secure: container run-time security & forensics
+  enabled: true
+  vulnerabilityManagement:
+    newEngineOnly: false
+
+sysdig:
+  # Required: You need your Sysdig access key before running agents, either specifying 'accessKey' here, or using 'existingAccessKeySecret'
+  accessKey: ""
+  # Alternatively, specify the name of a Kubernetes secret containing an 'access-key' entry
+  existingAccessKeySecret: ""
+
+nodeAnalyzer:
+  # Create node analyzer specific serviceAccount resource
+  serviceAccount:
+    create: true
+    # Use this value as nodeAnalyzerServiceAccountName
+    name: "node-analyzer"
+
+  deploy: true
+
+  # The API endpoint for Sysdig Secure, specified with no protocol:
+  # * SaaS default region (US East): secure.sysdig.com
+  # * SaaS US Web: us2.app.sysdig.com
+  # * SaaS European Union: eu1.app.sysdig.com
+  # * On-Prem: sysdig.my.company.com
+  apiEndpoint: ""
+
+  # Can be set to false to allow insecure connections to the Sysdig backend,
+  # such as for on-premise installs that use self-signed certificates.
+  # By default, certificates are always verified.
+  # sslVerifyCertificate: false
+
+  # Can be set to true to show debug logging, useful for troubleshooting.
+  debug: false
+
+  # Proxy configuration variables. See also: [Running Node Analyzer Behind a Proxy](https://docs.sysdig.com/en/node-analyzer--multi-feature-installation.html#UUID-35c14c46-b327-c2a8-ed9c-82a2af995218_section-idm51621039128136)
+  httpProxy:
+  httpsProxy:
+  noProxy:
+
+  # Allow sysdig Node Image Analyzer to run on Kubernetes 1.6 masters
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+
+  # Allow the DaemonSet to set labels
+  labels: {}
+  # Use this pullSecret to pull images from a private registry
+  # pullSecrets:
+  #   - name: myRegistryKeySecretName
+
+  nodeSelector: {}
+
+  # Allow the DaemonSet to schedule using affinity rules
+  # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+          - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+              - key: beta.kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+
+  imageAnalyzer:
+    image:
+      repository: sysdig/node-image-analyzer
+      tag: 0.1.16
+      digest:
+      pullPolicy: IfNotPresent
+
+    # The Docker socket path.
+    # If a custom path is specified, ensure it is correctly mounted from the host inside the container.
+    # dockerSocketPath: unix:///var/run/docker.sock
+
+    # The socket path to a CRI compatible runtime, such as CRI-O.
+    # If a custom path is specified, ensure it is correctly mounted from the host inside the container.
+    # criSocketPath: unix:///var/run/crio/crio.sock
+
+    # The socket path to a CRI-Containerd daemon.
+    # If a custom path is specified, ensure it is correctly mounted from the host inside the container.
+    # containerdSocketPath: unix:///var/run/containerd/containerd.sock
+
+    # Allow passing extra volumes to the Node Image Analyzer to mount docker socket, cri-o socket, etc.
+    extraVolumes:
+      volumes: []
+      mounts: []
+
+      # Example:
+
+      # volumes:
+      # - name: docker-sock
+      #   hostPath:
+      #     path: /var/run/docker.sock
+      # mounts:
+      # - mountPath: /var/run/docker.sock
+      #   name: docker-sock
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        cpu: 500m
+        memory: 1536Mi
+  hostAnalyzer:
+    image:
+      repository: sysdig/host-analyzer
+      tag: 0.1.6
+      digest:
+      pullPolicy: IfNotPresent
+
+    # The scanning schedule specification for the host analyzer expressed as a crontab string such as “5 4 * * *”.
+    # The default value of @dailydefault instructs the analyzer to automatically pick a schedule that will start
+    # shortly after it is deployed and will perform a scan every 24 hours.
+    schedule: "@dailydefault"
+
+    # The list of directories to inspect during the scan, expressed as a comma separated list.
+    # dirsToScan: "/etc,/var/lib/dpkg,/usr/local,/usr/lib/sysimage/rpm,/var/lib/rpm,/lib/apk/db"
+
+    # The number of times the analysis collector is allowed to retry sending results if backend communication fails.
+    # maxSendAttempts: 3
+
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        cpu: 500m
+        memory: 1536Mi
+  benchmarkRunner:
+    includeSensitivePermissions: false
+
+    image:
+      repository: sysdig/compliance-benchmark-runner
+      tag: 1.0.6.0
+      digest:
+      pullPolicy: IfNotPresent
+
+    resources:
+      requests:
+        cpu: 150m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+
+  runtimeScanner:
+    deploy: false
+    image:
+      repository: sysdig/vuln-runtime-scanner
+      tag: 0.2.1
+      digest:
+      pullPolicy: IfNotPresent
+
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+        ephemeral-storage: "2Gi"
+      limits:
+        cpu: 1000m
+        memory: 2Gi
+        ephemeral-storage: "4Gi"
+
+    settings:
+      eveEnabled: false
+
+    eveConnector:
+      deploy: false
+      image:
+        repository: sysdig/eveclient-api
+        tag: 1.0.0
+        digest:
+        pullPolicy: IfNotPresent
+
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 1000m
+          memory: 512Mi
+
+      settings:
+        replicas: 1


### PR DESCRIPTION
## What this PR does / why we need it:

Currently, the sysdig helm chart consists of the agent and node analyzer. These two components can be logically separated.

This PR is create a separate chart named node-analyzer. This chart will contain only the node analyzer daemonset and all of the configmaps, serviceaccounts, etc. required for it. The new chart's values.yaml file should use the same layout as the one from the sysdig chart, but with just the required values. For example, the daemonset map can be removed,  but nodeAnalyzer should be kept.

This chart was basically split off from sysdig chart 1.12.59. Follow up task is to bring this up to date with the latest changes in the sysdig chart.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
