### PR TITLE
[ci] Add job for publishing to vmware tanzu marketplace

### DIFF
--- a/.github/workflows/update-tanzu.yaml
+++ b/.github/workflows/update-tanzu.yaml
@@ -1,0 +1,41 @@
+name: Publish Sysdig-deploy to VM
+
+on:
+  push:
+    tags:
+    - 'sysdig-deploy*'
+
+env:
+  MKPCLI_VERSION: 0.14.1
+
+jobs:
+  publish-chart:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get name from tag
+      id: tag_name
+      env:
+        TAG_REF: ${{ github.ref }}
+      run: |
+        echo "::set-output name=name::${TAG_REF#refs/tags/}"
+        echo "::set-output name=version::${TAG_REF#refs/tags/sysdig-deploy-}"
+
+    - name: Set up mkpcli
+      run: |
+        curl -LO https://github.com/vmware-labs/marketplace-cli/releases/download/v${MKPCLI_VERSION}/mkpcli-linux-amd64.tgz
+        tar xvf mkpcli-linux-amd64.tgz
+        chmod +x mkpcli
+
+    - name: Publish chart version
+      env:
+        TAG_NAME: ${{ steps.tag_name.outputs.name }}
+        VERSION: ${{ steps.tag_name.outputs.version }}
+        CSP_API_TOKEN: ${{ secrets.CSP_API_TOKEN }}
+      run: |
+        ./mkpcli attach chart \
+          -p sysdig-agent-helm-chart \
+          -c https://github.com/sysdiglabs/charts/releases/download/${TAG_NAME}/${TAG_NAME}.tgz \
+          -v ${VERSION} \
+          --create-version \
+          --instructions "https://charts.sysdig.com/charts/sysdig-deploy/" \
+          --csp-api-token ${CSP_API_TOKEN}


### PR DESCRIPTION
## What this PR does / why we need it:

This uses the VMWare marketplace cli to publish new releases of sysdig-deploy.

Tested locally with nektos/act to publish sysdig-deploy-1.3.14:
<img width="266" alt="Screen Shot 2022-09-28 at 1 48 28 PM" src="https://user-images.githubusercontent.com/42815627/192853236-c8c76035-1bc8-4199-beca-f11dd4df5f6c.png">
