### PR TITLE
[agent] Add 'beta' tag back to agent DS

### DIFF
--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Change Log
 
+## v1.5.36
+### Minor changes
+* Revert changes from 1.5.35 due to breaking OKD3.
+
 ## v1.5.35
 ### Minor changes
 * Remove 'beta' from kubernets.io/arch and kubernetes.io/os in daemonset due to deprecation

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.35
+version: 1.5.36
 
 appVersion: 12.9.1
 

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -60,10 +60,10 @@ spec:
                 operator: In
                 values: {{- toYaml .Values.daemonset.os | nindent 18 }}
             - matchExpressions:
-              - key: kubernetes.io/arch
+              - key: beta.kubernetes.io/arch
                 operator: In
                 values: {{- toYaml .Values.daemonset.arch | nindent 18 }}
-              - key: kubernetes.io/os
+              - key: beta.kubernetes.io/os
                 operator: In
                 values: {{- toYaml .Values.daemonset.os | nindent 18 }}
       {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:

The removal of 'beta' from the agent daemonset `kubernetes.io/arch` and `kubernetes.io/os` node selector broke OKD3 installs since OKD3 is based off of Kubernetes 1.11. This commit adds the 'beta' extension back at the expense of some warnings during installation of more modern clusters.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped for the respective charts
- [x] Changelog updated for the charts with version updates.
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.