### PR TITLE
Improve CI to allow PR from forks

### DIFF
--- a/.github/workflows/approve-test-run.yaml
+++ b/.github/workflows/approve-test-run.yaml
@@ -1,0 +1,23 @@
+# If someone with write access comments "/approve-test-run" on a pull request, emit a repository_dispatch event
+name: Approve Test Run
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  approve-test-run:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request }}
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v1
+        with:
+          token: ${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          commands: approve-test-run
+          named-args: true
+          permission: write

--- a/.github/workflows/helm-unit-test.yaml
+++ b/.github/workflows/helm-unit-test.yaml
@@ -1,0 +1,35 @@
+name: Helm Unit Tests
+
+on: pull_request
+
+jobs:
+  Unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - name: Set up helm unit test plugin
+        run: helm plugin install https://github.com/quintush/helm-unittest
+
+      - name: Test node-analyzer
+        run: helm unittest --helm3 ./charts/node-analyzer
+
+      - name: Test agent
+        run: helm unittest --helm3 ./charts/agent
+
+      - name: Test kspm-collector
+        run: helm unittest --helm3 ./charts/kspm-collector
+
+      - name: Test rapid-response
+        run: helm unittest --helm3 ./charts/rapid-response
+
+      - name: Test admission-controller
+        run: helm unittest --helm3 ./charts/admission-controller/

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,10 +1,14 @@
 name: Lint and Test Charts
 
-on: pull_request
+on:
+  pull_request:
+  repository_dispatch:
+    types: [approve-test-run-command]
 
 jobs:
-  lint-test:
+  lint-test-branch:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -18,11 +22,11 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: "^1.18"
           check-latest: true
 
       - name: Install pre-commit
@@ -62,39 +66,97 @@ jobs:
 
       - name: Run chart-testing (install)
         run: ct install --upgrade
-  Unit-tests:
+
+  lint-test-fork:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    if: github.event_name == 'repository_dispatch' &&
+      github.event.client_payload.slash_command.sha != '' &&
+      contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.sha)
     steps:
-      - name: Checkout
+      - name: Fork based /approve-test-run checkout
         uses: actions/checkout@v2
         with:
+          ref: "refs/pull/${{ github.event.client_payload.pull_request.number }}/merge"
           fetch-depth: 0
-      
+
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
           version: v3.4.0
 
-      - name: Set up helm unit test plugin
-        run: helm plugin install https://github.com/quintush/helm-unittest
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
-      - name: Update dependencies for sysdig-deploy
-        run: helm dep update charts/sysdig-deploy
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "^1.18"
+          check-latest: true
 
-      - name: Test sysdig-deploy
-        run: helm unittest --helm3 ./charts/sysdig-deploy
+      - name: Install pre-commit
+        run: pip install pre-commit
 
-      - name: Test node-analyzer
-        run: helm unittest --helm3 ./charts/node-analyzer
+      - name: Check pre-commit
+        run: |
+          pre-commit run -a --show-diff-on-failure
+          git clean -df .
 
-      - name: Test agent
-        run: helm unittest --helm3 ./charts/agent
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.0
 
-      - name: Test kspm-collector
-        run: helm unittest --helm3 ./charts/kspm-collector
+      - name: Expand templates for CI
+        run: |
+          find -iname "*.yaml.template" | xargs -L1 -- bash -c 'envsubst < $0 > ${0%.template}'
+        shell: bash
+        env:
+          SECURE_API_TOKEN: ${{ secrets.KUBELAB_SECURE_API_TOKEN }}
+          SECURE_AGENT_TOKEN: ${{ secrets.KUBELAB_AGENT_KEY }}
 
-      - name: Test rapid-response
-        run: helm unittest --helm3 ./charts/rapid-response
+      - name: Run chart-testing (lint)
+        run: ct lint
 
-      - name: Test admission-controller
-        run: helm unittest --helm3 ./charts/admission-controller/
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Create testing cluster
+        uses: jupyterhub/action-k3s-helm@v3
+        with:
+          k3s-version: v1.23.9+k3s1
+
+      - name: Run chart-testing (install)
+        run: ct install --upgrade
+
+      - uses: actions/github-script@v5
+        id: update-check-run
+        if: ${{ always() }}
+        env:
+          number: ${{ github.event.client_payload.pull_request.number }}
+          job: ${{ github.job }}
+          conclusion: ${{ job.status }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: process.env.number
+            });
+            const ref = pull.head.sha;
+            const { data: checks } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref
+            });
+            const check = checks.check_runs.filter(c => c.name === process.env.job);
+            const { data: result } = await github.rest.checks.update({
+              ...context.repo,
+              check_run_id: check[0].id,
+              status: 'completed',
+              conclusion: process.env.conclusion
+            });
+            return result;


### PR DESCRIPTION
Signed-off-by: Michele Palazzi <michele.palazzi@sysdig.com>

## What this PR does / why we need it:

The idea is to avoid a cryptic CI failure in case a PR is opened from a fork of this repo.
Still Needs more testing

**Branch PR**
All checks will run immediately (no change)

**External Fork PR**
Helm Unit tests will run automatically since they do not require secrets
The Lint and Test Charts will be skipped, then if someone with write access to this repo adds a comment `/approve-test-run sha=CommitSHA` a `repository_dispatch` will trigger the workflow which in this case will work since it will have access to secrets and it will checkout `"refs/pull/${{ github.event.client_payload.pull_request.number }}/merge"`

This should improve our way of handling contributions from forks without security concerns

One downside is that right now it's not D.R.Y., an option to consider could be leveraging the reusable workflows https://docs.github.com/en/actions/using-workflows/reusing-workflows

Based on https://github.com/imjohnbo/ok-to-test

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Title of the PR starts with chart name (e.g. [mychartname])
- [ ] Chart Version bumped for the respective charts
- [ ] Changelog updated for the charts with version updates.
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.