### PR TITLE
[sysdig-deploy][agent][node-analyzer][rapid-response][admission-controller][harbor-scanner-sysdig-secure][kspm-collector] Fixed sysdig showel icon from the published charts

### DIFF
--- a/charts/admission-controller/CHANGELOG.md
+++ b/charts/admission-controller/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to the Admission Controller Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v0.7.14
+### Minor changes
+* Updated chart icon
+
 ## v0.7.13
 ### Minor changes
 * Updated override helm tests to include extra testcases.

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.7.13
+version: 0.7.14
 appVersion: 3.9.14
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.7.13
 appVersion: 3.9.14
 home: https://sysdiglabs.github.io/admission-controller/
-icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 maintainers:
   - name: hayk99
     email: hayk.kocharyan@sysdig.com

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.7.13  \
+      --create-namespace -n sysdig-admission-controller --version=0.7.14  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.url=SECURE_URL \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
@@ -56,7 +56,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.13
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.14
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -179,7 +179,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.13 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.14 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,sysdig.url=SECURE_URL,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -188,7 +188,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.13 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.14 \
     --values values.yaml
 ```
 

--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Change Log
 
+## v1.5.45
+### Minor changes
+* * Updated chart icon
+
 ## v1.5.44
 ### Minor changes
 * * Do not add psp policy to clusterrole if k8s > 1.25

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.44
+version: 1.5.45
 
 appVersion: 12.9.1
 

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - troubleshooting
   - run-time
 home: https://www.sysdig.com/
-icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 sources:
   - https://app.sysdigcloud.com/#/settings/user
   - https://github.com/draios/sysdig

--- a/charts/harbor-scanner-sysdig-secure/CHANGELOG.md
+++ b/charts/harbor-scanner-sysdig-secure/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Change Log
 
+## v0.3.4
+
+### Minor
+
+* Updated chart icon
+
 ## v0.3.3
 
 ### Feature

--- a/charts/harbor-scanner-sysdig-secure/Chart.yaml
+++ b/charts/harbor-scanner-sysdig-secure/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.3.3
 appVersion: 0.5.0
 home: https://github.com/sysdiglabs/harbor-scanner-sysdig-secure
-icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 maintainers:
   - name: nestorsalceda
     email: nestor.salceda@sysdig.com

--- a/charts/harbor-scanner-sysdig-secure/Chart.yaml
+++ b/charts/harbor-scanner-sysdig-secure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: harbor-scanner-sysdig-secure
 description: Harbor Scanner for Sysdig Secure
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: 0.5.0
 home: https://github.com/sysdiglabs/harbor-scanner-sysdig-secure
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/kspm-collector/CHANGELOG.md
+++ b/charts/kspm-collector/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.25
+### Minor changes
+* Updated chart icon
+
 # v0.1.24
 ### Minor changes
 * Updated override helm tests to include extra testcases.

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - troubleshooting
   - run-time
 home: https://www.sysdig.com/
-icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 sources:
   - https://app.sysdigcloud.com/#/settings/user
   - https://github.com/draios/sysdig

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.1.24
+version: 0.1.25
 appVersion: 1.11.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/CHANGELOG.md
+++ b/charts/node-analyzer/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to Sysdig Node Analyzer Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+# v1.8.2
+### Minor changes
+* Updated chart icon
+
 # v1.8.1
 ### Minor changes
 * NodeAnalyzer:

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
   - troubleshooting
   - run-time
 home: https://www.sysdig.com/
-icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 sources:
   - https://app.sysdigcloud.com/#/settings/user
   - https://github.com/draios/sysdig

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.8.1
+version: 1.8.2
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/rapid-response/CHANGELOG.md
+++ b/charts/rapid-response/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Change Log
 
+## v0.3.2
+### Minor changes
+* Updated chart icon
+
 ## v0.3.1
 ### Minor changes
 * Added `node-role.kubernetes.io/control-plane` toleration

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -31,7 +31,7 @@ keywords:
   - troubleshooting
   - run-time
 home: https://www.sysdig.com/
-icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 sources:
   - https://github.com/sysdiglabs/charts/
 maintainers:

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.5.2
+### Minor changes
+* Updated chart icon
+
 ## v1.5.1
 ### Minor changes
 * node-analyzer:

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.1
+version: 1.5.2
 
 maintainers:
   - name: aroberts87

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
   - name: yashgiri
     email: yashgiri.goswami@sysdig.com
 home: https://www.sysdig.com/
-icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 dependencies:
   - name: admission-controller
     # repository: https://charts.sysdig.com

--- a/charts/sysdig-mcm-navmenu/Chart.yaml
+++ b/charts/sysdig-mcm-navmenu/Chart.yaml
@@ -4,7 +4,7 @@ name: sysdig-mcm-navmenu
 version: 1.0.2
 appVersion: 1.0.0
 home: https://www.sysdig.com/
-icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
+icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
 maintainers:
     - name: airadier
       email: alvaro.iradier@sysdig.com

--- a/charts/sysdig-mcm-navmenu/Chart.yaml
+++ b/charts/sysdig-mcm-navmenu/Chart.yaml
@@ -4,7 +4,7 @@ name: sysdig-mcm-navmenu
 version: 1.0.2
 appVersion: 1.0.0
 home: https://www.sysdig.com/
-icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 maintainers:
     - name: airadier
       email: alvaro.iradier@sysdig.com

--- a/charts/sysdig-stackdriver-bridge/Chart.yaml
+++ b/charts/sysdig-stackdriver-bridge/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig-stackdriver-bridge
-version: 1.1.1
+version: 1.1.2
 appVersion: 0.0.7
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig-stackdriver-bridge/Chart.yaml
+++ b/charts/sysdig-stackdriver-bridge/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - troubleshooting
   - run-time
 home: https://www.sysdig.com/
-icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 sources:
   - https://app.sysdigcloud.com/#/settings/user
   - https://github.com/draios/sysdig

--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+## v1.15.58
+### Minor changes
+* Updated chart icon
+
 ## v1.15.57
 ### Minor changes
 * NodeAnalyzer:

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.57
+version: 1.15.58
 appVersion: 12.9.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - troubleshooting
   - run-time
 home: https://www.sysdig.com/
-icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
+icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 sources:
   - https://app.sysdigcloud.com/#/settings/user
   - https://github.com/draios/sysdig


### PR DESCRIPTION
Switched icon to github draios org logo. The previous one was tied to a blog url which does not exist anymore

## What this PR does / why we need it:

The legacy logo was tied from a blog url and it was removed. Third parties like marketplaces and platforms was showing their default logos instead our custom logo.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname]) 
- [x] Chart Version bumped for the respective charts
- [x] Changelog updated for the charts with version updates.
- [ ] Variables are documented in the README.md (or README.tpl in some charts) --> NA
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix --> NA

Check Contribution guidelines in README.md for more insight.