### PR TITLE
[sysdig] Disable PSP on k8s 1.25.x

### DIFF
--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to the Sysdig Agent Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.5.25
+### Bugfix
+* Don't deploy psp policies on k8s 1.25.x
+
 ## v1.5.24
 ### Minor changes
 * Added a global gke autopilot flag

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.24
+version: 1.5.25
 
 appVersion: 12.8.1
 

--- a/charts/agent/templates/psp.yaml
+++ b/charts/agent/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.psp.create  }}
+{{- if and .Values.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/node-analyzer/CHANGELOG.md
+++ b/charts/node-analyzer/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to Sysdig Node Analyzer Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.7.16
+### Bugfix
+* Don't deploy psp policies on k8s 1.25.x
+
 ## v1.7.15
 ### Minor changes
 * RuntimeScanner:

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.7.15
+version: 1.7.16
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/psp.yaml
+++ b/charts/node-analyzer/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if not (include "nodeAnalyzer.gke.autopilot" .) }}
-{{- if .Values.psp.create  }}
+{{- if and .Values.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.3.18
+### Bugfix
+* Don't deploy psp policies on k8s 1.25.x
+
 ## v1.3.17
 ### Minor changes
 * Added a global gke autopilot flag

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.3.17
+version: 1.3.18
 
 maintainers:
   - name: achandras
@@ -20,13 +20,13 @@ dependencies:
 - name: agent
   # repository: https://charts.sysdig.com
   repository: file://../agent
-  version: ~1.5.24
+  version: ~1.5.25
   alias: agent
   condition: agent.enabled
 - name: node-analyzer
   # repository: https://charts.sysdig.com
   repository: file://../node-analyzer
-  version: ~1.7.13
+  version: ~1.7.16
   alias: nodeAnalyzer
   condition: nodeAnalyzer.enabled
 - name: kspm-collector

--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.15.41
+### Bugfix
+* Don't deploy psp policies on k8s 1.25.x
+
 ## v1.15.40
 ### Minor changes
 * RuntimeScanner:

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.40
+version: 1.15.41
 appVersion: 12.8.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/psp-node-analyzer.yaml
+++ b/charts/sysdig/templates/psp-node-analyzer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.psp.create  }}
+{{- if and .Values.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/sysdig/templates/psp.yaml
+++ b/charts/sysdig/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.psp.create  }}
+{{- if and .Values.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
## What this PR does / why we need it:
This PR disable the deploy of PSP's when running on Kubernetes 1.25.x

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with chart name (e.g. [mychartname])
- [X] Chart Version bumped for the respective charts
- [X] Changelog updated for the charts with version updates.
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.