### PR TITLE
[registry-scanner] Bump registry scanner version to 0.1.7

### DIFF
--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -5,6 +5,13 @@
 This file documents all notable changes to Sysdig Registry Scanner. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.0.30
+
+### Minor changes
+
+* Bump registry-scanner version to 0.1.7:
+  * Support insecure registries
+
 ## v0.0.29
 
 ### Minor changes

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,8 +4,8 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.0.29
-appVersion: 0.1.6
+version: 0.0.30
+appVersion: 0.1.7
 maintainers:
   - name: airadier
     email: alvaro.iradier@sysdig.com


### PR DESCRIPTION
## What this PR does / why we need it:

Update registry scanner chart to bump its version to v0.1.7 to make it works with plain http registries.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [X] PR only contains changes for one chart
