### PR TITLE
[Registry scanner] fix template

### DIFF
--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -9,7 +9,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 ### Minor changes
 
-* Fix duplicate labels in the CronJob template
+* Fix duplicate labels in the CronJob template (thanks @firaxis)
 
 ## v0.0.31
 

--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -5,12 +5,18 @@
 This file documents all notable changes to Sysdig Registry Scanner. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.0.32
+
+### Minor changes
+
+* Fix duplicate labels in the CronJob template
+
 ## v0.0.31
 
 ### Minor changes
 
 * Bump registry-scanner version to 0.1.8:
-  * Fix a race condition when using multiple workers
+* Fix a race condition when using multiple workers
 
 ## v0.0.30
 

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.0.31
+version: 0.0.32
 appVersion: 0.1.8
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/templates/cronjob.yaml
+++ b/charts/registry-scanner/templates/cronjob.yaml
@@ -23,9 +23,7 @@ spec:
         metadata:
           name: {{ include "registry-scanner.fullname" . }}
           labels:
-            app.kubernetes.io/name: {{ include "registry-scanner.name" . }}
-            app.kubernetes.io/instance: {{ .Release.Name }}
-            {{- include "registry-scanner.selectorLabels" . | nindent 12 }}
+            {{- include "registry-scanner.labels" . | nindent 12 }}
             {{- include "registry-scanner.customLabels" . | nindent 12 }}
           {{- with .Values.podAnnotations }}
           annotations:


### PR DESCRIPTION
## What this PR does / why we need it:

Fix thanks to @firaxis and https://github.com/sysdiglabs/charts/pull/545 that noticed that a set of labels was duplicate in the template and might cause the deployment to fail.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x]  Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.