### PR TITLE
[sysdig] Move the K8S_NODE environment variable to the agent container

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.15.5
+### Minor changes
+* Fix expose node name to the Sysdig Agent container through Downward API
+  through K8S_NODE environment variable.
+
 ## v1.15.2
 ### Minor changes
 * KSPM: add kspmCollector.deploy parameter to docs

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.4
+version: 1.15.5
 appVersion: 12.6.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -90,10 +90,6 @@ spec:
           resources:
 {{ toYaml .Values.slim.resources | indent 12 }}
           env:
-            - name: K8S_NODE
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
           {{- if or .Values.ebpf.enabled .Values.gke.autopilot }}
             - name: SYSDIG_BPF_PROBE
               value:
@@ -142,6 +138,10 @@ spec:
             readOnlyRootFilesystem: false
             allowPrivilegeEscalation: true
           env:
+            - name: K8S_NODE
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             {{- if or .Values.ebpf.enabled .Values.gke.autopilot }}
             - name: SYSDIG_BPF_PROBE
               value:


### PR DESCRIPTION
## What this PR does / why we need it:

This PR moves the K8S_NODE environment variable from the init container where it placed by mistake to the agent container.

ref: https://github.com/sysdiglabs/charts/pull/319

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [X] PR only contains changes for one chart
