### PR TITLE
[sysdig] creation of key secure.vulnerabilityManagement.vmEngine

### DIFF
--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.12.70
+version: 1.13.0
 appVersion: 12.4.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/_helpers.tpl
+++ b/charts/sysdig/templates/_helpers.tpl
@@ -264,3 +264,17 @@ Validate .Values.secure.vulnerabilityManagement.vmEngine and explicitly fail if 
     {{- .Values.secure.vulnerabilityManagement.vmEngine }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return true if the new vulnerability management engine must be enabled
+*/}}
+{{- define "sysdig.secure.vulnerabilityManagement.newEngineEnabled" -}}
+    {{- has (include "sysdig.secure.vulnerabilityManagement.vmEngine" .) (list "new" "both") }}
+{{- end -}}
+
+{{/*
+Return true if the old vulnerability management engine must be enabled
+*/}}
+{{- define "sysdig.secure.vulnerabilityManagement.oldEngineEnabled" -}}
+    {{- has (include "sysdig.secure.vulnerabilityManagement.vmEngine" .) (list "old" "both") }}
+{{- end -}}

--- a/charts/sysdig/templates/_helpers.tpl
+++ b/charts/sysdig/templates/_helpers.tpl
@@ -239,7 +239,7 @@ Sysdig Eve Connector Secret generation (if not exists)
 {{- end -}}
 
 {{/*
-to help the maxUnavailable and max_parallel_cold_starts pick a reasonable value depending on the cluster size
+Help the maxUnavailable and max_parallel_cold_starts pick a reasonable value depending on the cluster size
 */}}
 {{- define "sysdig.parallelStarts" -}}
 {{- if .Values.daemonset.updateStrategy.rollingUpdate.maxUnavailable -}}
@@ -250,5 +250,17 @@ to help the maxUnavailable and max_parallel_cold_starts pick a reasonable value 
     {{- 10 -}}
 {{- else -}}
     {{- 1 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate .Values.secure.vulnerabilityManagement.vmEngine and explicitly fail if does not take an expected value
+*/}}
+{{- define "sysdig.secure.vulnerabilityManagement.vmEngine" -}}
+    {{- $allowedVMEngineValues := list "new" "old" "none" "both" -}}
+{{- if not (has .Values.secure.vulnerabilityManagement.vmEngine $allowedVMEngineValues) -}}
+    {{- fail (printf "Value of vmEngine must belong to %v but it was set to %s" $allowedVMEngineValues .Values.secure.vulnerabilityManagement.vmEngine) -}}
+{{- else -}}
+    {{- .Values.secure.vulnerabilityManagement.vmEngine }}
 {{- end -}}
 {{- end -}}

--- a/charts/sysdig/templates/_helpers.tpl
+++ b/charts/sysdig/templates/_helpers.tpl
@@ -266,15 +266,15 @@ Validate .Values.secure.vulnerabilityManagement.vmEngine and explicitly fail if 
 {{- end -}}
 
 {{/*
-Return true if the new vulnerability management engine must be enabled
+Return "true" if the new vulnerability management engine must be enabled
 */}}
 {{- define "sysdig.secure.vulnerabilityManagement.newEngineEnabled" -}}
     {{- has (include "sysdig.secure.vulnerabilityManagement.vmEngine" .) (list "new" "both") }}
 {{- end -}}
 
 {{/*
-Return true if the old vulnerability management engine must be enabled
+Return "true" if the legacy vulnerability management engine must be enabled
 */}}
-{{- define "sysdig.secure.vulnerabilityManagement.oldEngineEnabled" -}}
+{{- define "sysdig.secure.vulnerabilityManagement.legacyEngineEnabled" -}}
     {{- has (include "sysdig.secure.vulnerabilityManagement.vmEngine" .) (list "old" "both") }}
 {{- end -}}

--- a/charts/sysdig/templates/configmap-host-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-host-analyzer.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.gke.autopilot }}
-{{ if not .Values.secure.vulnerabilityManagement.newEngineOnly }}
+{{- if not (eq .Values.secure.vulnerabilityManagement.wmEngine "new") }}
 {{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/sysdig/templates/configmap-host-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-host-analyzer.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.gke.autopilot }}
-{{- if (has (include "sysdig.secure.vulnerabilityManagement.vmEngine" .) (list "old" "both")) }}
+{{- if (include "sysdig.secure.vulnerabilityManagement.oldEngineEnabled" .) }}
 {{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/sysdig/templates/configmap-host-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-host-analyzer.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.gke.autopilot }}
-{{- if not (eq .Values.secure.vulnerabilityManagement.vmEngine "new") }}
+{{- if (has (include "sysdig.secure.vulnerabilityManagement.vmEngine" .) (list "old" "both")) }}
 {{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/sysdig/templates/configmap-host-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-host-analyzer.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.gke.autopilot }}
-{{- if not (eq .Values.secure.vulnerabilityManagement.wmEngine "new") }}
+{{- if not (eq .Values.secure.vulnerabilityManagement.vmEngine "new") }}
 {{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/sysdig/templates/configmap-host-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-host-analyzer.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.gke.autopilot }}
-{{- if (include "sysdig.secure.vulnerabilityManagement.oldEngineEnabled" .) }}
+{{- if (eq (include "sysdig.secure.vulnerabilityManagement.legacyEngineEnabled" .) "true") }}
 {{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/sysdig/templates/configmap-image-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-image-analyzer.yaml
@@ -1,4 +1,4 @@
-{{- if (has (include "sysdig.secure.vulnerabilityManagement.vmEngine" .) (list "old" "both")) }}
+{{- if (include "sysdig.secure.vulnerabilityManagement.oldEngineEnabled" .) }}
 {{- if include "deploy-nia" . }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/sysdig/templates/configmap-image-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-image-analyzer.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.secure.vulnerabilityManagement.newEngineOnly }}
+{{- if not (eq .Values.secure.vulnerabilityManagement.wmEngine "new") }}
 {{- if include "deploy-nia" . }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/sysdig/templates/configmap-image-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-image-analyzer.yaml
@@ -1,4 +1,4 @@
-{{- if not (eq .Values.secure.vulnerabilityManagement.wmEngine "new") }}
+{{- if not (eq .Values.secure.vulnerabilityManagement.vmEngine "new") }}
 {{- if include "deploy-nia" . }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/sysdig/templates/configmap-image-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-image-analyzer.yaml
@@ -1,4 +1,4 @@
-{{- if (include "sysdig.secure.vulnerabilityManagement.oldEngineEnabled" .) }}
+{{- if (eq (include "sysdig.secure.vulnerabilityManagement.legacyEngineEnabled" .) "true") }}
 {{- if include "deploy-nia" . }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/sysdig/templates/configmap-image-analyzer.yaml
+++ b/charts/sysdig/templates/configmap-image-analyzer.yaml
@@ -1,4 +1,4 @@
-{{- if not (eq .Values.secure.vulnerabilityManagement.vmEngine "new") }}
+{{- if (has (include "sysdig.secure.vulnerabilityManagement.vmEngine" .) (list "old" "both")) }}
 {{- if include "deploy-nia" . }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -85,7 +85,7 @@ spec:
       # the host
       hostPID: true
       containers:
-{{- if not (eq .Values.secure.vulnerabilityManagement.vmEngine "new") }}
+{{- if (has (include "sysdig.secure.vulnerabilityManagement.vmEngine" .) (list "old" "both")) }}
       - name: sysdig-image-analyzer
         image: {{ template "sysdig.image.imageAnalyzer" . }}
         securityContext:

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -85,7 +85,7 @@ spec:
       # the host
       hostPID: true
       containers:
-{{- if not (eq .Values.secure.vulnerabilityManagement.wmEngine "new") }}
+{{- if not (eq .Values.secure.vulnerabilityManagement.vmEngine "new") }}
       - name: sysdig-image-analyzer
         image: {{ template "sysdig.image.imageAnalyzer" . }}
         securityContext:

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -85,7 +85,7 @@ spec:
       # the host
       hostPID: true
       containers:
-{{- if (include "sysdig.secure.vulnerabilityManagement.oldEngineEnabled" .) }}
+{{- if (eq (include "sysdig.secure.vulnerabilityManagement.legacyEngineEnabled" .) "true") }}
       - name: sysdig-image-analyzer
         image: {{ template "sysdig.image.imageAnalyzer" . }}
         securityContext:
@@ -365,7 +365,7 @@ spec:
               key: no_proxy
               name: {{ template "sysdig.fullname" . }}-benchmark-runner
               optional: true
-{{- if or (.Values.nodeAnalyzer.runtimeScanner.deploy) (or (eq .Values.secure.vulnerabilityManagement.wmEngine "both") (eq .Values.secure.vulnerabilityManagement.wmEngine "new")) }}
+{{- if eq (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) "true" }}
       # Runtime Scanner #
       - name: sysdig-runtime-scanner
         image: {{ template "sysdig.image.runtimeScanner" . }}

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -85,7 +85,7 @@ spec:
       # the host
       hostPID: true
       containers:
-{{- if (has (include "sysdig.secure.vulnerabilityManagement.vmEngine" .) (list "old" "both")) }}
+{{- if (include "sysdig.secure.vulnerabilityManagement.oldEngineEnabled" .) }}
       - name: sysdig-image-analyzer
         image: {{ template "sysdig.image.imageAnalyzer" . }}
         securityContext:

--- a/charts/sysdig/templates/daemonset-node-analyzer.yaml
+++ b/charts/sysdig/templates/daemonset-node-analyzer.yaml
@@ -85,7 +85,7 @@ spec:
       # the host
       hostPID: true
       containers:
-{{ if not .Values.secure.vulnerabilityManagement.newEngineOnly }}
+{{- if not (eq .Values.secure.vulnerabilityManagement.wmEngine "new") }}
       - name: sysdig-image-analyzer
         image: {{ template "sysdig.image.imageAnalyzer" . }}
         securityContext:
@@ -365,7 +365,7 @@ spec:
               key: no_proxy
               name: {{ template "sysdig.fullname" . }}-benchmark-runner
               optional: true
-{{ if or  .Values.nodeAnalyzer.runtimeScanner.deploy .Values.secure.vulnerabilityManagement.newEngineOnly }}
+{{- if or (.Values.nodeAnalyzer.runtimeScanner.deploy) (or (eq .Values.secure.vulnerabilityManagement.wmEngine "both") (eq .Values.secure.vulnerabilityManagement.wmEngine "new")) }}
       # Runtime Scanner #
       - name: sysdig-runtime-scanner
         image: {{ template "sysdig.image.runtimeScanner" . }}

--- a/charts/sysdig/templates/runtimeScanner/eveconnector-api-configmap.yaml
+++ b/charts/sysdig/templates/runtimeScanner/eveconnector-api-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/eveconnector-api-configmap.yaml
+++ b/charts/sysdig/templates/runtimeScanner/eveconnector-api-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (eq (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) "true") .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/eveconnector-api-deployment.yaml
+++ b/charts/sysdig/templates/runtimeScanner/eveconnector-api-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/sysdig/templates/runtimeScanner/eveconnector-api-deployment.yaml
+++ b/charts/sysdig/templates/runtimeScanner/eveconnector-api-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (eq (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) "true") .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/sysdig/templates/runtimeScanner/eveconnector-api-service.yaml
+++ b/charts/sysdig/templates/runtimeScanner/eveconnector-api-service.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (eq (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) "true") .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/eveconnector-api-service.yaml
+++ b/charts/sysdig/templates/runtimeScanner/eveconnector-api-service.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
+++ b/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy) .Values.secure.vulnerabilityManagement.newEngineOnly }}
+{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy) (or (eq .Values.secure.vulnerabilityManagement.wmEngine "both") (eq .Values.secure.vulnerabilityManagement.wmEngine "new")) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
+++ b/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy) (or (eq .Values.secure.vulnerabilityManagement.wmEngine "both") (eq .Values.secure.vulnerabilityManagement.wmEngine "new")) }}
+{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy) (or (eq .Values.secure.vulnerabilityManagement.vmEngine "both") (eq .Values.secure.vulnerabilityManagement.vmEngine "new")) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
+++ b/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot)) (eq (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) "true") }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (eq (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) "true") .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
+++ b/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy) (or (eq .Values.secure.vulnerabilityManagement.vmEngine "both") (eq .Values.secure.vulnerabilityManagement.vmEngine "new")) }}
+{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy) (has (include "sysdig.secure.vulnerabilityManagement.vmEngine" .) (list "new" "both")) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
+++ b/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .)) }}
+{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot)) (eq (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) "true") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
+++ b/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy) (has (include "sysdig.secure.vulnerabilityManagement.vmEngine" .) (list "new" "both")) }}
+{{- if or (and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
+++ b/charts/sysdig/templates/runtimeScanner/runtime-scanner-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (eq (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) "true") .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (eq (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) "true") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sysdig/templates/runtimeScanner/sysdig-eve-secret.yaml
+++ b/charts/sysdig/templates/runtimeScanner/sysdig-eve-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy (not .Values.gke.autopilot) }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (eq (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) "true") .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy (not .Values.gke.autopilot) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/sysdig/templates/runtimeScanner/sysdig-eve-secret.yaml
+++ b/charts/sysdig/templates/runtimeScanner/sysdig-eve-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) .Values.nodeAnalyzer.runtimeScanner.deploy .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy (not .Values.gke.autopilot) }}
+{{- if and (not (include "deploy-nia" .)) .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (include "sysdig.secure.vulnerabilityManagement.newEngineEnabled" .) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy (not .Values.gke.autopilot) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -203,7 +203,7 @@ secure:
   enabled: true
   vulnerabilityManagement:
     # it must take a value in list "new" "old" "none" "both"
-    vmEngine: "both"
+    vmEngine: "old"
 
 auditLog:
   # true here activates the K8s Audit Log feature for Sysdig Secure

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -468,7 +468,6 @@ nodeAnalyzer:
         memory: 256Mi
 
   runtimeScanner:
-    deploy: false
     image:
       repository: sysdig/vuln-runtime-scanner
       tag: 0.2.5

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -176,7 +176,7 @@ collectorSettings:
   sslVerifyCertificate:
 
 # Setting a cluster name allows you to filter events from this cluster using kubernetes.cluster.name
-clusterName: "myClusterName"
+clusterName: ""
 
 sysdig:
   # Required: You need your Sysdig Agent access key before running agents, either specifying 'accessKey' here, or using 'existingAccessKeySecret'

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -176,7 +176,7 @@ collectorSettings:
   sslVerifyCertificate:
 
 # Setting a cluster name allows you to filter events from this cluster using kubernetes.cluster.name
-clusterName: ""
+clusterName: "myClusterName"
 
 sysdig:
   # Required: You need your Sysdig Agent access key before running agents, either specifying 'accessKey' here, or using 'existingAccessKeySecret'
@@ -202,7 +202,7 @@ secure:
   # true here enables Sysdig Secure: container run-time security & forensics
   enabled: true
   vulnerabilityManagement:
-    newEngineOnly: false
+    wmEngine: "both" # it can take value "new", "both" or whatever else value
 
 auditLog:
   # true here activates the K8s Audit Log feature for Sysdig Secure

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -202,7 +202,7 @@ secure:
   # true here enables Sysdig Secure: container run-time security & forensics
   enabled: true
   vulnerabilityManagement:
-    wmEngine: "both" # it can take value "new", "both" or whatever else value
+    vmEngine: "both" # it can take value "new", "both" or whatever else value
 
 auditLog:
   # true here activates the K8s Audit Log feature for Sysdig Secure

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -202,7 +202,8 @@ secure:
   # true here enables Sysdig Secure: container run-time security & forensics
   enabled: true
   vulnerabilityManagement:
-    vmEngine: "both" # it can take value "new", "both" or whatever else value
+    # it must take a value in list "new" "old" "none" "both"
+    vmEngine: "both"
 
 auditLog:
   # true here activates the K8s Audit Log feature for Sysdig Secure


### PR DESCRIPTION
## What this PR does / why we need it:
Introduce key `secure.vulnerabilityManagement.vmEngine` in sysdig chart values file and delete redudant `nodeAnalyzer.runtimeScanner.deploy` and `secure.vulnerabilityManagement.newEngineOnly` keys.
The new variable is need to better manage all the following deployment scenarios:

-  both legacy and new engine at the same time
-  neither the legacy or the new engine
-  only the new engine
-  only the legacy engine


## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
