### PR TITLE
[rapid-response] Lowercase chart name and fullname

### DIFF
--- a/charts/rapid-response/CHANGELOG.md
+++ b/charts/rapid-response/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Change Log
 
+## v0.1.1
+
+### Bugfix
+
+* Fixed an issue that was causing k8s secrets to get generated with uppercase characters
+
 ## v0.1.0
 
 ### First release

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rapid-response/templates/_helpers.tpl
+++ b/charts/rapid-response/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 Expand the name of the chart.
 */}}
 {{- define "rapidResponse.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | lower }}
 {{- end }}
 
 {{/*
@@ -14,13 +14,13 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "rapidResponse.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" | lower }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := default .Chart.Name .Values.nameOverride | lower }}
 {{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" | lower }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" | lower }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -29,7 +29,7 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "rapidResponse.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | lower }}
 {{- end }}
 
 {{/*

--- a/charts/rapid-response/templates/daemonset.yaml
+++ b/charts/rapid-response/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
 {{ toYaml .Values.rapidResponse.imagePullSecrets | indent 8 }}
       {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: rapid-response
           image: {{ template "rapidResponse.image" . }}
           imagePullPolicy: {{ .Values.rapidResponse.image.pullPolicy }}
           resources: 

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.1.1
+
+### Minor changes
+
+* Bumped rapid-response sub-chart version
+
 ## v1.1.0
 
 ### Major changes

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.1.0
+version: 1.1.1
 
 maintainers:
   - name: achandras
@@ -38,6 +38,6 @@ dependencies:
 - name: rapid-response
   # repository: https://charts.sysdig.com
   repository: file://../rapid-response
-  version: ~0.1.0
+  version: ~0.1.1
   alias: rapidResponse
   condition: rapidResponse.enabled


### PR DESCRIPTION
## What this PR does / why we need it:
Secrets were generated with uppercase characters

```
  Warning  error   5m28s (x6 over 6m12s)  helm-controller  Helm upgrade failed: failed to create resource: Secret "sysdig-deploy-rapidResponse-passphrase" is invalid: metadata.name: Invalid value: "sysdig-deploy-rapidResponse-passphrase": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
