### PR TITLE
fix: fix changelog entry

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -8,10 +8,10 @@
 ### {{ .Title }}
 {{ range .Commits -}}
 * {{ if .Scope }}**{{ .Scope }}** [{{ end }}[{{.Hash.Short}}]({{ $.Info.RepositoryURL }}/commit/{{ .Hash.Long }})]: {{ .Subject }}
-{{- if .Notes -}}
+{{ if .Notes -}}
 {{ range .Notes }}
     * {{ .Body }}
-{{ end }}
+{{ end -}}
 {{ end -}}
 {{ end -}}
 {{ end -}}

--- a/.chglog/RELEASE.tpl.md
+++ b/.chglog/RELEASE.tpl.md
@@ -6,10 +6,10 @@
 ### {{ .Title }}
 {{ range .Commits -}}
 - {{ if .Scope }}**{{ .Scope }}** [{{ end }}[{{.Hash.Short}}]({{ $.Info.RepositoryURL }}/commit/{{ .Hash.Long }})]: {{ .Subject }}
-{{- if .Notes -}}
+{{ if .Notes -}}
 {{ range .Notes }}
     * {{ .Body }}
-{{ end }}
+{{ end -}}
 {{ end -}}
 {{ end -}}
 {{ end -}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,4 +154,4 @@ jobs:
               git commit -m "github_actions_ci: Update CHANGELOG and RELEASE-NOTES for ${chart_name}-${chart_version}"
           done
           # Push changes to the master branch.
-          git push origin "${GITHUB_REF##*/}":master
+          git push origin "${GITHUB_REF##*/}":master -f

--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -12,7 +12,8 @@ exclusively to fix incorrect entries and not to add new ones.
 ## Change Log
 # v1.5.13
 ### Chores
-* [f69a9c1](https://github.com/sysdiglabs/charts/commit/f69a9c10aa03dc0ec9e20d6d4dae762225046a23)]: Updating sysdig-deploy version ([#794](https://github.com/sysdiglabs/charts/issues/794))* [1fec8bc](https://github.com/sysdiglabs/charts/commit/1fec8bcc1f19f35a20683a061ec4894405dd678c)]: Updating sysdig-deploy version ([#792](https://github.com/sysdiglabs/charts/issues/792))### New Features
+* [f69a9c1](https://github.com/sysdiglabs/charts/commit/f69a9c10aa03dc0ec9e20d6d4dae762225046a23)]: Updating sysdig-deploy version ([#794](https://github.com/sysdiglabs/charts/issues/794))
+### New Features
 * [f4cb189](https://github.com/sysdiglabs/charts/commit/f4cb189afba6833fd458f99dcfcc0121f9d9dfa2)]: unify changelog headers ([#787](https://github.com/sysdiglabs/charts/issues/787))
 
 ## 1.5.12

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.13
+version: 1.5.14
 
 maintainers:
   - name: aroberts87

--- a/charts/sysdig-deploy/RELEASE-NOTES.md
+++ b/charts/sysdig-deploy/RELEASE-NOTES.md
@@ -1,6 +1,7 @@
 # What's Changed
 
 ### Chores
-- [f69a9c1](https://github.com/sysdiglabs/charts/commit/f69a9c10aa03dc0ec9e20d6d4dae762225046a23)]: Updating sysdig-deploy version ([#794](https://github.com/sysdiglabs/charts/issues/794))- [1fec8bc](https://github.com/sysdiglabs/charts/commit/1fec8bcc1f19f35a20683a061ec4894405dd678c)]: Updating sysdig-deploy version ([#792](https://github.com/sysdiglabs/charts/issues/792))### New Features
+- [f69a9c1](https://github.com/sysdiglabs/charts/commit/f69a9c10aa03dc0ec9e20d6d4dae762225046a23)]: Updating sysdig-deploy version ([#794](https://github.com/sysdiglabs/charts/issues/794))
+### New Features
 - [f4cb189](https://github.com/sysdiglabs/charts/commit/f4cb189afba6833fd458f99dcfcc0121f9d9dfa2)]: unify changelog headers ([#787](https://github.com/sysdiglabs/charts/issues/787))
 #### Full diff: https://github.com/sysdiglabs/charts/compare/sysdig-deploy-1.5.12...sysdig-deploy-1.5.13


### PR DESCRIPTION
## What this PR does / why we need it:

- fix sysdig-deploy change log entry
- fix newline in change log templates
- add -f to (hopefully) bypass branch protection rules for automated push

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.
