### PR TITLE
Added proxy support for agent initContainer

### DIFF
--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to the Sysdig Agent Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.5.15
+
+### Minor changes
+* Introduced support to proxy for agent initContainer
+
 ## v1.5.14
 * Documentation fix slim-agent defaults to true
 
@@ -11,6 +16,7 @@ This file documents all notable changes to the Sysdig Agent Helm Chart. The rele
 
 ### Minor changes
 * Reverted change for v1.5.10 that added /etc to /host/etc volume bind.
+
 ## v1.5.11
 
 ### Minor changes

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.14
+version: 1.5.15
 
 appVersion: 12.8.0
 

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -97,6 +97,18 @@ spec:
             - name: "{{ $key }}"
               value: "{{ $value }}"
           {{- end }}
+          {{- if (.Values.proxy.httpProxy | default .Values.global.proxy.httpProxy) }}
+            - name: http_proxy
+              value: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy }}
+          {{- end }}
+          {{- if (.Values.proxy.httpsProxy | default .Values.global.proxy.httpsProxy) }}
+            - name: https_proxy
+              value: {{ .Values.proxy.httpsProxy | default .Values.global.proxy.httpsProxy }}
+          {{- end }}
+          {{- if (.Values.proxy.noProxy | default .Values.global.proxy.noProxy) }}
+            - name: no_proxy
+              value: {{ .Values.proxy.noProxy | default .Values.global.proxy.noProxy }}
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/modprobe.d
               name: modprobe-d

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.1.13
+* Bumped agent to 1.5.15
+
 ## v1.1.12
 * Bumped agent to 1.5.14
 

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.1.12
+version: 1.1.13
 
 maintainers:
   - name: achandras
@@ -20,7 +20,7 @@ dependencies:
 - name: agent
   # repository: https://charts.sysdig.com
   repository: file://../agent
-  version: ~1.5.14
+  version: ~1.5.15
   alias: agent
   condition: agent.enabled
 - name: node-analyzer

--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.15.26
+
+### Minor changes
+* Agent: Introduced support to proxy for agent initContainer
+
 ## v1.15.25
 
 ### Minor changes

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.25
+version: 1.15.26
 appVersion: 12.8.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -98,6 +98,18 @@ spec:
             - name: "{{ $key }}"
               value: "{{ $value }}"
           {{- end }}
+          {{- if .Values.proxy.httpProxy }}
+            - name: http_proxy
+              value: {{ .Values.proxy.httpProxy }}
+          {{- end }}
+          {{- if .Values.proxy.httpsProxy }}
+            - name: https_proxy
+              value: {{ .Values.proxy.httpsProxy }}
+          {{- end }}
+          {{- if .Values.proxy.noProxy }}
+            - name: no_proxy
+              value: {{ .Values.proxy.noProxy }}
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/modprobe.d
               name: modprobe-d


### PR DESCRIPTION
Signed-off-by: Daniele De Lorenzi <daniele.delorenzi@sysdig.com>

## What this PR does / why we need it:
This PR introduce the proxy support for agent initContainer, right know the proxy is added only for agent container but not for agent-kmodule so when a customer is using a proxy and agent-slim (which is default) the kernel module cannot be downloaded.

There is also an old PR with the same modification here:
https://github.com/sysdiglabs/charts/pull/326
but it's quite old so I did it from scratch

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Chart Version bumped
- [X]  Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.