### PR TITLE
[cspm-collector] Use apiEndpoint helper

### DIFF
--- a/charts/cspm-collector/Chart.yaml
+++ b/charts/cspm-collector/Chart.yaml
@@ -3,7 +3,7 @@ name: cspm-collector
 description: Sysdig CSPM collector
 
 version: 0.0.2
-appVersion: 0.0.2
+appVersion: 0.0.1
 keywords:
   - monitoring
   - security

--- a/charts/cspm-collector/Chart.yaml
+++ b/charts/cspm-collector/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cspm-collector
 description: Sysdig CSPM collector
 
-version: 0.0.1
-appVersion: 0.0.1
+version: 0.0.2
+appVersion: 0.0.2
 keywords:
   - monitoring
   - security

--- a/charts/cspm-collector/templates/_helpers.tpl
+++ b/charts/cspm-collector/templates/_helpers.tpl
@@ -130,6 +130,6 @@ Sysdig NATS service URL
 {{- if .Values.natsUrl -}}
     {{- .Values.natsUrl -}}
 {{- else -}}
-    wss://{{ .Values.apiEndpoint }}:443
+    wss://{{ (include "cspmCollector.apiEndpoint" .) }}:443
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## What this PR does / why we need it:
Fix the NATS URL helper to include the `apiEndpoint` helper instead of using values.
## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [X] PR only contains changes for one chart
