### PR TITLE
[sysdig-deploy] Bump sysdig-deploy version due to new Node Analyzer release

### DIFF
--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Change Log
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+## v1.4.1
+### Minor changes:
+* node-analyzer bumping version to 1.7.32
+
 ## v1.4.0
 ### Major changes:
 * sysdig-deploy:

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.4.0
+version: 1.4.1
 
 maintainers:
   - name: aroberts87
@@ -32,7 +32,7 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.7.31
+    version: ~1.7.32
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: kspm-collector


### PR DESCRIPTION
Signed-off-by: Daniele De Lorenzi <daniele.delorenzi@sysdig.com>

## What this PR does / why we need it:
Updated Node Analyser dependency after merging https://github.com/sysdiglabs/charts/pull/696
## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with chart name (e.g. [mychartname])
- [X] Chart Version bumped for the respective charts
- [X] Changelog updated for the charts with version updates.
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.