### PR TITLE
[kspm-collector][sysdig-deploy] Implement imagePullSecrets on kspm-collector chart

### DIFF
--- a/charts/kspm-collector/CHANGELOG.md
+++ b/charts/kspm-collector/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.15
+### Feature
+* Add imagePullSecret flag for kspm-collector
+
 # v0.1.14
 ### Minor chagnes
 * Bumped image tag to 1.11.0

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.1.14
+version: 0.1.15
 appVersion: 1.11.0
 keywords:
   - monitoring

--- a/charts/kspm-collector/README.md
+++ b/charts/kspm-collector/README.md
@@ -37,9 +37,10 @@ The following table lists the configurable parameters of the Sysdig KSPM Collect
 | `clusterName`                    | Set a cluster name to identify events using *kubernetes.cluster.name* tag               | ` `                                                         |
 | `image.registry`                 | KSPM Collector image registry                                                           | `quay.io`                                                   |
 | `image.repository`               | The image repository to pull from                                                       | `sysdig/kspm-collector`                                     |
-| `image.tag`                      | The image tag to pull                                                                   | `1.11.0`                                                     |
+| `image.tag`                      | The image tag to pull                                                                   | `1.11.0`                                                    |
 | `image.digest`                   | The image digest to pull                                                                | ` `                                                         |
 | `image.pullPolicy`               | The Image pull policy                                                                   | `Always`                                                    |
+| `imagePullSecrets`               | The Image pull secret                                                                   | `[]`                                                        |
 | `replicas`                       | KSPM collector deployment replicas                                                      | `1`                                                         |
 | `namespaces.included`            | Namespaces to include in the KSPM collector scans, when empty scans all                 | ``                                                          |
 | `namespaces.excluded`            | Namespaces to exclude in the KSPM collector scans                                       | ``                                                          |

--- a/charts/kspm-collector/templates/deployment.yaml
+++ b/charts/kspm-collector/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
         operator: Equal
         value: arm64
         effect: NoSchedule
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ include "kspmCollector.name" . }}
         image: {{ template "kspmCollector.image.kspmCollector" . }}

--- a/charts/kspm-collector/values.yaml
+++ b/charts/kspm-collector/values.yaml
@@ -44,6 +44,12 @@ image:
   registry: quay.io
   pullPolicy: Always
 
+# Set image pull secret name
+# Example
+# imagePullSecrets:
+#   - name: my-super-secret-pull
+imagePullSecrets: []
+
 rbac:
   # true here enables creation of rbac resources
   create: true

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Change Log
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+## v1.4.3
+### Feature
+* Add imagePullSecret flag for kspm-collector
+
 ## v1.4.2
 ### Minor changes
 * Add ironashram to chart maintainers

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -3,9 +3,14 @@
 ## Change Log
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
-## v1.4.3
+## v1.4.4
 ### Feature
 * Add imagePullSecret flag for kspm-collector
+
+## v1.4.3
+### Minor changes
+* admission-controller:
+    * Fix bug while using secureAPITokenSecret, removed hard requirement for secureAPIToken
 
 ## v1.4.2
 ### Minor changes

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.4.2
+version: 1.4.3
 
 maintainers:
   - name: aroberts87
@@ -40,7 +40,7 @@ dependencies:
   - name: kspm-collector
     # repository: https://charts.sysdig.com
     repository: file://../kspm-collector
-    version: ~0.1.14
+    version: ~0.1.15
     alias: kspmCollector
     condition: global.kspm.deploy
   - name: rapid-response

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.4.3
+version: 1.4.4
 
 maintainers:
   - name: aroberts87


### PR DESCRIPTION
## What this PR does / why we need it:
Added the possibility of specifying an `imagePullSecrets` for kspm-collector chart. This will allow users to being able to host kspm collector image on a registry that requires authentication.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with chart name (e.g. [mychartname])
- [X] Chart Version bumped for the respective charts
- [X] Changelog updated for the charts with version updates.
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.