### PR TITLE
[harbor-scanner-sysdig-secure] Introduced customEntryPoint

### DIFF
--- a/charts/harbor-scanner-sysdig-secure/CHANGELOG.md
+++ b/charts/harbor-scanner-sysdig-secure/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Chart: Harbor Scanner for Sysdig Secure
+
+## Change Log
+
+## v0.3.3
+
+### Feature
+
+* Introduced the possibility to specify a customEntryPoint
+
+## v0.3.2
+
+### Feature
+
+* Introduced the possibility to specify podAnnotations
+
+## v0.3.1
+
+### Feature
+
+* Introduced support to external secrets

--- a/charts/harbor-scanner-sysdig-secure/Chart.yaml
+++ b/charts/harbor-scanner-sysdig-secure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: harbor-scanner-sysdig-secure
 description: Harbor Scanner for Sysdig Secure
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: 0.5.0
 home: https://github.com/sysdiglabs/harbor-scanner-sysdig-secure
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/harbor-scanner-sysdig-secure/README.md
+++ b/charts/harbor-scanner-sysdig-secure/README.md
@@ -32,6 +32,7 @@ Sysdig Secure chart and their default values:
 
 | Parameter                                     | Description                                                                                                                 | Default                                   |
 | ---                                           | ---                                                                                                                         | ---                                       |
+| `customEntryPoint`                            | Ovverride container entrypoint                                                                                              | `[]`                                      |
 | `replicaCount`                                | Amount of replicas for Scanner Adapter                                                                                      | `1`                                       |
 | `image.repository`                            | The image repository to pull from                                                                                           | `sysdiglabs/harbor-scanner-sysdig-secure` |
 | `image.pullPolicy`                            | The image pull policy                                                                                                       | `IfNotPresent`                            |

--- a/charts/harbor-scanner-sysdig-secure/templates/deployment.yaml
+++ b/charts/harbor-scanner-sysdig-secure/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.customEntryPoint }}
+          command: {{ .Values.customEntryPoint | toYaml | nindent 10 }}
+          {{- end }}
           env:
             - name: SECURE_URL
               valueFrom:

--- a/charts/harbor-scanner-sysdig-secure/values.yaml
+++ b/charts/harbor-scanner-sysdig-secure/values.yaml
@@ -59,6 +59,9 @@ tolerations: []
 
 affinity: {}
 
+# Custom entrypoint for the harbor plugin
+customEntryPoint: []
+
 sysdig:
   secure:
 


### PR DESCRIPTION
Signed-off-by: Daniele De Lorenzi <daniele.delorenzi@sysdig.com>

## What this PR does / why we need it:
This PR introduce the possibility to override the container entryPoint via `values.yaml file`, it's useful when you're using for example HashiCorp Vault for inject the secrets, ex:
```
customEntryPoint: ["/bin/sh", "-c", "source /vault/secrets/secret-file && /<path-to-entrypoint.sh>"]
```
I have created also the changelog file which was missing for this chart

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with chart name (e.g. [mychartname])
- [X] Chart Version bumped for the respective charts
- [x] Changelog updated for the charts with version updates.
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.