### PR TITLE
docs(agent,node-analyzer,sysdig): Remove references to Get Started in the READMEs

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.53
+version: 1.5.54
 
 appVersion: 12.10.1
 

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -36,7 +36,7 @@ $ helm install --namespace sysdig-agent sysdig-agent --set sysdig.accessKey=YOUR
 To find the values:
 
 - YOUR-KEY-HERE: This is the agent access key. You can retrieve this from Settings > Agent Installation in the Sysdig UI.
-- COLLECTOR_HOST and COLLECTOR_PORT: These values are region-dependent in SaaS and is auto-completed on the Get Started page in the UI. (They are custom values in on-prem installations.)
+- COLLECTOR_HOST and COLLECTOR_PORT: These values are region-dependent in SaaS and is auto-completed in install snippets in the UI. (They are custom values in on-prem installations.)
 
 After a few seconds, you should see hosts and containers appearing in Sysdig Monitor and Sysdig Secure.
 

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.8.19
+version: 1.8.20
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/README.md
+++ b/charts/node-analyzer/README.md
@@ -47,9 +47,9 @@ $ helm install --namespace nodeanalyzer node-analyzer --set sysdig.accessKey=YOU
 To find the values:
 
 - YOUR-KEY-HERE: This is the sysdig access key.
-- COLLECTOR_URL: This value is region-dependent in SaaS and is auto-completed on the Get Started page in the UI. (It is
+- COLLECTOR_URL: This value is region-dependent in SaaS and is auto-completed in install snippets in the UI. (It is
   a custom value in on-prem installations.)
-- API_ENDPOINT: This is the base URL (region-dependent) for Sysdig Secure and is auto-completed on the Get Started page.
+- API_ENDPOINT: This is the base URL (region-dependent) for Sysdig Secure and is auto-completed in install snippets in the UI.
   E.g. secure.sysdig.com, us2.app.sysdig.com, eu1.app.sysdig.com.
 
 After a few seconds, you should see hosts and containers appearing in Sysdig Monitor and Sysdig Secure.

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.67
+version: 1.15.68
 appVersion: 12.10.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -57,9 +57,9 @@ To find the values:
 
 - YOUR-KEY-HERE: This is the agent access key. You can retrieve this from Settings > Agent Installation in the Sysdig
   UI.
-- COLLECTOR_URL: This value is region-dependent in SaaS and is auto-completed on the Get Started page in the UI. (It is
+- COLLECTOR_URL: This value is region-dependent in SaaS and is auto-completed in install snippets in the UI. (It is
   a custom value in on-prem installations.)
-- API_ENDPOINT: This is the base URL (region-dependent) for Sysdig Secure and is auto-completed on the Get Started page.
+- API_ENDPOINT: This is the base URL (region-dependent) for Sysdig Secure and is auto-completed in install snippets in the UI.
   E.g. secure.sysdig.com, us2.app.sysdig.com, eu1.app.sysdig.com.
 
 After a few seconds, you should see hosts and containers appearing in Sysdig Monitor and Sysdig Secure.

--- a/charts/sysdig/templates/NOTES.txt
+++ b/charts/sysdig/templates/NOTES.txt
@@ -2,8 +2,8 @@ The agent for Sysdig Secure DevOps Platform is spinning up on each node in your
 cluster. After a few seconds, you should see your hosts appearing in the
 Sysdig Agent Health & Status Dashboard:
 
-COLLECTOR_URL: This value is region-dependent in SaaS and is auto-completed on the Get Started page in the UI. (It is a custom value in on-prem installations.)
-API_ENDPOINT: This is the base URL (region-dependent) for Sysdig Secure and is auto-completed on the Get Started page. E.g. secure.sysdig.com, us2.app.sysdig.com, eu1.app.sysdig.com.
+COLLECTOR_URL: This value is region-dependent in SaaS and is auto-completed in install snippets in the UI. (It is a custom value in on-prem installations.)
+API_ENDPOINT: This is the base URL (region-dependent) for Sysdig Secure and is auto-completed in install snippets in the UI. E.g. secure.sysdig.com, us2.app.sysdig.com, eu1.app.sysdig.com.
 
 These are few example links (valid for us-east only):
 


### PR DESCRIPTION
## What this PR does / why we need it:

The Get Started page has been deprecated, and replaced with TODO and Datasources. This PR removes references to Get Started, and uses more general language.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
