### PR TITLE
[node-analyzer][agent] Do not add psp policy to clusterrole if k8s version > 1.25

### DIFF
--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Change Log
 
+## v1.5.44
+### Minor changes
+* * Do not add psp policy to clusterrole if k8s > 1.25
+
 ## v1.5.43
 ### Minor changes
 * Added `node-role.kubernetes.io/control-plane` toleration
@@ -154,7 +158,7 @@ This file documents all notable changes to the Sysdig Agent Helm Chart. The rele
 
 ### Bugfix
 
-* make collectorHost required when region is custom 
+* make collectorHost required when region is custom
 
 ## v1.5.5
 

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.43
+version: 1.5.44
 
 appVersion: 12.9.1
 

--- a/charts/agent/templates/clusterrole.yaml
+++ b/charts/agent/templates/clusterrole.yaml
@@ -103,7 +103,7 @@ rules:
     - get
     - list
     - watch
-{{- if .Values.psp.create  }}
+{{- if and .Values.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
   - apiGroups:
       - "policy"
     resources:

--- a/charts/node-analyzer/CHANGELOG.md
+++ b/charts/node-analyzer/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to Sysdig Node Analyzer Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.7.47
+### Minor changes
+* Do not add psp policy to clusterrole if k8s > 1.25
+
 ## v1.7.46
 ### Minor changes
 * Added `node-role.kubernetes.io/control-plane` toleration

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.7.46
+version: 1.7.47
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/clusterrole-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/clusterrole-node-analyzer.yaml
@@ -91,7 +91,7 @@ rules:
     - create
     - delete
 {{- end }}
-{{- if .Values.psp.create  }}
+{{- if and .Values.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
 - apiGroups:
     - "policy"
   resources:

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.4.31
+### Minor changes
+* agent
+    * Do not add psp policy to clusterrole if k8s > 1.25
+* node-analyzer
+    * Do not add psp policy to clusterrole if k8s > 1.25
+
 ## v1.4.30
 ### Minor changes
 * agent
@@ -98,7 +105,7 @@ This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. Th
 ### Minor changes:
 * node-analyzer
     * bump to version 1.7.39
-    
+
 ## v1.4.20
 ### Minor changes
 * admission-controller

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,8 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.4.30
-
+version: 1.4.31
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com
@@ -25,13 +24,13 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.5.43
+    version: ~1.5.44
     alias: agent
     condition: agent.enabled
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.7.46
+    version: ~1.7.47
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: kspm-collector


### PR DESCRIPTION
Signed-off-by: Michele Palazzi <michele.palazzi@sysdig.com>

## What this PR does / why we need it:

Do not add psp policy to clusterrole if k8s version > 1.25
bump versions and add change log entries

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped for the respective charts
- [x] Changelog updated for the charts with version updates.
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.