### PR TITLE
[kspm collector] bumped image tag to 1.15.0

### DIFF
--- a/charts/kspm-collector/CHANGELOG.md
+++ b/charts/kspm-collector/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.27
+### Minor changes
+* Bumped image tag to 1.15.0
+
 # v0.1.26
 ### Minor changes
 * Add deployment test to kspm collector chart

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.1.26
-appVersion: 1.11.0
+version: 0.1.27
+appVersion: 1.15.0
 keywords:
   - monitoring
   - security

--- a/charts/kspm-collector/README.md
+++ b/charts/kspm-collector/README.md
@@ -37,7 +37,7 @@ The following table lists the configurable parameters of the Sysdig KSPM Collect
 | `clusterName`                             | Set a cluster name to identify events using *kubernetes.cluster.name* tag               | ` `                                                         |
 | `image.registry`                          | KSPM Collector image registry                                                           | `quay.io`                                                   |
 | `image.repository`                        | The image repository to pull from                                                       | `sysdig/kspm-collector`                                     |
-| `image.tag`                               | The image tag to pull                                                                   | `1.14.0`                                                    |
+| `image.tag`                               | The image tag to pull                                                                   | `1.15.0`                                                    |
 | `image.digest`                            | The image digest to pull                                                                | ` `                                                         |
 | `image.pullPolicy`                        | The Image pull policy                                                                   | `Always`                                                    |
 | `imagePullSecrets`                        | The Image pull secret                                                                   | `[]`                                                        |

--- a/charts/kspm-collector/values.yaml
+++ b/charts/kspm-collector/values.yaml
@@ -39,7 +39,7 @@ clusterName: ""
 
 image:
   repository: sysdig/kspm-collector
-  tag: 1.14.0
+  tag: 1.15.0
   digest:
   registry: quay.io
   pullPolicy: Always


### PR DESCRIPTION
## What this PR does / why we need it:
Bump kspm collector version to fix CVEs

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with chart name (e.g. [mychartname])
- [x] Chart Version bumped for the respective charts
- [x] Changelog updated for the charts with version updates.
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.