### PR TITLE
[sysdig][agent] add /etc -> /host/etc volume bind

### DIFF
--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to the Sysdig Agent Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.5.18
+
+### Minor changes
+* Added /etc to container and initContainer /host/etc volume bind
+
 ## v1.5.17
 
 ### Minor changes

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.17
+version: 1.5.18
 
 appVersion: 12.8.0
 

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -129,8 +129,8 @@ spec:
               name: sys-tracing
               readOnly: true
             {{- end }}
-            - mountPath: /host/etc/os-release
-              name: osrel
+            - mountPath: /host/etc
+              name: etc-vol
               readOnly: true
       {{- end }}
       containers:
@@ -187,6 +187,9 @@ spec:
               name: modprobe-d
               readOnly: true
             {{- end }}
+            - mountPath: /host/etc
+              name: etc-vol
+              readOnly: true
             - mountPath: /host/dev
               name: dev-vol
               readOnly: false
@@ -214,11 +217,6 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
-            {{- if (and (include "agent.ebpfEnabled" .) .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
-            - mountPath: /host/etc
-              name: etc-fs
-              readOnly: true
-            {{- end }}
             {{- if (and (or (include "agent.ebpfEnabled" .) .Values.gke.autopilot) .Values.slim.enabled) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -226,9 +224,6 @@ spec:
               name: sys-tracing
               readOnly: true
             {{- end }}
-            - mountPath: /host/etc/os-release
-              name: osrel
-              readOnly: true
             {{- if .Values.extraVolumes.mounts }}
 {{ toYaml .Values.extraVolumes.mounts | indent 12 }}
             {{- end }}
@@ -238,13 +233,12 @@ spec:
         - name: modprobe-d
           hostPath:
             path: /etc/modprobe.d
-        - name: osrel
-          hostPath:
-            path: /etc/os-release
-            type: FileOrCreate
         - name: dshm
           emptyDir:
             medium: Memory
+        - name: etc-vol
+          hostPath:
+            path: /etc
         - name: dev-vol
           hostPath:
             path: /dev
@@ -266,11 +260,6 @@ spec:
         - name: varrun-vol
           hostPath:
             path: /var/run
-        {{- if (and (include "agent.ebpfEnabled" .) .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
-        - name: etc-fs
-          hostPath:
-            path: /etc
-        {{- end }}
         {{- if (and (or (include "agent.ebpfEnabled" .) .Values.gke.autopilot) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.3.5
+
+### Minor changes
+* Added /etc to container and initContainer /host/etc volume bind
+
 ## v1.3.4
 
 ### Bugfix

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.3.4
+version: 1.3.5
 
 maintainers:
   - name: achandras
@@ -20,7 +20,7 @@ dependencies:
 - name: agent
   # repository: https://charts.sysdig.com
   repository: file://../agent
-  version: ~1.5.17
+  version: ~1.5.18
   alias: agent
   condition: agent.enabled
 - name: node-analyzer

--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.15.29
+
+### Minor changes
+* Added /etc to container and initContainer /host/etc volume bind
+
 ## v1.15.28
 
 ### Minor changes
@@ -18,6 +23,7 @@ This file documents all notable changes to Sysdig Helm Chart. The release number
 
 ### Minor changes
 * reverted change made in v1.15.21 that added /etc to container /host/etc volume bind
+
 ## v1.15.24
 ### Minor changes
 * runtimeScanner: version 1.2.5 with fixes on ruby file analyzer

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.28
+version: 1.15.29
 appVersion: 12.8.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -130,8 +130,8 @@ spec:
               name: sys-tracing
               readOnly: true
             {{- end }}
-            - mountPath: /host/etc/os-release
-              name: osrel
+            - mountPath: /host/etc
+              name: etc-vol
               readOnly: true
       {{- end }}
       containers:
@@ -188,6 +188,9 @@ spec:
               name: modprobe-d
               readOnly: true
             {{- end }}
+            - mountPath: /host/etc
+              name: etc-vol
+              readOnly: true
             - mountPath: /host/dev
               name: dev-vol
               readOnly: false
@@ -215,11 +218,6 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
-            {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
-            - mountPath: /host/etc
-              name: etc-fs
-              readOnly: true
-            {{- end }}
             {{- if (and (or .Values.ebpf.enabled .Values.gke.autopilot) .Values.slim.enabled) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -231,9 +229,6 @@ spec:
             - mountPath: /opt/draios/lib/python/checks.custom.d
               name: custom-app-checks-volume
             {{- end }}
-            - mountPath: /host/etc/os-release
-              name: osrel
-              readOnly: true
             {{- if .Values.extraVolumes.mounts }}
 {{ toYaml .Values.extraVolumes.mounts | indent 12 }}
             {{- end }}
@@ -243,13 +238,12 @@ spec:
         - name: modprobe-d
           hostPath:
             path: /etc/modprobe.d
-        - name: osrel
-          hostPath:
-            path: /etc/os-release
-            type: FileOrCreate
         - name: dshm
           emptyDir:
             medium: Memory
+        - name: etc-vol
+          hostPath:
+            path: /etc
         - name: dev-vol
           hostPath:
             path: /dev
@@ -271,11 +265,6 @@ spec:
         - name: varrun-vol
           hostPath:
             path: /var/run
-        {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.mountEtcVolume (not .Values.gke.autopilot)) }}
-        - name: etc-fs
-          hostPath:
-            path: /etc
-        {{- end }}
         {{- if (and (or .Values.ebpf.enabled .Values.gke.autopilot) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}


### PR DESCRIPTION
## What this PR does / why we need it:

This is re-revert that adds the etc volume mount back, which should allow eBPF to be built on GKE

Ref:
- https://github.com/sysdiglabs/charts/pull/542 (original)
- https://github.com/sysdiglabs/charts/pull/562 (revert)

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [ ]  Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.