### PR TITLE
[sysdig-deploy] docs: fix 404 for migrate helper script link in charts.sysdig.com

### DIFF
--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.3.34
+### Minor changes
+* sysdig-deploy:
+    * Fix migrate_values.py link
+
 ## v1.3.33
 ### Minor changes
 * Bumped agent to 1.5.29 to include the usage of global.sysdig.tags

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.3.33
+version: 1.3.34
 
 maintainers:
   - name: aroberts87
@@ -17,27 +17,27 @@ home: https://www.sysdig.com/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
 
 dependencies:
-- name: agent
-  # repository: https://charts.sysdig.com
-  repository: file://../agent
-  version: ~1.5.29
-  alias: agent
-  condition: agent.enabled
-- name: node-analyzer
-  # repository: https://charts.sysdig.com
-  repository: file://../node-analyzer
-  version: ~1.7.27
-  alias: nodeAnalyzer
-  condition: nodeAnalyzer.enabled
-- name: kspm-collector
-  # repository: https://charts.sysdig.com
-  repository: file://../kspm-collector
-  version: ~0.1.13
-  alias: kspmCollector
-  condition: global.kspm.deploy
-- name: rapid-response
-  # repository: https://charts.sysdig.com
-  repository: file://../rapid-response
-  version: ~0.2.3
-  alias: rapidResponse
-  condition: rapidResponse.enabled
+  - name: agent
+    # repository: https://charts.sysdig.com
+    repository: file://../agent
+    version: ~1.5.29
+    alias: agent
+    condition: agent.enabled
+  - name: node-analyzer
+    # repository: https://charts.sysdig.com
+    repository: file://../node-analyzer
+    version: ~1.7.27
+    alias: nodeAnalyzer
+    condition: nodeAnalyzer.enabled
+  - name: kspm-collector
+    # repository: https://charts.sysdig.com
+    repository: file://../kspm-collector
+    version: ~0.1.13
+    alias: kspmCollector
+    condition: global.kspm.deploy
+  - name: rapid-response
+    # repository: https://charts.sysdig.com
+    repository: file://../rapid-response
+    version: ~0.2.3
+    alias: rapidResponse
+    condition: rapidResponse.enabled

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -73,7 +73,7 @@ Currently included components:
       ```
 
 
-    - Install with a values file. 
+    - Install with a values file.
 
       To do so, create a new file `values.sysdig.yaml`:
 
@@ -96,7 +96,7 @@ Currently included components:
 
 ## Migrating from `sysdig` chart
 
-To easily migrate from the previous `sysdig` chart to the new unified `sysdig-deploy` chart, use the [migration helper script](scripts/migrate_values.py) from this repo. This script will help re-map your existing values from the `sysdig` chart, allowing you to deploy this chart with the exact same configuration.
+To easily migrate from the previous `sysdig` chart to the new unified `sysdig-deploy` chart, use the [migration helper script](https://raw.githubusercontent.com/sysdiglabs/charts/master/charts/sysdig-deploy/scripts/migrate_values.py) from this repo. This script will help re-map your existing values from the `sysdig` chart, allowing you to deploy this chart with the exact same configuration.
 
 *Note*: unlike the previous chart, this chart only supports Helm 3. If you have not already done so, please upgrade your Helm version to 3.x to use this chart.
 


### PR DESCRIPTION
## What this PR does / why we need it:
At the moment the docs rendered in https://charts.sysdig.com/charts/sysdig-deploy/ has a [broken link](https://charts.sysdig.com/charts/sysdig-deploy/scripts/migrate_values.py) to the `migrate_values.py` script

This PR should fix that.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped for the respective charts
- [x] Changelog updated for the charts with version updates.
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.