### PR TITLE
[sysdig-deploy] Update mantainers and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # request review from agent team members for changes to sysdig chart
-/charts/sysdig/         @aroberts87 @yashgiri @lilx1ao
-/charts/agent/          @aroberts87 @yashgiri @lilx1ao
-/charts/sysdig-deploy/  @aroberts87 @yashgiri @lilx1ao
+/charts/sysdig/         @aroberts87 @ironashram @yashgiri @lilx1ao
+/charts/agent/          @aroberts87 @ironashram @yashgiri @lilx1ao
+/charts/sysdig-deploy/  @aroberts87 @ironashram @yashgiri @lilx1ao
 
 /charts/admission-controller @sysdiglabs/cloud-native
 /charts/cloud-connector @sysdiglabs/cloud-native

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Change Log
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+## v1.4.2
+### Minor changes
+* Add ironashram to chart maintainers
+
 ## v1.4.1
 ### Minor changes:
 * node-analyzer bumping version to 1.7.32

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,11 +4,13 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.4.1
+version: 1.4.2
 
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com
+  - name: ironashram
+    email: michele.palazzi@sysdig.com
   - name: lilx1ao
     email: zhongcheng.xiao@sysdig.com
   - name: yashgiri


### PR DESCRIPTION
Signed-off-by: Michele Palazzi <michele.palazzi@sysdig.com>

## What this PR does / why we need it:

Add ironashram to mantainers in sysdig-deploy and bump version
Add ironashram to CODEOWNERS

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped for the respective charts
- [x] Changelog updated for the charts with version updates.
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.