### PR TITLE
[sysdig-deploy] Bump agent chart version

### DIFF
--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.1.9
+* Bumped agent to 1.5.12
+
 ## v1.1.8
 
 ### Minor Changes

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.1.8
+version: 1.1.9
 
 maintainers:
   - name: achandras
@@ -20,7 +20,7 @@ dependencies:
 - name: agent
   # repository: https://charts.sysdig.com
   repository: file://../agent
-  version: ~1.5.11
+  version: ~1.5.12
   alias: agent
   condition: agent.enabled
 - name: node-analyzer


### PR DESCRIPTION
Signed-off-by: Daniele De Lorenzi <daniele.delorenzi@sysdig.com>

## What this PR does / why we need it:
Bumped agent sub-chart version due to release of Agent 12.8.0, see:
https://github.com/sysdiglabs/charts/pull/554

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with chart name (e.g. [mychartname])
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ]  Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.