### PR TITLE
[sysdig-deploy] Fix indentation in for install steps in README

### DIFF
--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.3.8
+
+### Minor changes
+* Fix indentation for install steps in README.md
+
 ## v1.3.7
 
 ### Minor changes

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.3.7
+version: 1.3.8
 
 maintainers:
   - name: achandras

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -48,48 +48,48 @@ Currently included components:
 
 4. Do one of the following:
 
-   - Using the release name `sysdig`, run the following snippet to install the release into the namespace `sysdig-agent`:
-
-    ```bash
-   helm install sysdig sysdig/sysdig-deploy \
-       --namespace sysdig-agent \
-       --set global.sysdig.accessKey=ACCESS_KEY \
-       --set global.sysdig.region=SAAS_REGION \
-       --set global.clusterConfig.name=CLUSTER_NAME
-    ```
-
-     **GKE Autopilot**: GKE Autopilot environments require an additional configuration parameter, `agent.gke.autopilot=true`, to install the Sysdig agent:
+    - Using the release name `sysdig`, run the following snippet to install the release into the namespace `sysdig-agent`:
 
       ```bash
-   helm install sysdig sysdig/sysdig-deploy \
-        --namespace sysdig-agent \
-        --set global.sysdig.accessKey=ACCESS_KEY \
-        --set global.sysdig.region=SAAS_REGION \
-        --set global.clusterConfig.name=CLUSTER_NAME \
-        --set agent.gke.autopilot=true \
-        --set agent.slim.enabled=false \
-        --set nodeAnalyzer.enabled=false
+      helm install sysdig sysdig/sysdig-deploy \
+          --namespace sysdig-agent \
+          --set global.sysdig.accessKey=ACCESS_KEY \
+          --set global.sysdig.region=SAAS_REGION \
+          --set global.clusterConfig.name=CLUSTER_NAME
+        ```
+
+      **GKE Autopilot**: GKE Autopilot environments require an additional configuration parameter, `agent.gke.autopilot=true`, to install the Sysdig agent:
+
+      ```bash
+      helm install sysdig sysdig/sysdig-deploy \
+          --namespace sysdig-agent \
+          --set global.sysdig.accessKey=ACCESS_KEY \
+          --set global.sysdig.region=SAAS_REGION \
+          --set global.clusterConfig.name=CLUSTER_NAME \
+          --set agent.gke.autopilot=true \
+          --set agent.slim.enabled=false \
+          --set nodeAnalyzer.enabled=false
       ```
 
 
-   - Install with a values file. 
+    - Install with a values file. 
 
-     To do so, create a new file `values.sysdig.yaml`:
+      To do so, create a new file `values.sysdig.yaml`:
 
-        ```yaml
-     global:
-       sysdig:
-         accessKey: ACCESS_KEY
-         region: SAAS_REGION
-       clusterConfig:
-         name: CLUSTER_NAME
-        ```
+       ```yaml
+       global:
+         sysdig:
+           accessKey: ACCESS_KEY
+           region: SAAS_REGION
+         clusterConfig:
+           name: CLUSTER_NAME
+       ```
 
-        and install it with:
+       and install it with:
 
-        ```bash
-     helm install -n sysdig-agent sysdig sysdig/sysdig-deploy -f values.sysdig.yaml
-        ```
+       ```bash
+       helm install -n sysdig-agent sysdig sysdig/sysdig-deploy -f values.sysdig.yaml
+       ```
 
 
 


### PR DESCRIPTION
## What this PR does / why we need it:
The indentation for step 4 of the install steps seems to be off by one space in some places. This leads to some of the code blocks being rendered inconsistently, specifically the example `values.sysdig.yaml` file. While this block render correctly on Github Pages, [README.md on GitHub itself](https://github.com/sysdiglabs/charts/blob/d8b5835a69b1b11376ddd69085432fe5c169841f/charts/sysdig-deploy/README.md#installation) shows improper indentation (putting `clusterConfig` at the same level as `global`. By fixing indentation, both the Github Markdown renderer and GitHub Pages show these code blocks correctly.

## Checklist

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [ ]  Check GithubAction checks (like lint) to avoid merge-check stoppers