### PR TITLE
CI lint-test k3s testing cluster created instead of kind

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -55,11 +55,10 @@ jobs:
             echo "::set-output name=changed::true"
           fi
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+      - name: Create testing cluster
+        uses: jupyterhub/action-k3s-helm@v3
         with:
-          wait: 120s
-        if: steps.list-changed.outputs.changed == 'true'
+          k3s-version: v1.23.9+k3s1
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --upgrade

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+
 ## v1.3.19
 ### Bug fix
 * node-analyzer readme held incorrect values for runtimeScanner resources

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
-
+## v1.3.20
+* CI workflow testing with kind cluster replaced with k3s.
 ## v1.3.19
 ### Bug fix
 * node-analyzer readme held incorrect values for runtimeScanner resources

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.3.19
+version: 1.3.20
 
 maintainers:
   - name: achandras


### PR DESCRIPTION
## What this PR does / why we need it:

This PR reverts one of the code changes made in PR - https://github.com/sysdiglabs/charts/pull/638, which was determined to be causing many issues in the CI workflow and blocking new commits.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped for the respective charts
- [x] Changelog updated for the charts with version updates.
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.