### PR TITLE
[cloud-connector] allow role based access

### DIFF
--- a/charts/cloud-connector/Chart.yaml
+++ b/charts/cloud-connector/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-connector
 description: Sysdig Cloud Connector
 
 type: application
-version: 0.7.8
+version: 0.7.9
 appVersion: 0.16.10
 home: https://sysdiglabs.github.io/cloud-connector
 

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install cloud-connector sysdig/cloud-connector \
-      --create-namespace -n cloud-connector --version=0.7.8  \
+      --create-namespace -n cloud-connector --version=0.7.9  \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
 ```
 
@@ -47,7 +47,7 @@ to enable threat-detection and image scanning capabilities for the main three pr
 To install the chart with the release name `cloud-connector`:
 
 ```console
-$ helm upgrade --install cloud-connector sysdig/cloud-connector -n cloud-connector --version=0.7.8
+$ helm upgrade --install cloud-connector sysdig/cloud-connector -n cloud-connector --version=0.7.9
 ```
 
 The command deploys the Sysdig Cloud Connector on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -93,6 +93,7 @@ The following table lists the configurable parameters of the `cloud-connector` c
 | affinity                                | Configure affinity rules                                                                                               | <code>{}</code>                                                                                          |
 | telemetryDeploymentMethod               | Configure deployment source for inner telemetry                                                                        | <code>"helm"</code>                                                                                      |
 | extraEnvVars                            | Extra environment variables to be set                                                                                  | <code>[]</code>                                                                                          |
+| aws.roleBasedAccess                     | get the credentials from current role                                                                                  | <code>false</code>                                                                                       |
 | aws.accessKeyId                         | AWS Credentials AccessKeyID                                                                                            | <code>""</code>                                                                                          |
 | aws.secretAccessKey                     | AWS Credentials: SecretAccessKey                                                                                       | <code>""</code>                                                                                          |
 | aws.region                              | AWS Region                                                                                                             | <code>""</code>                                                                                          |
@@ -118,7 +119,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install cloud-connector sysdig/cloud-connector \
-    --create-namespace -n cloud-connector --version=0.7.8 \
+    --create-namespace -n cloud-connector --version=0.7.9 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE
 ```
 
@@ -127,7 +128,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install cloud-connector sysdig/cloud-connector \
-    --create-namespace -n cloud-connector --version=0.7.8 \
+    --create-namespace -n cloud-connector --version=0.7.9 \
     --values values.yaml
 ```
 

--- a/charts/cloud-connector/templates/deployment.yaml
+++ b/charts/cloud-connector/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            {{- if not .Values.aws.roleBasedAccess }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -65,6 +66,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "cloud-connector.secretname" . }}
                   key: aws_region
+            {{- end }}
             - name: SECURE_URL
               value: {{ .Values.sysdig.url }}
             - name: SECURE_API_TOKEN

--- a/charts/cloud-connector/templates/secret.yaml
+++ b/charts/cloud-connector/templates/secret.yaml
@@ -7,9 +7,11 @@ metadata:
     {{- include "cloud-connector.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if not .Values.aws.roleBasedAccess }}
   aws_access_key_id: {{ .Values.aws.accessKeyId | b64enc | quote }}
   aws_secret_access_key: {{ .Values.aws.secretAccessKey | b64enc | quote }}
   aws_region: {{ .Values.aws.region | b64enc | quote }}
+  {{- end }}
   gcp_credentials: {{ .Values.gcpCredentials | b64enc | quote }}
   azure_event_hub_connection_string: {{ .Values.azure.eventHubConnectionString | b64enc | quote }}
   azure_event_grid_event_hub_connection_string: {{ .Values.azure.eventGridEventHubConnectionString | b64enc | quote }}

--- a/charts/cloud-connector/values.yaml
+++ b/charts/cloud-connector/values.yaml
@@ -82,6 +82,8 @@ extraEnvVars: []
 ## Secret values
 
 aws:
+  # get the credentials from current role
+  roleBasedAccess: false
   # AWS Credentials AccessKeyID
   accessKeyId: ""
   # AWS Credentials: SecretAccessKey


### PR DESCRIPTION
The only current way to connect to the ingestors in AWS are through
a User and generate an access key and a secret.

However, kubernetes workloads can also assume a role at startup time (for example, [kube2iam](https://github.com/jtblin/kube2iam)) without the need to impersonate a user. IAM Users are limited and their secrets are difficult to rotate. On the other hand, assuming an IAM role generates temporary credentials at each assume and is safe to use.

In the current implementation, the secret will always include the AWS credentials (even if empty) in the secret, and the deployment always loads it in an environment variable at load time.

That causes a problem as in the AWS SDK, the env vars will take precedence over the [role assumption](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html).
This PR introduces a new toggled called `aws.roleBasedAccess`, it doesn't add the accessKeyId and secretAccessKey into the secret and it doesn't mount it from the deployment, leaving the connector to assume the IAM role.

## What this PR does / why we need it:

The current setup doesn't allow IAM role based access because it always sets the AWS_... environment variables.
This PR allows those variables not to be set if a flag is enabled.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
