### PR TITLE
[sysdig][agent] add app label to agent

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.12.70
-version: 1.4.4
+version: 1.4.5
 
 appVersion: "12.4.0"
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -112,6 +112,7 @@ helm.sh/chart: {{ include "agent.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app: "sysdig-agent"
 {{- end }}
 
 {{/*

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.14.32
+version: 1.14.33
 appVersion: 12.6.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/_helpers.tpl
+++ b/charts/sysdig/templates/_helpers.tpl
@@ -177,6 +177,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app: "sysdig-agent"
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## What this PR does / why we need it:

To make it easier to select sysdig agents, whether using helm or the install script, this adds a common `app: sysdig-agent` label.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped