### PR TITLE
[node-analyzer] Fix empty nats endpoint for KSPM Analyzer

### DIFF
--- a/charts/node-analyzer/CHANGELOG.md
+++ b/charts/node-analyzer/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig Node Analyzer Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.5.6
+### Bugfixes
+
+* KSPM: Fix Analyzer nats url
+
 ## v1.5.5
 ### Bugfixes
 

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.5.5
+version: 1.5.6
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/_helpers.tpl
+++ b/charts/node-analyzer/templates/_helpers.tpl
@@ -200,6 +200,6 @@ Sysdig NATS service URL
 {{- if .Values.natsUrl -}}
     {{- .Values.natsUrl -}}
 {{- else -}}
-    wss://{{ .Values.nodeAnalyzer.apiEndpoint }}:443
+    wss://{{ ( include "nodeAnalyzer.apiEndpoint" .) }}:443
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## What this PR does / why we need it:
Fix nats url for KSPM Analyzer see ESC-2268/SSPROD-14711

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [X] PR only contains changes for one chart
