### PR TITLE
[admission-controller] - Added log level configuration to webhook helm chart

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.6.10
+version: 0.6.11
 appVersion: 3.9.6
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -340,10 +340,11 @@ A: This happens when DEBUG is enabled but Admission Controller will behave as ex
 
 
 ### Q: I need to troubleshoot, any way to switch to `debug verbose`?
-S: Add the `LOG_LEVEL=debug` key-value to the admission configmap and respawn webhook
+A: If you used helm to install, you can edit the helm values.yaml to set webhook.logLevel=debug
+S: You can edit the webhook configmap - add the `LOG_LEVEL=debug` key-value and restart the webhook
 
     $ kubectl edit configmaps -n sysdig-admission-controller sysdig-admission-controller-webhook
-    $ kubectl delete pod -n sysdig-admission-controller -l app.kubernetes.io/component=webhook
+    $ kubectl rollout restart deployment -n sysdig-admission-controller sysdig-admission-controller-webhook
     
 
 ### Q: I don't see `Policy Rules` honored
@@ -355,9 +356,9 @@ S: Review the [Admission Controller - Understanding:Evaluation Order](https://do
 
 ### Q: I don't see changes on `Policy Assignments` being applied on my cluster
 A: Admission Controller pull changes from the Sysdig Secure platform every 5 minutes<br/>
-S: You can wait those five minutes, or force the admission controller webhook respawn
+S: You can wait those five minutes, or force the admission controller webhook restart
 
-    $ kubectl delete pod -n sysdig-admission-controller -l app.kubernetes.io/component=webhook
+    $ kubectl rollout restart deployment -n sysdig-admission-controller sysdig-admission-controller-webhook
 
 <!--
 Q: Helm v2 usage

--- a/charts/admission-controller/templates/webhook/configmap.yaml
+++ b/charts/admission-controller/templates/webhook/configmap.yaml
@@ -12,6 +12,7 @@ data:
   SCANNER_URL: ""
   {{- end }}
   CLUSTER_NAME: {{ required "value 'clusterName' is required, but is not set"  .Values.clusterName }}
+  LOG_LEVEL: "{{ .Values.webhook.logLevel }}"
   VERIFY_SSL: "{{ .Values.verifySSL }}"
   K8S_AUDIT_DETECTIONS: "{{ .Values.features.k8sAuditDetections }}"
   DENY_ON_ERROR: "{{ .Values.webhook.denyOnError }}"

--- a/charts/admission-controller/values.yaml
+++ b/charts/admission-controller/values.yaml
@@ -156,6 +156,8 @@ webhook:
   denyOnError: false
   # Dry Run request
   dryRun: false
+  # Log Level - Valid Values info or debug
+  logLevel: info
 
   ssl:
     ca:


### PR DESCRIPTION
## This PR is adding support to set the Admission Controller Webhook log level via the helm chart values.yml

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
