### PR TITLE
[sysdig-stackdriver-bridge] Remove duplicate labels

### DIFF
--- a/charts/sysdig-stackdriver-bridge/Chart.yaml
+++ b/charts/sysdig-stackdriver-bridge/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig-stackdriver-bridge
-version: 1.1.1
+version: 1.1.2
 appVersion: 0.0.7
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig-stackdriver-bridge/templates/configmap.yaml
+++ b/charts/sysdig-stackdriver-bridge/templates/configmap.yaml
@@ -3,7 +3,6 @@ kind: ConfigMap
 metadata:
   name: {{ template "sysdig-stackdriver-bridge.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "sysdig-stackdriver-bridge.name" . }}
 {{ include "sysdig-stackdriver-bridge.labels" . | indent 4 }}
 data:
   swb-config.yaml: |

--- a/charts/sysdig-stackdriver-bridge/templates/deployment.yaml
+++ b/charts/sysdig-stackdriver-bridge/templates/deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: {{ template "sysdig-stackdriver-bridge.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "sysdig-stackdriver-bridge.name" . }}
 {{ include "sysdig-stackdriver-bridge.labels" . | indent 4 }}
 spec:
   replicas: 1


### PR DESCRIPTION
The `app.kubernetes.io/name` label  is already set by the `sysdig-stackdriver-bridge.labels` helper which includes the `sysdig-stackdriver-bridge.selectorLabels` one that set this label. The duplicate labels on the ressources are triggering issues with some tools (like Flux v2).
