### PR TITLE
[sysdig-deploy] update imageregistry flag

### DIFF
--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.3.3
+
+### Bugfix
+* Fix readme to refer to `global.imageRegistry`
+
 ## v1.3.2
 
 ### Minor changes

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.3.2
+version: 1.3.3
 
 maintainers:
   - name: achandras

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -170,7 +170,7 @@ The following table lists the configurable parameters of this chart and their de
 | `global.sysdig.accessKey`               | Sysdig Agent Access Key                                                                                                 | `""`      |
 | `global.sysdig.accessKeySecret`         | The name of a Kubernetes secret containing an 'access-key' entry.                                                       | `""`      |
 | `global.sysdig.region`                  | The SaaS region for these agents. Possible values: `"us1"`, `"us2"`, `"us3"`, `"us4"`, `"eu1"`, `"au1"`, and `"custom"`. See [Regions and IP Ranges](https://docs.sysdig.com/en/docs/administration/saas-regions-and-ip-ranges/) for more information. | `"us1"`   |
-| `global.image.registry`                 | Container image registry                                                                                                | `quay.io` |
+| `global.imageRegistry`                  | Container image registry                                                                                                | `quay.io` |
 | `global.proxy.httpProxy`                | Sets `http_proxy` on the Agent container                                                                                | `""`      |
 | `global.proxy.httpsProxy`               | Sets `https_proxy` on the Agent container                                                                               | `""`      |
 | `global.proxy.noProxy`                  | Sets `no_proxy` on the Agent container                                                                                  | `""`      |

--- a/charts/sysdig-deploy/values.yaml
+++ b/charts/sysdig-deploy/values.yaml
@@ -5,8 +5,7 @@ global:
     accessKey: ""
     accessKeySecret: ""
     region: "us1"
-  image:
-    registry: quay.io
+  imageRegistry: quay.io
   proxy: {}
   kspm:
     deploy: false


### PR DESCRIPTION
## What this PR does / why we need it:

We previously documented `global.image.registry` for the global image flag. Apparently it's actually `global.imageRegistry`.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x]  Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.