### PR TITLE
fix(kspm-collector): Fix numeric port on configmap

### DIFF
--- a/charts/kspm-collector/CHANGELOG.md
+++ b/charts/kspm-collector/CHANGELOG.md
@@ -10,6 +10,10 @@ Manual edits are supported only below '## Change Log' and should be used
 exclusively to fix incorrect entries and not to add new ones.
 
 ## Change Log
+# v0.1.29
+### Minor changes
+* Fix port configmap numeric value
+
 # v0.1.28
 ### New Features
 * [f4cb189](https://github.com/sysdiglabs/charts/commit/f4cb189afba6833fd458f99dcfcc0121f9d9dfa2)]: unify changelog headers ([#787](https://github.com/sysdiglabs/charts/issues/787))

--- a/charts/kspm-collector/CHANGELOG.md
+++ b/charts/kspm-collector/CHANGELOG.md
@@ -10,9 +10,6 @@ Manual edits are supported only below '## Change Log' and should be used
 exclusively to fix incorrect entries and not to add new ones.
 
 ## Change Log
-# v0.1.29
-### Minor changes
-* Fix port configmap numeric value
 
 # v0.1.28
 ### New Features

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.1.28
+version: 0.1.29
 appVersion: 1.15.0
 keywords:
   - monitoring

--- a/charts/kspm-collector/templates/configmap.yaml
+++ b/charts/kspm-collector/templates/configmap.yaml
@@ -27,5 +27,7 @@ data:
   {{- end -}}
   {{- if (.Values.noProxy | default .Values.global.proxy.noProxy) }}
   no_proxy: {{ .Values.noProxy | default .Values.global.proxy.noProxy }}
-  agent_port: {{ .Values.port }}
+  {{- end -}}
+  {{- if .Values.port }}
+  agent_port: {{ .Values.port | quote }}
   {{- end -}}

--- a/charts/node-analyzer/templates/configmap-kspm-analyzer.yaml
+++ b/charts/node-analyzer/templates/configmap-kspm-analyzer.yaml
@@ -27,7 +27,6 @@ data:
   {{- end -}}
   {{- if (.Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy) }}
   no_proxy: {{ .Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy }}
-  agent_port: {{ .Values.nodeAnalyzer.kspmAnalyzer.port }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/node-analyzer/templates/configmap-kspm-analyzer.yaml
+++ b/charts/node-analyzer/templates/configmap-kspm-analyzer.yaml
@@ -27,6 +27,7 @@ data:
   {{- end -}}
   {{- if (.Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy) }}
   no_proxy: {{ .Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy }}
+  agent_port: {{ .Values.nodeAnalyzer.kspmAnalyzer.port }}
   {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## What this PR does / why we need it:
A fix for:
* Agent port configuration was applied when the `noProxy` variable was set.
* Wrap numeric agent port configuration value in quotes.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
