### PR TITLE
[sysdig-deploy] Fixed Rapid Response and KSPM Collector links that were not working

### DIFF
--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Change Log
 
+## v1.3.40
+### Minor changes:
+* sysdig-deploy:
+    * Updated readme.md file
+
 ## v1.3.39
 ### Minor changes:
 * node-analyzer: 

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.3.39
+version: 1.3.40
 
 maintainers:
   - name: aroberts87

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -188,9 +188,9 @@ The following table lists the configurable parameters of this chart and their de
 | `nodeAnalyzer`                          | Config specific to the [Sysdig nodeAnalyzer](#nodeAnalyzer)                                                             | `{}`      |
 | `nodeAnalyzer.enabled`                  | Enable the nodeAnalyzer component in this chart                                                                         | `true`    |
 | `nodeAnalyzer.nodeAnalyzer.apiEndpoint` | nodeAnalyzer apiEndpoint                                                                                                | `""`      |
-| `kspmCollector`                         | Config specific to the [Sysdig KSPM Collector](#kspm collector)                                                         | `{}`      |
+| `kspmCollector`                         | Config specific to the [Sysdig KSPM Collector](#kspm-collector)                                                         | `{}`      |
 | `kspmCollector.apiEndpoint`             | kspmCollector apiEndpoint                                                                                               | `""`      |
-| `rapidResponse`                         | Config specific to [Sysdig Rapid Response](#rapid response)                                                             | `{}`      |
+| `rapidResponse`                         | Config specific to [Sysdig Rapid Response](#rapid-response)                                                             | `{}`      |
 | `rapidResponse.enabled`                 | Enable Rapid Response component in this chart                                                                           | `""`      |
 
 ## Agent


### PR DESCRIPTION
Signed-off-by: Daniele De Lorenzi <daniele.delorenzi@sysdig.com>

## What this PR does / why we need it:
Fixed the links to Rapid Response and KSPM instructions (they were not clickable as you can see from the screenshot)
![Screenshot 2022-11-09 at 16 25 50](https://user-images.githubusercontent.com/2905124/200873007-50638a38-30ae-4909-b101-a6c3f7c83162.png)


## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with chart name (e.g. [mychartname])
- [X] Chart Version bumped for the respective charts
- [X] Changelog updated for the charts with version updates.
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.