### PR TITLE
[none] README improvements

### DIFF
--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -3,7 +3,7 @@
 ---
 **WARNING**
 
-This chart is still experimental and may have issues! Please use the [supported chart](https://github.com/sysdiglabs/charts/tree/master/charts/sysdig) for production deployments.
+This chart is still experimental and may have issues! Please use the [supported chart](https://github.com/sysdiglabs/charts/tree/master/charts/sysdig-deploy) for production deployments.
 
 ---
 

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -10,6 +10,8 @@ This chart deploys various Sysdig components into your Kubernetes cluster.
 
 Currently included components:
 - [Sysdig agent](https://github.com/sysdiglabs/charts/tree/master/charts/agent)
+- [Sysdig NodeAnalyzer](https://github.com/sysdiglabs/charts/tree/master/charts/node-analyzer)
+- [Sysdig KSPM Collector](https://github.com/sysdiglabs/charts/tree/master/charts/kspm-collector)
 
 ## Prerequisites
 


### PR DESCRIPTION
## What this PR does / why we need it:

* Skipped a redirection in the agent chart (currently agent -> sysdig -> sysdig-deploy)
* Also links for the components available to use with sysdig-deploy chart

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
