### PR TITLE
[node-analyzer, sysdig-deploy] Bump benchmark-runner image version

### DIFF
--- a/charts/node-analyzer/CHANGELOG.md
+++ b/charts/node-analyzer/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to Sysdig Node Analyzer Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.7.5
+### Minor changes
+* BenchmarkRunner: bump tag to 1.0.18.2
+
 ## v1.7.4
 ### Minor changes
 * RuntimeScanner: bumped to 1.2.6 with fix of ignoring the fix solution date of a vuln when no fix version is available

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.7.4
+version: 1.7.5
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -215,7 +215,7 @@ nodeAnalyzer:
 
     image:
       repository: sysdig/compliance-benchmark-runner
-      tag: 1.0.18.1
+      tag: 1.0.18.2
       digest:
       pullPolicy: IfNotPresent
 

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.3.10
+
+### Minor changes
+* Bumped nodeAnalyzer to 1.7.5
+* Bumped benchmark runner to 1.0.18.2 
+
 ## v1.3.8
 
 ### Minor changes

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.3.9
+version: 1.3.10
 
 maintainers:
   - name: achandras
@@ -26,7 +26,7 @@ dependencies:
 - name: node-analyzer
   # repository: https://charts.sysdig.com
   repository: file://../node-analyzer
-  version: ~1.7.4
+  version: ~1.7.5
   alias: nodeAnalyzer
   condition: nodeAnalyzer.enabled
 - name: kspm-collector


### PR DESCRIPTION
## What this PR does / why we need it:

Bump the benchmark-runner image version to the latest to fix vulnerabilities. Also bumps the version of the node-analyzer chart within the sysdig-deploy chart to ensure the latest version of this image is always used.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ]  Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.