### PR TITLE
feat(agent): add extra secrets

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.49
+version: 1.5.50
 
 appVersion: 12.10.0
 

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -131,6 +131,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `prometheus.yaml`                              | prometheus.yaml content to configure metric collection: relabelling and filtering                                                                       | ` `                                                         |
 | `extraVolumes.volumes`                         | Additional volumes to mount in the sysdig agent to pass new secrets or configmaps                                                                       | `[]`                                                        |
 | `extraVolumes.mounts`                          | Mount points for additional volumes                                                                                                                     | `[]`                                                        |
+| `extraSecrets`                                 | Allow passing extra secrets that can be mounted via extraVolumes                                                                                        | `[]`                                                        |
 | `proxy.httpProxy`                              | Sets `http_proxy` on the Agent container. Overrides the proxy setting from `global.proxy`                                                               | `""`                                                        |
 | `proxy.httpsProxy`                             | Sets `https_proxy` on the Agent container. Overrides the proxy setting from `global.proxy`                                                              | `""`                                                        |
 | `proxy.noProxy`                                | Sets `no_proxy` on the Agent container. Overrides the proxy setting from `global.proxy`                                                                 | `""`                                                        |
@@ -413,6 +414,21 @@ extraVolumes:
       name: sysdig-new-cm
     - mountPath: /opt/draios/secret
       name: sysdig-new-secret
+```
+
+### Adding additional secrets
+
+To add a new secret to the sysdig agent.
+
+You can create additional secrets (for example for Prometheus basic auth). The values are Opaque type secrets and must be in base64 encoded.
+An example of this could be:
+
+```yaml
+extraSecrets:
+  - name: sysdig-new-secret
+    data:
+      sysdig-new-password-key1: bXlwYXNzd29yZA==
+      sysdig-new-password-key2: bXlwYXNzd29yZA==
 ```
 
 ## Running helm unit tests

--- a/charts/agent/templates/secrets.yaml
+++ b/charts/agent/templates/secrets.yaml
@@ -9,4 +9,17 @@ metadata:
 type: Opaque
 data:
  access-key : {{ include "agent.accessKey" . | b64enc | quote }}
+---
+{{- end }}
+{{- range .Values.extraSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ include "agent.namespace" $ }}
+  labels:
+{{ include "agent.labels" $ | indent 4 }}
+type: Opaque
+data: {{ toYaml .data | nindent 2 }}
+---
 {{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -246,6 +246,15 @@ extraVolumes:
   #     - mountPath: /opt/draios/secret
   #       name: sysdig-new-secret
 
+extraSecrets: []
+  # Allow passing extra secrets that can be mounted via extraVolumes
+  #
+  # extraSecrets:
+  #   - name: sysdig-new-secret
+  #     data:
+  #       sysdig-new-password-key1: bXlwYXNzd29yZA==
+  #       sysdig-new-password-key2: bXlwYXNzd29yZA==
+
 # Allow sysdig to run on Kubernetes 1.6 masters.
 tolerations:
   - effect: NoSchedule


### PR DESCRIPTION
## What this PR does / why we need it:

Allow passing extra secrets that can be mounted via extraVolumes. This is useful if you need to pass credentials e.g. for pormetheus basic_auth:

```
basic_auth:
    username: prom_user
    password_file: /opt/draios/etc/kubernetes/metrics/password
```

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
