### PR TITLE
[cloud-connector] Add /tmp as emptyDir because fs is read-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ docs: deps
 			"cd %; chart-doc-gen -v values.yaml -d doc.yaml -t README.tpl > README.md"
 
 lint:
-	docker run --rm -e CT_VALIDATE_MAINTAINERS=false -v $(PWD):/charts quay.io/helmpack/chart-testing:latest sh -c "cd /charts; ct lint --all"
+	docker run --rm -e CT_VALIDATE_MAINTAINERS=false -u $(shell id -u) -v $(PWD):/charts quay.io/helmpack/chart-testing:latest sh -c "cd /charts; ct lint --all"
 
 deps:
 	go install kubepack.dev/chart-doc-gen@latest

--- a/charts/cloud-connector/Chart.yaml
+++ b/charts/cloud-connector/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-connector
 description: Sysdig Cloud Connector
 
 type: application
-version: 0.7.8
+version: 0.7.9
 appVersion: 0.16.10
 home: https://sysdiglabs.github.io/cloud-connector
 

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install cloud-connector sysdig/cloud-connector \
-      --create-namespace -n cloud-connector --version=0.7.8  \
+      --create-namespace -n cloud-connector --version=0.7.9  \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
 ```
 
@@ -47,7 +47,7 @@ to enable threat-detection and image scanning capabilities for the main three pr
 To install the chart with the release name `cloud-connector`:
 
 ```console
-$ helm upgrade --install cloud-connector sysdig/cloud-connector -n cloud-connector --version=0.7.8
+$ helm upgrade --install cloud-connector sysdig/cloud-connector -n cloud-connector --version=0.7.9
 ```
 
 The command deploys the Sysdig Cloud Connector on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -118,7 +118,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install cloud-connector sysdig/cloud-connector \
-    --create-namespace -n cloud-connector --version=0.7.8 \
+    --create-namespace -n cloud-connector --version=0.7.9 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE
 ```
 
@@ -127,7 +127,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install cloud-connector sysdig/cloud-connector \
-    --create-namespace -n cloud-connector --version=0.7.8 \
+    --create-namespace -n cloud-connector --version=0.7.9 \
     --values values.yaml
 ```
 

--- a/charts/cloud-connector/templates/deployment.yaml
+++ b/charts/cloud-connector/templates/deployment.yaml
@@ -118,6 +118,8 @@ spec:
               name: cloud-connector-config
             - mountPath: /var/secrets/gcp
               name: google-application-credentials
+            - mountPath: /tmp
+              name: tmp-dir
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -131,6 +133,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: tmp-dir
+          emptyDir: {}
         - name: home-dir
           emptyDir: {}
         - name: cloud-connector-config


### PR DESCRIPTION
## What this PR does / why we need it:

Because the new inline scanner uses /tmp as storage for the database, the directory needs to be mounted from an emptyDir so it's writable.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
