### PR TITLE
[Fix] Missing cpu limits for slim agent (sysdig + agent charts)

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.12.70
-version: 1.4.1
+version: 1.4.2
 
 appVersion: "12.4.0"
 

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.12.70
-version: 1.4.0
+version: 1.4.1
 
 appVersion: "12.4.0"
 

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -171,6 +171,7 @@ slim:
       cpu: 1000m
       memory: 348Mi
     limits:
+      cpu: 1000m
       memory: 512Mi
 
 # For Sysdig On-Prem installations or for custom collector settings, set the following fields

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.13.2
+version: 1.13.3
 appVersion: 12.5.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.13.1
+version: 1.13.2
 appVersion: 12.5.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -166,6 +166,7 @@ slim:
       cpu: 1000m
       memory: 348Mi
     limits:
+      cpu: 1000m
       memory: 512Mi
 
 # For Sysdig On-Prem installations or for custom collector settings, set the following fields


### PR DESCRIPTION
## What this PR does / why we need it:

There is missing the cpu limits which cause to have this error while deploying the agent (this message is coming from k8s events while describing agent daemonset):
```
Error creating: Pod "sysdig-agent-<id>" is invalid: spec.initContainers[0].resources.requests: Invalid value: "1": must be less that equal to cpu limit
```

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [X] PR only contains changes for one chart
