### PR TITLE
[sysdig-deploy] migration helper

### DIFF
--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 0.1.8
+version: 0.1.9
 
 maintainers:
   - name: achandras

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -120,6 +120,8 @@ helm upgrade -n sysdig-agent sysdig sysdig/sysdig-deploy -f values.sysdig.yaml
 
 ## Configuration
 
+The following table lists the configurable parameters of this chart and their default values.
+
 | Parameter                        | Description                                                       | Default        |
 | -------------------------------- | ----------------------------------------------------------------- | -------------- |
 | `global.clusterConfig.name`      | Identifier for this cluster                                       | `""`           |
@@ -137,6 +139,7 @@ helm upgrade -n sysdig-agent sysdig sysdig/sysdig-deploy -f values.sysdig.yaml
 | `nodeAnalyzer.nodeAnalyzer.apiEndpoint`           | nodeAnalyzer apiEndpoint                         | `""`           |
 | `kspmCollector.enabled`          | Enable the kspmCollector component in this chart                  | `false`        |
 | `kspmCollector.apiEndpoint`      | kspmCollector apiEndpoint                                         | `""`           |
+
 ## Agent
 
 For possible configuration values of the Agent, please refer to the Agent subchart [README](https://github.com/sysdiglabs/charts/tree/master/charts/agent/README.md). All agent-specific configuration can be prefixed with `agent.` to apply them to this chart.

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -65,6 +65,39 @@ helm install -n sysdig-agent sysdig sysdig/sysdig-deploy -f values.sysdig.yaml
 
 Further configuration information can be found below.
 
+## Migrating from `sysdig`
+
+To easily migrate from the previous `sysdig` chart to the new unified `sysdig-deploy` chart, use the migration helper script from this repo.
+
+Requirements:
+- Python 3.x
+- PyYAML
+
+Save the user-values from the currently deployed version of the `sysdig` chart:
+
+```bash
+helm get values -n sysdig-agent sysdig-agent -o yaml > values.old.yaml
+```
+
+Note: the migration script has a dependency on `pyyaml`, which can be installed with
+
+```bash
+pip install pyyaml
+```
+
+Run the migration script and redirect the output to a new file. For example, if the old values were saved to `values.old.yaml`:
+
+```bash
+python scripts/migrate_values.py values.old.yaml > values.new.yaml
+```
+
+Now the `sysdig` chart can be removed and replaced with the `sysdig-deploy` chart.
+
+```bash
+helm delete -n sysdig-agent sysdig-agent
+
+helm install -n sysdig-agent sysdig sysdig/sysdig-deploy -f values.new.yaml
+
 ## Upgrading
 
 Refresh the `sysdig` helm repo to get the latest chart.

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -99,6 +99,7 @@ Now the `sysdig` chart can be removed and replaced with the `sysdig-deploy` char
 helm delete -n sysdig-agent sysdig-agent
 
 helm install -n sysdig-agent sysdig sysdig/sysdig-deploy -f values.new.yaml
+```
 
 ## Upgrading
 

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -67,7 +67,9 @@ Further configuration information can be found below.
 
 ## Migrating from `sysdig`
 
-To easily migrate from the previous `sysdig` chart to the new unified `sysdig-deploy` chart, use the migration helper script from this repo.
+To easily migrate from the previous `sysdig` chart to the new unified `sysdig-deploy` chart, use the migration helper script from this repo. This script will help re-map your existing values from the `sysdig` chart, allowing you to deploy this chart with the exact same configuration.
+
+*Note*: unlike the previous chart, this chart only supports Helm 3. If you have not already done so, please upgrade your Helm version to 3.x to use this chart.
 
 Requirements:
 - Python 3.x

--- a/charts/sysdig-deploy/scripts/migrate_values.py
+++ b/charts/sysdig-deploy/scripts/migrate_values.py
@@ -3,52 +3,47 @@ import sys
 import yaml
 
 
-## path mappings for values to be extracted to globals
-GLOBAL_VALUES = [
-    ("clusterName",                    "global.clusterConfig.name"),
-    ("sysdig.accessKey",               "global.sysdig.accessKey"),
-    ("sysdig.existingAccessKeySecret", "global.sysdig.accessKeySecret"),
-    ("image.registry",                 "global.image.registry"),
-]
-
-## The keys listed here will be copied over to their respective sections as-is
-AGENT_VALUES = [
-    "auditLog",
-    "collectorSettings",
-    "daemonset",
-    "ebpf",
-    "extraVolumes",
-    "gke",
-    "image.repository",
-    "image.tag",
-    "image.pullPolicy",
-    "leaderelection",
-    "namespace",
-    "priorityClassName",
-    "prometheus",
-    "proxy",
-    "psp",
-    "rbac",
-    "resourceProfile",
-    "scc",
-    "secure",
-    "serviceAccount",
-    "slim",
-    "sysdig.disableCaptures",
-    "sysdig.settings",
-    "timezone",
-    "tolerations",
-]
-
-NODE_ANALYZER_VALUES = [
-    "gke",
-    "image.pullPolicy",
-    "natsUrl",
-    "nodeAnalyzer",
-    "psp",
-    "rbac",
-    "scc",
-    "secure",
+## path mappings for values to be extracted to new paths
+VALUES_MAPPINGS = [
+    # globals
+    ("clusterName",                     "global.clusterConfig.name"),
+    ("sysdig.accessKey",                "global.sysdig.accessKey"),
+    ("sysdig.existingAccessKeySecret",  "global.sysdig.accessKeySecret"),
+    ("image.registry",                  "global.image.registry"),
+    # agent-only
+    ("auditLog",                        "agent.auditLog"),
+    ("collectorSettings",               "agent.collectorSettings"),
+    ("daemonset",                       "agent.daemonset"),
+    ("ebpf",                            "agent.ebpf"),
+    ("extraVolumes",                    "agent.extraVolumes"),
+    ("gke",                             "agent.gke"),
+    ("image.repository",                "agent.image.repository"),
+    ("image.tag",                       "agent.image.tag"),
+    ("image.pullPolicy",                "agent.image.pullPolicy"),
+    ("leaderelection",                  "agent.leaderelection"),
+    ("priorityClassName",               "agent.priorityClassName"),
+    ("prometheus",                      "agent.prometheus"),
+    ("proxy",                           "agent.proxy"),
+    ("psp",                             "agent.psp"),
+    ("rbac",                            "agent.rbac"),
+    ("resourceProfile",                 "agent.resourceProfile"),
+    ("scc",                             "agent.scc"),
+    ("secure",                          "agent.secure"),
+    ("serviceAccount",                  "agent.serviceAccount"),
+    ("slim",                            "agent.slim"),
+    ("sysdig.disableCaptures",          "agent.sysdig.disableCaptures"),
+    ("sysdig.settings",                 "agent.sysdig.settings"),
+    ("timezone",                        "agent.timezone"),
+    ("tolerations",                     "agent.tolerations"),
+    # node-analyzer-only
+    ("gke",                             "nodeAnalyzer.gke"),
+    ("image.pullPolicy",                "nodeAnalyzer.image.pullPolicy"),
+    ("natsUrl",                         "nodeAnalyzer.natsUrl"),
+    ("nodeAnalyzer",                    "nodeAnalyzer.nodeAnalyzer"),
+    ("psp",                             "nodeAnalyzer.psp"),
+    ("rbac",                            "nodeAnalyzer.rbac"),
+    ("scc",                             "nodeAnalyzer.scc"),
+    ("secure",                          "nodeAnalyzer.secure"),
 ]
 
 
@@ -82,33 +77,11 @@ def set_nested_key(key, value, values):
 
 
 # copy keys from old path to new
-def populate_globals(new_values, old_values):
-    for old_path, new_path in GLOBAL_VALUES:
+def populate_values(new_values, old_values):
+    for old_path, new_path in VALUES_MAPPINGS:
         value = get_nested_key(old_path, old_values)
         if value:
             set_nested_key(new_path, value, new_values)
-
-
-def populate_agent(new_values, old_values):
-    agent_values = {}
-
-    for key in AGENT_VALUES:
-        value = get_nested_key(key, old_values)
-        if value:
-            set_nested_key(key, value, agent_values)
-
-    new_values["agent"] = agent_values
-
-
-def populate_node_analyzer(new_values, old_values):
-    node_analyzer_values = {}
-
-    for key in NODE_ANALYZER_VALUES:
-        value = get_nested_key(key, old_values)
-        if value:
-            set_nested_key(key, value, node_analyzer_values)
-
-    new_values["nodeAnalyzer"] = node_analyzer_values
 
 
 def migrate_values(old_values_filename):
@@ -117,9 +90,7 @@ def migrate_values(old_values_filename):
         old_values = yaml.safe_load(f)
 
     new_values = {}
-    populate_globals(new_values, old_values)
-    populate_agent(new_values, old_values)
-    populate_node_analyzer(new_values, old_values)
+    populate_values(new_values, old_values)
 
     new_values_yaml = yaml.dump(new_values, sort_keys=False)
     print(new_values_yaml)

--- a/charts/sysdig-deploy/scripts/migrate_values.py
+++ b/charts/sysdig-deploy/scripts/migrate_values.py
@@ -1,0 +1,67 @@
+import copy
+import sys
+import yaml
+
+
+## helpers for migrating values
+def populate_globals(new_values, values):
+    globals = {
+        "clusterConfig": {},
+        "sysdig": {},
+        "image": {},
+    }
+
+    name = values.pop("clusterName", "")
+    if name:
+        globals["clusterConfig"]["name"] = name
+
+    accessKey = values.get("sysdig", {}).pop("accessKey", "")
+    if accessKey:
+        globals["sysdig"]["accessKey"] = accessKey
+
+    accessKeySecret = values.get("sysdig", {}).pop("existingAccessKeySecret", "")
+    if accessKeySecret:
+        globals["sysdig"]["accessKeySecret"] = accessKeySecret
+
+    registry = values.get("image", {}).pop("registry", "")
+    if registry:
+        globals["image"]["registry"] = registry
+
+    new_values["global"] = globals
+
+
+def populate_agent(new_values, values):
+    new_values["agent"] = copy.deepcopy(values)
+    new_values["agent"].pop("nodeAnalyzer", {})
+    new_values["agent"].pop("nodeImageAnalyzer", {})
+
+
+def populate_node_analyzer(new_values, values):
+    new_values["nodeAnalyzer"] = copy.deepcopy(values)
+    new_values["nodeAnalyzer"].pop("daemonset", {})
+    new_values["nodeAnalyzer"].pop("resourceProfile", {})
+    new_values["nodeAnalyzer"].get("sysdig", {}).pop("settings", {})
+
+
+def migrate_values(old_values_filename):
+    old_values = {}
+    with open(old_values_filename, 'r') as f:
+        old_values = yaml.safe_load(f)
+
+    new_values = {}
+    populate_globals(new_values, old_values)
+    populate_agent(new_values, old_values)
+    populate_node_analyzer(new_values, old_values)
+
+    new_values_yaml = yaml.dump(new_values, sort_keys=False)
+    print(new_values_yaml)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python migrate_values.py <old_values_file>")
+        sys.exit(1)
+
+    old_values_filename = sys.argv[1]
+
+    migrate_values(old_values_filename)

--- a/charts/sysdig-deploy/scripts/migrate_values.py
+++ b/charts/sysdig-deploy/scripts/migrate_values.py
@@ -65,15 +65,17 @@ def get_nested_key(key, values):
 def set_nested_key(key, value, values):
     nested_keys = key.split(".")
 
-    path = values
+    # descend into the nested keys, where the value at the cuurently traversed
+    # path is nested_values
+    nested_values = values
     for nested_key in nested_keys[:-1]:
-        if nested_key in path:
-            path = path.get(nested_key, None)
+        if nested_key in nested_values:
+            nested_values = nested_values.get(nested_key, None)
         else:
-            path[nested_key] = {}
-            path = path[nested_key]
+            nested_values[nested_key] = {}
+            nested_values = nested_values[nested_key]
 
-    path[nested_keys[-1]] = value
+    nested_values[nested_keys[-1]] = value
 
 
 # copy keys from old path to new


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a simple migration helper for moving values from the `sysdig` format to the `sysdig-deploy` format

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
