### PR TITLE
[agent] fix container name for sysdig agent

### DIFF
--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This file documents all notable changes to the Sysdig Agent Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.5.9
+
+### Bugfix
+
+* Fix agent container name to match previous name `sysdig`
+
 ## v1.5.8
 
 ### Bugfix

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.8
+version: 1.5.9
 
 appVersion: 12.7.1
 

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -122,7 +122,7 @@ spec:
               readOnly: true
       {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: sysdig
           image: {{ template "agent.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:


### PR DESCRIPTION
## What this PR does / why we need it:

Reduce discrepancy between charts by fixing container name, which was `sysdig` in the previous chart.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
