### PR TITLE
fix: use token to bypass branch protection in automated changelog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,6 +140,8 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Commit CHANGELOG.md and RELEASE-NOTES.md
+        with:
+          token: ${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}
         run: |
           released_charts_files="${{ needs.charts-to-release.outputs.modified-charts-files }}"
           echo "released_charts_files: ${released_charts_files}"


### PR DESCRIPTION
Signed-off-by: Michele Palazzi <michele.palazzi@sysdig.com>

## What this PR does / why we need it:

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)

Check Contribution guidelines in README.md for more insight.
