### PR TITLE
[sysdig] Adding PSP support for sysdig-node-analyzer

### DIFF
--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.2
+version: 1.15.3
 appVersion: 12.6.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/psp-node-analyzer.yaml
+++ b/charts/sysdig/templates/psp-node-analyzer.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.psp.create  }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "sysdig.fullname" . }}-node-analyzer
+spec:
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65536
+    min: 1
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+{{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:

After the addition of the individualized service account for the Sysdig Node Analyzer the permissions in the cluster role do not have the correct PSP specified in: https://github.com/sysdiglabs/charts/commit/22d921a84d3aaaaf13cd1d0af7e7f5db11b05d9f 

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
