### PR TITLE
[sysdig-deploy] Bump nodeAnalyzer version

### DIFF
--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.3.26
+### Minor changes
+* node-analyzer bumping version to 1.7.23
+
 ## v1.3.25
 ### Minor changes
 * RapidResponse:

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.3.25
+version: 1.3.26
 
 maintainers:
   - name: achandras
@@ -26,7 +26,7 @@ dependencies:
 - name: node-analyzer
   # repository: https://charts.sysdig.com
   repository: file://../node-analyzer
-  version: ~1.7.18
+  version: ~1.7.23
   alias: nodeAnalyzer
   condition: nodeAnalyzer.enabled
 - name: kspm-collector


### PR DESCRIPTION
Signed-off-by: Daniele De Lorenzi <daniele.delorenzi@sysdig.com>

## What this PR does / why we need it:
PR #665 bump the version of node-analyzer chart for the new runtime scanner but on sysdig-deploy the new version of this chart has not been included. As side effect customer would not get the latest version of that chart.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with chart name (e.g. [mychartname])
- [X] Chart Version bumped for the respective charts
- [X] Changelog updated for the charts with version updates.
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.