### PR TITLE
[agent] use nil check instead of emptiness

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.3
+version: 1.5.4
 
 appVersion: 12.7.0
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -143,7 +143,7 @@ Return the default only if the value is not defined in sysdig.settings.<agent_se
 */}}
 {{- define "get_if_not_in_settings" -}}
 {{- if not (hasKey .root.Values.sysdig.settings .setting) -}}
-  {{- if ne .default nil -}}
+  {{- if and (ne .default nil) (printf "%s" .default) -}}
     {{- .default -}}
   {{- end -}}
 {{- end -}}

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -143,7 +143,7 @@ Return the default only if the value is not defined in sysdig.settings.<agent_se
 */}}
 {{- define "get_if_not_in_settings" -}}
 {{- if not (hasKey .root.Values.sysdig.settings .setting) -}}
-  {{- if .default -}}
+  {{- if ne .default nil -}}
     {{- .default -}}
   {{- end -}}
 {{- end -}}

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -143,7 +143,7 @@ Return the default only if the value is not defined in sysdig.settings.<agent_se
 */}}
 {{- define "get_if_not_in_settings" -}}
 {{- if not (hasKey .root.Values.sysdig.settings .setting) -}}
-  {{- if and (ne .default nil) (printf "%s" .default) -}}
+  {{- if or (kindIs "bool" .default) (.default) -}}
     {{- .default -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## What this PR does / why we need it:

Previously, the emptiness check would prevent boolean "false" values from being printed

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
