### PR TITLE
feat: unify changelog headers

### DIFF
--- a/charts/admission-controller/CHANGELOG.md
+++ b/charts/admission-controller/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Chart: Admission Controller
 
-## Change Log
+All notable changes to this chart will be documented in this file.
 
-This file documents all notable changes to the Admission Controller Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please note that it's automatically updated vía github actions.
+Manual edits are supported only below '## Change Log' and should be used
+exclusively to fix incorrect entries and not to add new ones.
+
+## Change Log
 
 ## v0.7.16
 ### Minor changes

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.7.16
+version: 0.7.17
 appVersion: 3.9.14
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.7.16  \
+      --create-namespace -n sysdig-admission-controller --version=0.7.17  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.url=SECURE_URL \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
@@ -56,7 +56,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.16
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.17
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -181,7 +181,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.16 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.17 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,sysdig.url=SECURE_URL,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -190,7 +190,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.16 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.17 \
     --values values.yaml
 ```
 

--- a/charts/agent/CHANGELOG.md
+++ b/charts/agent/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Chart: Agent
 
+All notable changes to this chart will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please note that it's automatically updated vía github actions.
+Manual edits are supported only below '## Change Log' and should be used
+exclusively to fix incorrect entries and not to add new ones.
+
 ## Change Log
 
 

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.46
+version: 1.5.47
 
 appVersion: 12.9.1
 

--- a/charts/cloud-bench/CHANGELOG.md
+++ b/charts/cloud-bench/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Chart: Cloud Connector
+# Chart: Cloud Bench
 
 All notable changes to this chart will be documented in this file.
 
@@ -10,13 +10,3 @@ Manual edits are supported only below '## Change Log' and should be used
 exclusively to fix incorrect entries and not to add new ones.
 
 ## Change Log
-
-# cloud-connector-0.16.22
-
-Features
-Disable bruteforce until explicitly specified
-
-# cloud-connector-0.7.16
-
-## Documentation
-- changelog addition

--- a/charts/cloud-bench/Chart.yaml
+++ b/charts/cloud-bench/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-bench
 description: Sysdig Cloud Bench
 
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.1.0
 home: https://sysdig.com
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/cloud-connector/Chart.yaml
+++ b/charts/cloud-connector/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-connector
 description: Sysdig Cloud Connector
 
 type: application
-version: 0.7.19
+version: 0.7.20
 appVersion: 0.16.23
 home: https://sysdiglabs.github.io/cloud-connector
 

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install cloud-connector sysdig/cloud-connector \
-      --create-namespace -n cloud-connector --version=0.7.19  \
+      --create-namespace -n cloud-connector --version=0.7.20  \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
 ```
 
@@ -48,7 +48,7 @@ to enable threat-detection and image scanning capabilities for the main three pr
 To install the chart with the release name `cloud-connector`:
 
 ```console
-$ helm upgrade --install cloud-connector sysdig/cloud-connector -n cloud-connector --version=0.7.19
+$ helm upgrade --install cloud-connector sysdig/cloud-connector -n cloud-connector --version=0.7.20
 ```
 
 The command deploys the Sysdig Cloud Connector on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -120,7 +120,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install cloud-connector sysdig/cloud-connector \
-    --create-namespace -n cloud-connector --version=0.7.19 \
+    --create-namespace -n cloud-connector --version=0.7.20 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE
 ```
 
@@ -129,7 +129,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install cloud-connector sysdig/cloud-connector \
-    --create-namespace -n cloud-connector --version=0.7.19 \
+    --create-namespace -n cloud-connector --version=0.7.20 \
     --values values.yaml
 ```
 

--- a/charts/cloud-scanning/CHANGELOG.md
+++ b/charts/cloud-scanning/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Chart: Cloud Connector
+# Chart: Cloud Scanning
 
 All notable changes to this chart will be documented in this file.
 
@@ -10,13 +10,3 @@ Manual edits are supported only below '## Change Log' and should be used
 exclusively to fix incorrect entries and not to add new ones.
 
 ## Change Log
-
-# cloud-connector-0.16.22
-
-Features
-Disable bruteforce until explicitly specified
-
-# cloud-connector-0.7.16
-
-## Documentation
-- changelog addition

--- a/charts/cloud-scanning/Chart.yaml
+++ b/charts/cloud-scanning/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-scanning
 description: Sysdig Cloud Scanning
 
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.11.3
 home: https://sysdiglabs.github.io/cloud-connector
 

--- a/charts/harbor-scanner-sysdig-secure/CHANGELOG.md
+++ b/charts/harbor-scanner-sysdig-secure/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Chart: Harbor Scanner for Sysdig Secure
 
+All notable changes to this chart will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please note that it's automatically updated vía github actions.
+Manual edits are supported only below '## Change Log' and should be used
+exclusively to fix incorrect entries and not to add new ones.
+
 ## Change Log
 
 ## v0.3.4

--- a/charts/harbor-scanner-sysdig-secure/Chart.yaml
+++ b/charts/harbor-scanner-sysdig-secure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: harbor-scanner-sysdig-secure
 description: Harbor Scanner for Sysdig Secure
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: 0.5.0
 home: https://github.com/sysdiglabs/harbor-scanner-sysdig-secure
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/kspm-collector/CHANGELOG.md
+++ b/charts/kspm-collector/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Chart: KSPM Collector
+
+All notable changes to this chart will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please note that it's automatically updated vía github actions.
+Manual edits are supported only below '## Change Log' and should be used
+exclusively to fix incorrect entries and not to add new ones.
+
+## Change Log
+
 # v0.1.27
 ### Minor changes
 * Bumped image tag to 1.15.0
@@ -92,7 +105,7 @@
 
 # v0.1.5
 ### Bugfixes
-* Removed duplicate labels from deployment of `app.kubernetes.io/instance` 
+* Removed duplicate labels from deployment of `app.kubernetes.io/instance`
 
 # v0.1.4
 ### Bugfixes

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.1.27
+version: 0.1.28
 appVersion: 1.15.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/CHANGELOG.md
+++ b/charts/node-analyzer/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Chart: Node Analyzer
 
+All notable changes to this chart will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please note that it's automatically updated vía github actions.
+Manual edits are supported only below '## Change Log' and should be used
+exclusively to fix incorrect entries and not to add new ones.
+
 ## Change Log
 
 This file documents all notable changes to Sysdig Node Analyzer Helm Chart. The release numbering uses [semantic versioning](http://semver.org).

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.8.7
+version: 1.8.8
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/rapid-response/CHANGELOG.md
+++ b/charts/rapid-response/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Chart: Rapid Response
 
+All notable changes to this chart will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please note that it's automatically updated vía github actions.
+Manual edits are supported only below '## Change Log' and should be used
+exclusively to fix incorrect entries and not to add new ones.
+
 ## Change Log
 
 ## v0.3.3

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Chart: Sysdig Registry Scanner
 
-## Change Log
+All notable changes to this chart will be documented in this file.
 
-This file documents all notable changes to Sysdig Registry Scanner. The release
-numbering uses [semantic versioning](http://semver.org).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please note that it's automatically updated vía github actions.
+Manual edits are supported only below '## Change Log' and should be used
+exclusively to fix incorrect entries and not to add new ones.
+
+## Change Log
 
 ## v0.1.0
 
@@ -22,8 +28,8 @@ numbering uses [semantic versioning](http://semver.org).
 
 ### Minor changes
 
-* Bump registry-scanner version to 0.1.11 (Update gem deps) 
-* Experimental an unsupported feature to activate the new vm beta image scanning 
+* Bump registry-scanner version to 0.1.11 (Update gem deps)
+* Experimental an unsupported feature to activate the new vm beta image scanning
 
 ## v0.0.34
 

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.2.0
 maintainers:
   - name: airadier

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -1,15 +1,22 @@
-# Chart: sysdig-deploy
+# Chart: Sysdig Deploy
+
+All notable changes to this chart will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please note that it's automatically updated vía github actions.
+Manual edits are supported only below '## Change Log' and should be used
+exclusively to fix incorrect entries and not to add new ones.
 
 ## Change Log
-
-This file documents all notable changes to Sysdig's sysdig-deploy Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
 ## 1.5.12
 * node-analyzer
   * bump version to fix CVEs
 * kspm-collector
   * bump version to fix CVEs
-  
+
 ## 1.5.11
 * node-analuzer
   * namespace definition added

--- a/charts/sysdig-mcm-navmenu/CHANGELOG.md
+++ b/charts/sysdig-mcm-navmenu/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Chart: Cloud Connector
+# Chart: sysdig-mcm-navmenu
 
 All notable changes to this chart will be documented in this file.
 
@@ -10,13 +10,3 @@ Manual edits are supported only below '## Change Log' and should be used
 exclusively to fix incorrect entries and not to add new ones.
 
 ## Change Log
-
-# cloud-connector-0.16.22
-
-Features
-Disable bruteforce until explicitly specified
-
-# cloud-connector-0.7.16
-
-## Documentation
-- changelog addition

--- a/charts/sysdig-mcm-navmenu/Chart.yaml
+++ b/charts/sysdig-mcm-navmenu/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sysdig IBM MCM Nav Menu integration
 name: sysdig-mcm-navmenu
-version: 1.0.2
+version: 1.0.3
 appVersion: 1.0.0
 home: https://www.sysdig.com/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/sysdig-stackdriver-bridge/CHANGELOG.md
+++ b/charts/sysdig-stackdriver-bridge/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Chart: Cloud Connector
+# Chart: Sysdig Stackdriver Bridge
 
 All notable changes to this chart will be documented in this file.
 
@@ -10,13 +10,3 @@ Manual edits are supported only below '## Change Log' and should be used
 exclusively to fix incorrect entries and not to add new ones.
 
 ## Change Log
-
-# cloud-connector-0.16.22
-
-Features
-Disable bruteforce until explicitly specified
-
-# cloud-connector-0.7.16
-
-## Documentation
-- changelog addition

--- a/charts/sysdig-stackdriver-bridge/Chart.yaml
+++ b/charts/sysdig-stackdriver-bridge/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig-stackdriver-bridge
-version: 1.1.2
+version: 1.1.3
 appVersion: 0.0.7
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/CHANGELOG.md
+++ b/charts/sysdig/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Chart: Sysdig
 
-## Change Log
+All notable changes to this chart will be documented in this file.
 
-This file documents all notable changes to Sysdig Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please note that it's automatically updated vía github actions.
+Manual edits are supported only below '## Change Log' and should be used
+exclusively to fix incorrect entries and not to add new ones.
+
+## Change Log
 
 ## v1.15.60
 ### Minor changes:

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.60
+version: 1.15.61
 appVersion: 12.9.1
 description: Sysdig Monitor and Secure agent
 keywords:


### PR DESCRIPTION
Signed-off-by: Michele Palazzi <michele.palazzi@sysdig.com>

## What this PR does / why we need it:

This PR will be necessary after merging https://github.com/sysdiglabs/charts/pull/754.
Created a separate one to avoid mixing the implementation and the chart changes themselves.

The CI will probably fail (even after adding all the version bumps) due to timeout or errors on some of the almost abandoned charts, but i would suggest to ignore that since it's not in the scope and clearly unrelated.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped for the respective charts
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.