### PR TITLE
ci: Mark inactive PRs and Issues as stale and close them automatically

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days'
+        stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        close-issue-message: 'This issue has been closed due to inactivity.'
+        close-pr-message: 'This PR has been closed due to inactivity.'


### PR DESCRIPTION
## What this PR does / why we need it:

Marks the PRs and Issues as Stale if they have been inactive for more than 60 days. It closes them after 7 days after being marked as stale.
This will ensure we don't have inactive PRs in this repository that could just add noise.