### PR TITLE
[agent] return empty value from ebpf helper to act as boolean

### DIFF
--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This file documents all notable changes to the Sysdig Agent Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.4.4
+
+### Bugfix
+
+* fix the `agent.ebpfEnabled` helper so it doesn't always evaluate to `true`
+
 ## v1.4.3
 
 ### Minor Changes

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.12.70
-version: 1.4.3
+version: 1.4.4
 
 appVersion: "12.4.0"
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -169,6 +169,8 @@ This helper uses the lookup function to check the osImage field of every node.
 If all of them match the string indicating COS, then this will return true. If
 the list is empty (ie, the lookup failed) or one or more don't match, this will
 be false.
+This doesn't return a true boolean, so anywhere it is used, it must be checked:
+    eq "true" (include "agent.isAllCos")
 */}}
 {{- define "agent.isAllCos" -}}
     {{- $nodes := (lookup "v1" "Node" "" "").items -}}
@@ -180,10 +182,13 @@ be false.
 {{- end -}}
 
 {{/*
-Check for all COS nodes or a flag to enable eBPF.
+Check for all COS nodes or a flag to enable eBPF. If false, return nothing so
+it can act like a boolean
 */}}
 {{- define "agent.ebpfEnabled" -}}
-  {{- or (include "agent.isAllCos" .) .Values.ebpf.enabled -}}
+  {{- if (or (eq "true" (include "agent.isAllCos" .)) .Values.ebpf.enabled) -}}
+    true
+  {{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## What this PR does / why we need it:

Using `agent.ebpfEnabled` as a boolean check wasn't working as expected, since helpers return their value as a string, so it would always get a non-zero string and evaluate to `true`. Now this returns an empty value/string for `false`, which will let `if (include "agent.ebpfEnabled")` behave as intended.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
