### PR TITLE
[sysdig-deploy][admission-controller] Add Secure API token validation for Admission Controller

### DIFF
--- a/charts/admission-controller/CHANGELOG.md
+++ b/charts/admission-controller/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Change Log
 
 This file documents all notable changes to the Admission Controller Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+## v0.7.2
+### Minor changes
+* Add proper validation check for Secure API Token
+
 ## v0.7.1
 ### Minor changes
 * Fix bug while using secureAPITokenSecret, removed hard requirement for secureAPIToken

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.7.1
+version: 0.7.2
 appVersion: 3.9.11
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.7.1  \
+      --create-namespace -n sysdig-admission-controller --version=0.7.2  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.url=SECURE_URL \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
@@ -56,7 +56,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.1
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.2
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -175,7 +175,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.1 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.2 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,sysdig.url=SECURE_URL,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -184,7 +184,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.1 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.2 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/templates/NOTES.txt
+++ b/charts/admission-controller/templates/NOTES.txt
@@ -1,4 +1,6 @@
+Validating Admission Controller Secure API Token configuration:
 {{- if (include "admissionController.validTokenConfig" .) }}
+Success!
 {{- end }}
 
 Sysdig Admission Controller is now installed!

--- a/charts/admission-controller/templates/NOTES.txt
+++ b/charts/admission-controller/templates/NOTES.txt
@@ -1,4 +1,5 @@
-{{- include "admissionController.validTokenConfig" . }}
+{{- if (include "admissionController.validTokenConfig" .) }}
+{{- end }}
 
 Sysdig Admission Controller is now installed!
 Confirm its working status https://charts.sysdig.com/charts/admission-controller/#confirm-working-status

--- a/charts/admission-controller/templates/NOTES.txt
+++ b/charts/admission-controller/templates/NOTES.txt
@@ -1,16 +1,11 @@
+{{- include "admissionController.validTokenConfig" . }}
+
 Sysdig Admission Controller is now installed!
 Confirm its working status https://charts.sysdig.com/charts/admission-controller/#confirm-working-status
-{{- if not (or .Values.sysdig.existingSecureAPITokenSecret .Values.sysdig.secureAPIToken) }}
 ================================================================================================
-Warning: the Sysdig Secure API Token was not provided with either the `sysdig.secureAPIToken` or
-`sysdig.existingSecureAPITokenSecret` values.
 
-This deployment may not work correctly unless the token is provided through the SECURE_API_TOKEN
-environment variable, which is up to the final user to decide how to configure.
 {{- if .Values.scanner.enabled }}
-
 The Scanner also needs the AUTH_BEARER_TOKEN environment variable configured with the valid
 Secure API Token.
-{{- end }}
 ================================================================================================
 {{- end }}

--- a/charts/admission-controller/templates/_helpers.tpl
+++ b/charts/admission-controller/templates/_helpers.tpl
@@ -239,6 +239,8 @@ Allow overriding registry and repository for air-gapped environments
 {{- end -}}
 {{- end -}}
 
+
+
 {{/*
 The following helper functions are all designed to use global values where
 possible, but accept overrides from the chart values.
@@ -277,4 +279,14 @@ possible, but accept overrides from the chart values.
 
 {{- define "webhook.noProxy" -}}
     {{- .Values.webhook.noProxy | default .Values.global.proxy.noProxy | default "" -}}
+{{- end -}}
+
+{{/*
+Validate Secure API Token Config
+*/}}
+{{- define "admissionController.validTokenConfig" -}}
+{{- $errorMsg := `
+The Sysdig Secure API Token was not provided with either the sysdig.secureAPIToken or sysdig.secureAPITokenSecret values.`
+-}}
+    {{- required $errorMsg (or (include "sysdig.secureAPIToken" .) (include "sysdig.secureAPITokenSecret" .)) -}}
 {{- end -}}

--- a/charts/admission-controller/templates/_helpers.tpl
+++ b/charts/admission-controller/templates/_helpers.tpl
@@ -281,6 +281,9 @@ possible, but accept overrides from the chart values.
 
 {{/*
 Validate Secure API Token Config
+The follwoing named template is not used in the chart itself, it is used to
+check whether at least one of the required parameters was specified and return
+an error if not.
 */}}
 {{- define "admissionController.validTokenConfig" -}}
 {{- $errorMsg := "The Sysdig Secure API Token was not provided with either the sysdig.secureAPIToken or sysdig.secureAPITokenSecret values." -}}

--- a/charts/admission-controller/templates/_helpers.tpl
+++ b/charts/admission-controller/templates/_helpers.tpl
@@ -239,8 +239,6 @@ Allow overriding registry and repository for air-gapped environments
 {{- end -}}
 {{- end -}}
 
-
-
 {{/*
 The following helper functions are all designed to use global values where
 possible, but accept overrides from the chart values.

--- a/charts/admission-controller/templates/_helpers.tpl
+++ b/charts/admission-controller/templates/_helpers.tpl
@@ -283,8 +283,6 @@ possible, but accept overrides from the chart values.
 Validate Secure API Token Config
 */}}
 {{- define "admissionController.validTokenConfig" -}}
-{{- $errorMsg := `
-The Sysdig Secure API Token was not provided with either the sysdig.secureAPIToken or sysdig.secureAPITokenSecret values.`
--}}
+{{- $errorMsg := "The Sysdig Secure API Token was not provided with either the sysdig.secureAPIToken or sysdig.secureAPITokenSecret values." -}}
     {{- required $errorMsg (or (include "sysdig.secureAPIToken" .) (include "sysdig.secureAPITokenSecret" .)) -}}
 {{- end -}}

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Change Log
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+## v1.4.7
+### Minor changes
+* admission-controller:
+    * Add proper validation check for Secure API Token
 
 ## v1.4.6
 ### Minor changes

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart with various Sysdig components for Kubernetes
 
 type: application
 
-version: 1.4.6
+version: 1.4.7
 
 maintainers:
   - name: aroberts87
@@ -22,7 +22,7 @@ dependencies:
   - name: admission-controller
     # repository: https://charts.sysdig.com
     repository: file://../admission-controller
-    version: ~0.7.1
+    version: ~0.7.2
     alias: admissionController
     condition: admissionController.enabled
   - name: agent


### PR DESCRIPTION
## What this PR does / why we need it:

- Add Secure API token validation for Admission Controller
- Bump sysdig-deploy and admission-controller

This PR will make specifying either a `secureAPIToken` or a `secureAPITokenSecret` a requirement and return a meaningful error
Mainly meant as an improvement over https://github.com/sysdiglabs/charts/pull/708

The only concern is that before adding the admission-controller to sysdig-deploy this requirement was not present and only a warning message was returned.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped for the respective charts
- [x] Changelog updated for the charts with version updates.
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.