### PR TITLE
[agent] Incorrect collector URL for us4 and au1

### DIFF
--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This file documents all notable changes to the Sysdig Agent Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.5.8
+
+### Bugfix
+
+* Fixed region collector addresses for us4, au1
+
 ## v1.5.7
 
 ### Minor Changes

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.7
+version: 1.5.8
 
 appVersion: 12.7.1
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -229,11 +229,11 @@ Determine collector endpoint based on provided region
     {{- else if (eq .Values.global.sysdig.region "us3") -}}
         {{- "ingest.us3.app.sysdig.com" -}}
     {{- else if (eq .Values.global.sysdig.region "us4") -}}
-        {{- "ingest.us4.app.sysdig.com" -}}
+        {{- "ingest.us4.sysdig.com" -}}
     {{- else if (eq .Values.global.sysdig.region "eu1") -}}
         {{- "ingest-eu1.app.sysdig.com" -}}
     {{- else if (eq .Values.global.sysdig.region "au1") -}}
-        {{- "ingest.au1.app.sysdig.com" -}}
+        {{- "ingest.au1.sysdig.com" -}}
     {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
## What this PR does / why we need it:
Fix the URL for the us4 and au1 regions

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
