### PR TITLE
fix(node-analyzer): Fix numeric port on kspm configmap

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.8.8
+version: 1.8.9
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/configmap-kspm-analyzer.yaml
+++ b/charts/node-analyzer/templates/configmap-kspm-analyzer.yaml
@@ -27,7 +27,9 @@ data:
   {{- end -}}
   {{- if (.Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy) }}
   no_proxy: {{ .Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy }}
-  agent_port: {{ .Values.nodeAnalyzer.kspmAnalyzer.port }}
+  {{- end -}}
+  {{- if .Values.nodeAnalyzer.kspmAnalyzer.port }}
+  agent_port: {{ .Values.nodeAnalyzer.kspmAnalyzer.port | quote }}
   {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## What this PR does / why we need it:
A fix for:

* Agent port configuration was applied when the `noProxy` variable was set.
* Wrap numeric agent port configuration value in quotes.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
