### PR TITLE
add /etc -> /host/etc volume bind

### DIFF
--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to the Sysdig Agent Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.5.10
+
+### Minor changes
+* Added /etc to container /host/etc volume bind
+
 ## v1.5.9
 
 ### Bugfix

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.9
+version: 1.5.10
 
 appVersion: 12.7.1
 

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -117,9 +117,6 @@ spec:
               name: sys-tracing
               readOnly: true
             {{- end }}
-            - mountPath: /host/etc/os-release
-              name: osrel
-              readOnly: true
       {{- end }}
       containers:
         - name: sysdig
@@ -175,6 +172,9 @@ spec:
               name: modprobe-d
               readOnly: true
             {{- end }}
+            - mountPath: /host/etc
+              name: etc-vol
+              readOnly: true
             - mountPath: /host/dev
               name: dev-vol
               readOnly: false
@@ -202,11 +202,6 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
-            {{- if (and (include "agent.ebpfEnabled" .) .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
-            - mountPath: /host/etc
-              name: etc-fs
-              readOnly: true
-            {{- end }}
             {{- if (and (or (include "agent.ebpfEnabled" .) .Values.gke.autopilot) .Values.slim.enabled) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -214,9 +209,6 @@ spec:
               name: sys-tracing
               readOnly: true
             {{- end }}
-            - mountPath: /host/etc/os-release
-              name: osrel
-              readOnly: true
             {{- if .Values.extraVolumes.mounts }}
 {{ toYaml .Values.extraVolumes.mounts | indent 12 }}
             {{- end }}
@@ -226,13 +218,12 @@ spec:
         - name: modprobe-d
           hostPath:
             path: /etc/modprobe.d
-        - name: osrel
-          hostPath:
-            path: /etc/os-release
-            type: FileOrCreate
         - name: dshm
           emptyDir:
             medium: Memory
+        - name: etc-vol
+          hostPath:
+            path: /etc
         - name: dev-vol
           hostPath:
             path: /dev
@@ -254,11 +245,6 @@ spec:
         - name: varrun-vol
           hostPath:
             path: /var/run
-        {{- if (and (include "agent.ebpfEnabled" .) .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
-        - name: etc-fs
-          hostPath:
-            path: /etc
-        {{- end }}
         {{- if (and (or (include "agent.ebpfEnabled" .) .Values.gke.autopilot) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}

--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.15.21
+### Minor changes
+* Added /etc to container /host/etc volume bind
+
 ## v1.15.20
 ### Bugfixes
 * Removed duplicate labels from deployment of `app.kubernetes.io/instance` 

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.20
+version: 1.15.21
 appVersion: 12.7.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -118,9 +118,6 @@ spec:
               name: sys-tracing
               readOnly: true
             {{- end }}
-            - mountPath: /host/etc/os-release
-              name: osrel
-              readOnly: true
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -176,6 +173,9 @@ spec:
               name: modprobe-d
               readOnly: true
             {{- end }}
+            - mountPath: /host/etc
+              name: etc-vol
+              readOnly: true
             - mountPath: /host/dev
               name: dev-vol
               readOnly: false
@@ -203,11 +203,6 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
-            {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
-            - mountPath: /host/etc
-              name: etc-fs
-              readOnly: true
-            {{- end }}
             {{- if (and (or .Values.ebpf.enabled .Values.gke.autopilot) .Values.slim.enabled) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -219,9 +214,6 @@ spec:
             - mountPath: /opt/draios/lib/python/checks.custom.d
               name: custom-app-checks-volume
             {{- end }}
-            - mountPath: /host/etc/os-release
-              name: osrel
-              readOnly: true
             {{- if .Values.extraVolumes.mounts }}
 {{ toYaml .Values.extraVolumes.mounts | indent 12 }}
             {{- end }}
@@ -231,13 +223,12 @@ spec:
         - name: modprobe-d
           hostPath:
             path: /etc/modprobe.d
-        - name: osrel
-          hostPath:
-            path: /etc/os-release
-            type: FileOrCreate
         - name: dshm
           emptyDir:
             medium: Memory
+        - name: etc-vol
+          hostPath:
+            path: /etc
         - name: dev-vol
           hostPath:
             path: /dev
@@ -259,11 +250,6 @@ spec:
         - name: varrun-vol
           hostPath:
             path: /var/run
-        {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
-        - name: etc-fs
-          hostPath:
-            path: /etc
-        {{- end }}
         {{- if (and (or .Values.ebpf.enabled .Values.gke.autopilot) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}


### PR DESCRIPTION
## What this PR does / why we need it:
After integrating falcosecurity/libs/pull/220, the agent can have an up-to-date users and groups list from `/etc/passwd` and `/etc/group`.
To have those files in the container we mount `/etc` in `/host/etc` and symlink them in the container `/etc`.
If we mount them individually, they will become stale in case of an inode change, which is what happens with `useradd`.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ]  Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.