### PR TITLE
fix pr-lint on PRs from forks

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.7.0
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: ${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}
           title-regex: "^(\\w*)(?:\\(([\\w\\$\\.\\,\\-\\*\\s]*)\\))?\\:\\s?(.*)$"
           on-failed-regex-fail-action: false
           on-failed-regex-create-review: true

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,7 +1,7 @@
 name: PR Lint
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, synchronize]
 
 jobs:

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,11 +1,13 @@
 name: PR Lint
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 jobs:
   pr-lint:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: morrisoncole/pr-lint-action@v1.7.0


### PR DESCRIPTION
Signed-off-by: Michele Palazzi <michele.palazzi@sysdig.com>

## What this PR does / why we need it:

fix `Error: HttpError: Resource not accessible by integration`

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)

Check Contribution guidelines in README.md for more insight.
