### PR TITLE
fix(sysdig-deploy): Chart documentation fix values missing from configuration but referenced in examples

### DIFF
--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -195,7 +195,7 @@ The following table lists the configurable parameters of this chart and their de
 | `nodeAnalyzer.secure.enabled`           | Enable Sysdig Secure                                                                                                    | `true`    |
 | `nodeAnalyzer.secure.vulnerabilityManagement.newEngineOnly` | Enable only the new vulnerability management engine                                                 | `false`   |
 | `nodeAnalyzer.nodeAnalyzer.apiEndpoint` | nodeAnalyzer apiEndpoint                                                                                                | `""`      |
-| `nodeAnalyzer.nodeAnalyzer.benchmarkRunner.deploy` | Deploy the Runtime Scanner                                                                                   | `true`   |
+| `nodeAnalyzer.nodeAnalyzer.benchmarkRunner.deploy` | Deploy the Benchmark Runner Scanner                                                                          | `true`   |
 | `nodeAnalyzer.nodeAnalyzer.runtimeScanner.deploy` | Deploy the Runtime Scanner                                                                                    | `false`   |
 | `kspmCollector`                         | Config specific to the [Sysdig KSPM Collector](#kspm-collector)                                                         | `{}`      |
 | `kspmCollector.apiEndpoint`             | kspmCollector apiEndpoint                                                                                               | `""`      |

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -168,7 +168,7 @@ helm upgrade -n sysdig-agent sysdig sysdig/sysdig-deploy -f values.sysdig.yaml
 
 ## Configuration
 
-The following table lists the configurable parameters of this chart and their default values.
+The following table lists the configurable parameters of this chart and their default values, it is indicate and is not complete. If you are looking for more advanced configuration values, those are available in the documentation of the admission-controller, agent, node-analyzer, kspm-collector and rapid-response charts.
 
 | Parameter                               | Description                                                                                                             | Default   |
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | --------- |
@@ -192,7 +192,11 @@ The following table lists the configurable parameters of this chart and their de
 | `agent.enabled`                         | Enable the agent component in this chart                                                                                | `true`    |
 | `nodeAnalyzer`                          | Config specific to the [Sysdig nodeAnalyzer](#nodeanalyzer)                                                             | `{}`      |
 | `nodeAnalyzer.enabled`                  | Enable the nodeAnalyzer component in this chart                                                                         | `true`    |
+| `nodeAnalyzer.secure.enabled`           | Enable Sysdig Secure                                                                                                    | `true`    |
+| `nodeAnalyzer.secure.vulnerabilityManagement.newEngineOnly` | Enable only the new vulnerability management engine                                                 | `false`   |
 | `nodeAnalyzer.nodeAnalyzer.apiEndpoint` | nodeAnalyzer apiEndpoint                                                                                                | `""`      |
+| `nodeAnalyzer.nodeAnalyzer.benchmarkRunner.deploy` | Deploy the Runtime Scanner                                                                                   | `true`   |
+| `nodeAnalyzer.nodeAnalyzer.runtimeScanner.deploy` | Deploy the Runtime Scanner                                                                                    | `false`   |
 | `kspmCollector`                         | Config specific to the [Sysdig KSPM Collector](#kspm-collector)                                                         | `{}`      |
 | `kspmCollector.apiEndpoint`             | kspmCollector apiEndpoint                                                                                               | `""`      |
 | `rapidResponse`                         | Config specific to [Sysdig Rapid Response](#rapid-response)                                                             | `{}`      |


### PR DESCRIPTION
## What this PR does / why we need it:
People looking for the first time at the chart have a hard time understanding what gets deployed and not. The helm commands examples contain values that are not listed in the sysdig-deploy chart.

To help people understand how they can enable different components, I added some of them to the sysdig-deploy chart documentation.

I also direct users to the different sub-charts composing the sysdig-deploy chart so new folks know where to look for advanced config.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [N/A] Chart Version bumped for the respective charts
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
