### PR TITLE
ci: Enforce pre-commit step

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -16,13 +16,14 @@ jobs:
         with:
           version: v3.4.0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: ^1
+          go-version: '^1.18'
+          check-latest: true
 
       - name: Install pre-commit
         run: pip install pre-commit

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -18,7 +18,11 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.10
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1
 
       - name: Install pre-commit
         run: pip install pre-commit

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -20,6 +20,14 @@ jobs:
         with:
           python-version: 3.7
 
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Check pre-commit
+        run: |
+          pre-commit run -a --show-diff-on-failure
+          git clean -df .
+
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.0
 


### PR DESCRIPTION
## What this PR does / why we need it:

This enforces the pre-commit execution to keep the documentation sync.