### PR TITLE
[agent] Add kubectl rollout test with 5m timeout

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -61,4 +61,4 @@ jobs:
           k3s-version: v1.23.9+k3s1
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --upgrade

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -55,11 +55,10 @@ jobs:
             echo "::set-output name=changed::true"
           fi
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+      - name: Set up testing cluster
+        uses: jupyterhub/action-k3s-helm@v3
         with:
-          wait: 120s
-        if: steps.list-changed.outputs.changed == 'true'
+          k3s-version: v1.23.9+k3s1
 
       - name: Run chart-testing (install)
         run: ct install

--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -4,10 +4,15 @@
 
 This file documents all notable changes to the Sysdig Agent Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.5.22
+
+### Minor changes
+* Add deployment test to agent chart
+
 ## v1.5.21
 
 ### Minor changes
-* Moved the clusterrole's Ingresses resource in the networking.k8s.io group 
+* Moved the clusterrole's Ingresses resource in the networking.k8s.io group
 
 ## v1.5.19
 

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.21
+version: 1.5.22
 
 appVersion: 12.8.1
 

--- a/charts/agent/templates/tests/test-rollout.yaml
+++ b/charts/agent/templates/tests/test-rollout.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "agent.fullname" . }}-test-rollout"
+  labels:
+    helm.sh/chart: {{ include "agent.chart" . }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  serviceAccountName: {{ include "agent.serviceAccountName" . }}
+  containers:
+    - name: kubectl
+      image: {{ .Values.tests.image.repo }}:{{ .Values.tests.image.tag }}
+      imagePullPolicy: IfNotPresent
+      command:
+      - kubectl
+      args:
+      - rollout
+      - status
+      - daemonset/{{ include "agent.fullname" . }}
+      - -n
+      - {{ include "agent.namespace" . }}
+      - -w
+      - --timeout={{ .Values.tests.timeout }}
+  restartPolicy: Never

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -250,3 +250,9 @@ tolerations:
 
 leaderelection:
   enable: false
+
+tests:
+  timeout: 300s
+  image:
+    repo: bitnami/kubectl
+    tag: 1.24.4

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.3.14
+
+### Minor changes
+* Add deployment test to agent chart
+
 ## v1.3.13
 
 ### Minor changes
@@ -25,7 +30,7 @@ This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. Th
 
 ### Minor changes
 * Bumped nodeAnalyzer to 1.7.5
-* Bumped benchmark runner to 1.0.18.2 
+* Bumped benchmark runner to 1.0.18.2
 
 ## v1.3.8
 

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.3.13
+version: 1.3.14
 
 maintainers:
   - name: achandras
@@ -20,7 +20,7 @@ dependencies:
 - name: agent
   # repository: https://charts.sysdig.com
   repository: file://../agent
-  version: ~1.5.21
+  version: ~1.5.22
   alias: agent
   condition: agent.enabled
 - name: node-analyzer


### PR DESCRIPTION
## What this PR does / why we need it:

This adds a rudimentary test for the chart testing suite - `kubectl rollout status` with a timeout of 5 minutes.

Unfortunately, `kind` was not suitable for running the agent, so I switched the testing cluster to `k3s`. There should be no difference in actual use, and setup times for both are fairly similar.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ]  Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.