### PR TITLE
[agent][sysdig][sysdig-deploy] Revert "add /etc -> /host/etc volume bind (#542)"

### DIFF
--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 This file documents all notable changes to the Sysdig Agent Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.5.13
 
+### Minor changes
+* Reverted change for v1.5.10 that added /etc to /host/etc volume bind.
 ## v1.5.11
 
 ### Minor changes

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.12
+version: 1.5.13
 
 appVersion: 12.8.0
 

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -117,6 +117,9 @@ spec:
               name: sys-tracing
               readOnly: true
             {{- end }}
+            - mountPath: /host/etc/os-release
+              name: osrel
+              readOnly: true
       {{- end }}
       containers:
         - name: sysdig
@@ -172,9 +175,6 @@ spec:
               name: modprobe-d
               readOnly: true
             {{- end }}
-            - mountPath: /host/etc
-              name: etc-vol
-              readOnly: true
             - mountPath: /host/dev
               name: dev-vol
               readOnly: false
@@ -202,6 +202,11 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
+            {{- if (and (include "agent.ebpfEnabled" .) .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
+            - mountPath: /host/etc
+              name: etc-fs
+              readOnly: true
+            {{- end }}
             {{- if (and (or (include "agent.ebpfEnabled" .) .Values.gke.autopilot) .Values.slim.enabled) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -209,6 +214,9 @@ spec:
               name: sys-tracing
               readOnly: true
             {{- end }}
+            - mountPath: /host/etc/os-release
+              name: osrel
+              readOnly: true
             {{- if .Values.extraVolumes.mounts }}
 {{ toYaml .Values.extraVolumes.mounts | indent 12 }}
             {{- end }}
@@ -218,12 +226,13 @@ spec:
         - name: modprobe-d
           hostPath:
             path: /etc/modprobe.d
+        - name: osrel
+          hostPath:
+            path: /etc/os-release
+            type: FileOrCreate
         - name: dshm
           emptyDir:
             medium: Memory
-        - name: etc-vol
-          hostPath:
-            path: /etc
         - name: dev-vol
           hostPath:
             path: /dev
@@ -245,6 +254,11 @@ spec:
         - name: varrun-vol
           hostPath:
             path: /var/run
+        {{- if (and (include "agent.ebpfEnabled" .) .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
+        - name: etc-fs
+          hostPath:
+            path: /etc
+        {{- end }}
         {{- if (and (or (include "agent.ebpfEnabled" .) .Values.gke.autopilot) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.1.10
+* Bumped agent to 1.5.13
+
 ## v1.1.9
 * Bumped agent to 1.5.12
 

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.1.9
+version: 1.1.10
 
 maintainers:
   - name: achandras
@@ -20,7 +20,7 @@ dependencies:
 - name: agent
   # repository: https://charts.sysdig.com
   repository: file://../agent
-  version: ~1.5.12
+  version: ~1.5.13
   alias: agent
   condition: agent.enabled
 - name: node-analyzer

--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.15.25
+
+### Minor changes
+* reverted change made in v1.15.21 that added /etc to container /host/etc volume bind
 ## v1.15.24
 ### Minor changes
 * runtimeScanner: version 1.2.5 with fixes on ruby file analyzer

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.24
+version: 1.15.25
 appVersion: 12.8.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -118,6 +118,9 @@ spec:
               name: sys-tracing
               readOnly: true
             {{- end }}
+            - mountPath: /host/etc/os-release
+              name: osrel
+              readOnly: true
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -173,9 +176,6 @@ spec:
               name: modprobe-d
               readOnly: true
             {{- end }}
-            - mountPath: /host/etc
-              name: etc-vol
-              readOnly: true
             - mountPath: /host/dev
               name: dev-vol
               readOnly: false
@@ -203,6 +203,11 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
+            {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
+            - mountPath: /host/etc
+              name: etc-fs
+              readOnly: true
+            {{- end }}
             {{- if (and (or .Values.ebpf.enabled .Values.gke.autopilot) .Values.slim.enabled) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -214,6 +219,9 @@ spec:
             - mountPath: /opt/draios/lib/python/checks.custom.d
               name: custom-app-checks-volume
             {{- end }}
+            - mountPath: /host/etc/os-release
+              name: osrel
+              readOnly: true
             {{- if .Values.extraVolumes.mounts }}
 {{ toYaml .Values.extraVolumes.mounts | indent 12 }}
             {{- end }}
@@ -223,12 +231,13 @@ spec:
         - name: modprobe-d
           hostPath:
             path: /etc/modprobe.d
+        - name: osrel
+          hostPath:
+            path: /etc/os-release
+            type: FileOrCreate
         - name: dshm
           emptyDir:
             medium: Memory
-        - name: etc-vol
-          hostPath:
-            path: /etc
         - name: dev-vol
           hostPath:
             path: /dev
@@ -250,6 +259,11 @@ spec:
         - name: varrun-vol
           hostPath:
             path: /var/run
+        {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
+        - name: etc-fs
+          hostPath:
+            path: /etc
+        {{- end }}
         {{- if (and (or .Values.ebpf.enabled .Values.gke.autopilot) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}


### PR DESCRIPTION
This reverts commit bc96b33e7cef9da44957ec32244feac2cc66b6de.

## What this PR does / why we need it:

Change made by the above commit introduced issues in installing the slim-agent component on gke cluster both by old and new sysdig helm charts.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ]  Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.