### PR TITLE
Add CODEOWNERS for sysdig, sysdig-deploy, and agent charts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# request review from agent team members for changes to sysdig chart
+/charts/sysdig/         @achandras @yashgiri @lilx1ao
+/charts/agent/          @achandras @yashgiri @lilx1ao
+/charts/sysdig-deploy/  @achandras @yashgiri @lilx1ao


### PR DESCRIPTION
## What this PR does / why we need it:

Add codeowners for charts so reviews can be automatically requested.
