### PR TITLE
[sysdig] move ingress between api groups

### DIFF
--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.15.32
+ ### Minor changes
+ * Moved the clusterrole's Ingresses resource to the networking.k8s.io group 
+
 ## v1.15.31
 ### Bugfixes
 * Don't mount /etc in GKE Autopilot

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.32
+version: 1.15.33
 appVersion: 12.8.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/clusterrole.yaml
+++ b/charts/sysdig/templates/clusterrole.yaml
@@ -58,6 +58,7 @@ rules:
       - networking.k8s.io
     resources:
       - networkpolicies
+      - ingresses
     verbs:
       - get
       - list
@@ -67,7 +68,6 @@ rules:
     resources:
       - daemonsets
       - deployments
-      - ingresses
       - replicasets
     verbs:
       - get


### PR DESCRIPTION
## What this PR does / why we need it:

Moved the clusterrole's Ingresses resource to the networking.k8s.io group 

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ]  Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.