### PR TITLE
[agent] update agent to sysdig 1.14.32

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -4,10 +4,10 @@ description: Sysdig Monitor and Secure agent
 
 type: application
 
-# currently matching sysdig 1.12.70
-version: 1.4.5
+# currently matching sysdig 1.14.32
+version: 1.5.0
 
-appVersion: "12.4.0"
+appVersion: "12.6.0"
 
 keywords:
   - monitoring

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -143,7 +143,9 @@ Return the default only if the value is not defined in sysdig.settings.<agent_se
 */}}
 {{- define "get_if_not_in_settings" -}}
 {{- if not (hasKey .root.Values.sysdig.settings .setting) -}}
+  {{- if .default -}}
     {{- .default -}}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   dragent.yaml: |
     new_k8s: true
-{{- $clusterName := include "get_if_not_in_settings" (dict "root" . "default" (coalesce .Values.sysdig.disableCaptures .Values.global.clusterConfig.name) "setting" "k8s_cluster_name") }}
+{{- $clusterName := include "get_if_not_in_settings" (dict "root" . "default" (coalesce .Values.clusterName .Values.global.clusterConfig.name) "setting" "k8s_cluster_name") }}
 {{- if $clusterName }}
     k8s_cluster_name: {{ $clusterName }}
 {{- end }}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.deploy }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -65,4 +66,5 @@ data:
 {{- if .Values.prometheus.file }}
   prometheus.yaml: |
 {{ toYaml .Values.prometheus.yaml | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.deploy }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -295,3 +296,4 @@ spec:
     type: {{ .Values.daemonset.updateStrategy.type }}
     rollingUpdate:
       maxUnavailable: {{include "agent.parallelStarts" .}}
+{{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -16,7 +16,7 @@ image:
 
   registry: quay.io
   repository: sysdig/agent
-  tag: 12.4.0
+  tag: 12.6.0
   # Specify a imagePullPolicy
   # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -74,7 +74,7 @@ resourceProfile: small
 #     memory: <memory limits>Mi
 
 gke:
-   # true here enables the deployment on gke autopilot clusters
+  # true here enables the deployment on gke autopilot clusters
   autopilot: false
 
 rbac:
@@ -96,6 +96,8 @@ serviceAccount:
   name:
 
 daemonset:
+  deploy: true
+
   # Perform rolling updates by default in the DaemonSet agent
   # ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
   updateStrategy:
@@ -124,6 +126,7 @@ daemonset:
   # Liveness and readiness probes initial delay (in seconds)
   probes:
     initialDelay: 90
+
   kmodule:
     env: {}
 
@@ -153,7 +156,7 @@ ebpf:
 
 slim:
   # Uses a slim version of the Sysdig Agent
-  enabled: false
+  enabled: true
   # The image repo to be used for slim Agents
   image:
     repository: sysdig/agent-slim


### PR DESCRIPTION
## What this PR does / why we need it:

Brings this chart up to date with the current sysdig chart

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
