### PR TITLE
ci: Add cloud-native team CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,7 @@
 /charts/sysdig/         @achandras @yashgiri @lilx1ao
 /charts/agent/          @achandras @yashgiri @lilx1ao
 /charts/sysdig-deploy/  @achandras @yashgiri @lilx1ao
+
+/charts/admission-controller @sysdiglabs/cloud-native
+/charts/cloud-connector @sysdiglabs/cloud-native
+/charts/cloud-scanning @sysdiglabs/cloud-native


### PR DESCRIPTION
## What this PR does / why we need it:

This adds the Cloud Native Team to the CODEOWNERS file