### PR TITLE
[registry-scanner] Fix templating error (#545)

### DIFF
--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -5,6 +5,12 @@
 This file documents all notable changes to Sysdig Registry Scanner. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.0.32
+
+### Minor changes
+
+* Fix templating error
+
 ## v0.0.31
 
 ### Minor changes

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.0.31
+version: 0.0.32
 appVersion: 0.1.8
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/templates/cronjob.yaml
+++ b/charts/registry-scanner/templates/cronjob.yaml
@@ -23,10 +23,7 @@ spec:
         metadata:
           name: {{ include "registry-scanner.fullname" . }}
           labels:
-            app.kubernetes.io/name: {{ include "registry-scanner.name" . }}
-            app.kubernetes.io/instance: {{ .Release.Name }}
-            {{- include "registry-scanner.selectorLabels" . | nindent 12 }}
-            {{- include "registry-scanner.customLabels" . | nindent 12 }}
+            {{- include "registry-scanner.labels" . | nindent 12 }}
           {{- with .Values.podAnnotations }}
           annotations:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
## What this PR does / why we need it:
Hi!
This fixes templating error.
I try to install this chart with flux, but I get following error
```
  Warning  error   7s (x6 over 31s)  helm-controller  Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 29: mapping key "app.kubernetes.io/name" already defined at line 27
  line 30: mapping key "app.kubernetes.io/instance" already defined at line 28
```
Looks like selectorLabels that is valid for deployments in .spec.selector.matchLabels, accidentally got into a cronjob.

## Checklist

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped
- [x]  Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.