### PR TITLE
[admission-controller] fix: Remove strict requirement for secureAPIToken

### DIFF
--- a/charts/admission-controller/CHANGELOG.md
+++ b/charts/admission-controller/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Change Log
 
 This file documents all notable changes to the Admission Controller Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+## v0.7.1
+### Minor changes
+
+* Fix bug while using secureAPITokenSecret, removed hard requirement for secureAPIToken
 
 ## v0.7.0
 ### Major changes

--- a/charts/admission-controller/CHANGELOG.md
+++ b/charts/admission-controller/CHANGELOG.md
@@ -5,7 +5,6 @@
 This file documents all notable changes to the Admission Controller Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 ## v0.7.1
 ### Minor changes
-
 * Fix bug while using secureAPITokenSecret, removed hard requirement for secureAPIToken
 
 ## v0.7.0

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: 3.9.11
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.7.0  \
+      --create-namespace -n sysdig-admission-controller --version=0.7.1  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.url=SECURE_URL \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
@@ -56,7 +56,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.0
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.1
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -175,7 +175,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.0 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.1 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,sysdig.url=SECURE_URL,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -184,7 +184,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.0 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.1 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/templates/_helpers.tpl
+++ b/charts/admission-controller/templates/_helpers.tpl
@@ -244,7 +244,7 @@ The following helper functions are all designed to use global values where
 possible, but accept overrides from the chart values.
 */}}
 {{- define "sysdig.secureAPIToken" -}}
-    {{- required "A valid secureAPIToken is required" (.Values.sysdig.secureAPIToken | default .Values.global.sysdig.secureAPIToken) -}}
+    {{- .Values.sysdig.secureAPIToken | default .Values.global.sysdig.secureAPIToken -}}
 {{- end -}}
 
 {{- define "sysdig.secureAPITokenSecret" -}}

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Change Log
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+## v1.4.3
+### Minor changes
+* admission-controller:
+    * Fix bug while using secureAPITokenSecret, removed hard requirement for secureAPIToken
+
 ## v1.4.2
 ### Minor changes
 * Add ironashram to chart maintainers

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.4.2
+version: 1.4.3
 
 maintainers:
   - name: aroberts87
@@ -22,7 +22,7 @@ dependencies:
   - name: admission-controller
     # repository: https://charts.sysdig.com
     repository: file://../admission-controller
-    version: ~0.7.0
+    version: ~0.7.1
     alias: admissionController
     condition: admissionController.enabled
   - name: agent


### PR DESCRIPTION
## What this PR does / why we need it:

Fix bug introduced with latest changes, it was not possible to use secureAPITokenSecret

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped for the respective charts
- [x] Changelog updated for the charts with version updates.
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.