### PR TITLE
[admission-controller] Avoid scanner webhook configuration when scanner.enabled is set to false

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.6.2
+version: 0.6.3
 appVersion: 3.9.2
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/templates/webhook/admissionregistration.yaml
+++ b/charts/admission-controller/templates/webhook/admissionregistration.yaml
@@ -12,6 +12,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
 webhooks:
+{{- if .Values.scanner.enabled -}}
 - name: scanning.secure.sysdig.com
   matchPolicy: Equivalent
   rules:
@@ -44,6 +45,7 @@ webhooks:
   {{- else }}
   failurePolicy: Ignore
   {{- end }}
+{{- end }}
 {{- if .Values.features.k8sAuditDetections }}
 - name: audit.secure.sysdig.com
   matchPolicy: Equivalent

--- a/charts/admission-controller/templates/webhook/admissionregistration.yaml
+++ b/charts/admission-controller/templates/webhook/admissionregistration.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
 webhooks:
-{{- if .Values.scanner.enabled -}}
+{{- if .Values.scanner.enabled }}
 - name: scanning.secure.sysdig.com
   matchPolicy: Equivalent
   rules:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [X] PR only contains changes for one chart

When deploying the admission controller with just k8s audit detection, so with following flags:
```
--set features.k8sAuditDetections=true
--set scanner.enabled=false
```
Our template will configure anyway webhook configuration for `scanning.secure.sysdig.com` for ValidatingWebhookConfiguration object which causes to have logs full of these entries (this is an example from a k3s cluster):

```
Jun 06 11:47:32 prod-k3s-master k3s[402708]: E0606 11:47:32.241735  402708 dispatcher.go:149] failed calling webhook "scanning.secure.sysdig.com": failed to call webhook: the server could not find the requested resource
Jun 06 11:47:32 prod-k3s-master k3s[402708]: W0606 11:47:32.268591  402708 dispatcher.go:142] Failed calling webhook, failing open scanning.secure.sysdig.com: failed calling webhook "scanning.secure.sysdig.com": failed to call webhook: the server could not find the requested resource
Jun 06 11:47:32 prod-k3s-master k3s[402708]: E0606 11:47:32.269515  402708 dispatcher.go:149] failed calling webhook "scanning.secure.sysdig.com": failed to call webhook: the server could not find the requested resource
Jun 06 11:47:32 prod-k3s-master k3s[402708]: W0606 11:47:32.296006  402708 dispatcher.go:142] Failed calling webhook, failing open scanning.secure.sysdig.com: failed calling webhook "scanning.secure.sysdig.com": failed to call webhook: the server could not find the requested resource
Jun 06 11:47:32 prod-k3s-master k3s[402708]: E0606 11:47:32.296063  402708 dispatcher.go:149] failed calling webhook "scanning.secure.sysdig.com": failed to call webhook: the server could not find the requested resource
Jun 06 11:47:32 prod-k3s-master k3s[402708]: W0606 11:47:32.318974  402708 dispatcher.go:142] Failed calling webhook, failing open scanning.secure.sysdig.com: failed calling webhook "scanning.secure.sysdig.com": failed to call webhook: the server could not find the requested resource
Jun 06 11:47:32 prod-k3s-master k3s[402708]: E0606 11:47:32.319034  402708 dispatcher.go:149] failed calling webhook "scanning.secure.sysdig.com": failed to call webhook: the server could not find the requested resource
Jun 06 11:47:32 prod-k3s-master k3s[402708]: W0606 11:47:32.349677  402708 dispatcher.go:142] Failed calling webhook, failing open scanning.secure.sysdig.com: failed calling webhook "scanning.secure.sysdig.com": failed to call webhook: the server could not find the requested resource
Jun 06 11:47:32 prod-k3s-master k3s[402708]: E0606 11:47:32.350139  402708 dispatcher.go:149] failed calling webhook "scanning.secure.sysdig.com": failed to call webhook: the server could not find the requested resource
```