### PR TITLE
[sysdig-deploy] Remove global.clusterConfig.namespace

### DIFF
--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 0.1.3
+version: 0.1.4
 
 maintainers:
   - name: achandras

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -70,7 +70,6 @@ Further configuration information can be found below.
 | Parameter                        | Description                                                       | Default        |
 | -------------------------------- | ----------------------------------------------------------------- | -------------- |
 | `global.clusterConfig.name`      | Identifier for this cluster                                       | `""`           |
-| `global.clusterConfig.namespace` | Default namespace for all components                              | `sysdig-agent` |
 | `global.sysdig.accessKey`        | Sysdig Agent Access Key                                           | `""`           |
 | `global.sysdig.accessKeySecret`  | The name of a Kubernetes secret containing an 'access-key' entry. | `""`           |
 | `global.sysdig.region`           | The SaaS region for these agents                                  | `"us1"`        |

--- a/charts/sysdig-deploy/values.yaml
+++ b/charts/sysdig-deploy/values.yaml
@@ -1,7 +1,6 @@
 global:
   clusterConfig:
     name: ""  # name to identify this cluster for events and metrics
-    namespace: "sysdig-agent"  # namespace to install all components; can be overridden by components
   sysdig:
     accessKey: ""
     accessKeySecret: ""


### PR DESCRIPTION
## What this PR does / why we need it:

This is a redundant and potentially confusing flag, since `.Release.Namespace`, set by `--namespace` on the helm command, serves the exact same purpose

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
