### PR TITLE
[agent] use global namespace value if provided

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.12.70
-version: 1.2.0
+version: 1.3.0
 
 appVersion: "12.4.0"
 

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -68,6 +68,8 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `global.proxy.httpProxy`                       | Sets `http_proxy` on the Agent container                                                   | `""`                                                        |
 | `global.proxy.httpsProxy`                      | Sets `https_proxy` on the Agent container                                                  | `""`                                                        |
 | `global.proxy.noProxy`                         | Sets `no_proxy` on the Agent container                                                     | `""`                                                        |
+| `global.clusterConfig.namespace`               | Overrides the release namespace                                                            | `""`                                                        |
+| `namespace`                                    | Overrides the global namespace setting and release namespace for components.               | `""`                                                        |
 | `image.registry`                               | Sysdig Agent image registry                                                                | `quay.io`                                                   |
 | `image.repository`                             | The image repository to pull from                                                          | `sysdig/agent`                                              |
 | `image.tag`                                    | The image tag to pull                                                                      | `12.4.0`                                                    |

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -207,3 +207,10 @@ to help the maxUnavailable and max_parallel_cold_starts pick a reasonable value 
     {{- 1 -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Returns the namespace for installing components
+*/}}
+{{- define "agent.namespace" -}}
+    {{- coalesce .Values.namespace .Values.global.clusterConfig.namespace .Release.Namespace -}}
+{{- end -}}

--- a/charts/agent/templates/auditsink.yaml
+++ b/charts/agent/templates/auditsink.yaml
@@ -3,6 +3,7 @@ apiVersion: auditregistration.k8s.io/v1alpha1
 kind: AuditSink
 metadata:
   name: {{ template "agent.fullname" . }}
+  namespace: {{ include "agent.namespace" . }}
   labels:
 {{ include "agent.labels" . | indent 4 }}
 spec:
@@ -17,7 +18,7 @@ spec:
       burst: 15
     clientConfig:
       service:
-        namespace: {{ .Release.Namespace }}
+        namespace: {{ include "agent.namespace" . }}
         name: {{ template "agent.fullname" . }}
         port: {{ .Values.auditLog.auditServerPort }}
         path: /k8s_audit

--- a/charts/agent/templates/clusterrolebinding.yaml
+++ b/charts/agent/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "agent.serviceAccountName" .}}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "agent.namespace" . }}
 roleRef:
   kind: ClusterRole
   name: {{ template "agent.fullname" .}}

--- a/charts/agent/templates/configmap-custom-app-checks.yaml
+++ b/charts/agent/templates/configmap-custom-app-checks.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "agent.fullname" . }}-custom-app-checks
+  namespace: {{ include "agent.namespace" . }}
   labels:
 {{ include "agent.labels" . | indent 4 }}
 data:

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "agent.fullname" . }}
+  namespace: {{ include "agent.namespace" . }}
   labels:
 {{ include "agent.labels" . | indent 4 }}
 data:
@@ -57,7 +58,7 @@ data:
     k8s_coldstart:
       enabled: true
       enforce_leader_election: true
-      namespace: {{ .Release.Namespace}}
+      namespace: {{ include "agent.namespace" . }}
 {{- end }}
 {{- if .Values.prometheus.file }}
   prometheus.yaml: |

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "agent.fullname" . }}
+  namespace: {{ include "agent.namespace" . }}
   labels:
 {{ include "agent.labels" . | indent 4 }}
 {{ include "daemonset.labels" . | indent 4 }}

--- a/charts/agent/templates/psp.yaml
+++ b/charts/agent/templates/psp.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "agent.fullname" . }}
+  namespace: {{ include "agent.namespace" . }}
 spec:
   allowedCapabilities:
   - '*'

--- a/charts/agent/templates/secrets.yaml
+++ b/charts/agent/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "agent.fullname" . }}
+  namespace: {{ include "agent.namespace" . }} 
   labels:
 {{ include "agent.labels" . | indent 4 }}
 type: Opaque

--- a/charts/agent/templates/securitycontextconstraint.yaml
+++ b/charts/agent/templates/securitycontextconstraint.yaml
@@ -33,7 +33,7 @@ seccompProfiles:
 supplementalGroups:
   type: RunAsAny
 users:
-- system:serviceaccount:{{ .Release.Namespace }}:{{ template "agent.serviceAccountName" .}}
+- system:serviceaccount:{{ include "agent.namespace" . }}:{{ template "agent.serviceAccountName" .}}
 volumes:
 - hostPath
 - emptyDir

--- a/charts/agent/templates/service.yaml
+++ b/charts/agent/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "agent.fullname" . }}
+  namespace: {{ include "agent.namespace" . }}
   labels:
 {{ include "agent.labels" . | indent 4 }}
 spec:

--- a/charts/agent/templates/serviceaccount.yaml
+++ b/charts/agent/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "agent.serviceAccountName" .}}
+  namespace: {{ include "agent.namespace" . }}
   labels:
 {{ include "agent.labels" . | indent 4 }}
 {{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -4,6 +4,8 @@ global:
   sysdig: {}
   proxy: {}
 
+namespace: ""
+
 image:
   # This is a hack to support RELATED_IMAGE_<identifier> feature in Helm based
   # Operators


### PR DESCRIPTION
## What this PR does / why we need it:

Provides options for installing namespace-scoped components into a different namespace.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
