### PR TITLE
fix(sysdig,agent): add extra secrets and tests

### DIFF
--- a/charts/agent/templates/secrets.yaml
+++ b/charts/agent/templates/secrets.yaml
@@ -20,6 +20,8 @@ metadata:
   labels:
 {{ include "agent.labels" $ | indent 4 }}
 type: Opaque
-data: {{ toYaml .data | nindent 2 }}
+data:
+{{ toYaml .data | indent 2 }}
 ---
 {{- end }}
+

--- a/charts/agent/tests/secrets_test.yaml
+++ b/charts/agent/tests/secrets_test.yaml
@@ -1,0 +1,56 @@
+suite: Test agent secrets
+templates:
+  - templates/secrets.yaml
+tests:
+  - it: Checking default values
+    set:
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+    asserts:
+      - isKind:
+          of: Secret
+
+  - it: Check multiple keys in one extra secret
+    set:
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+      extraSecrets:
+        - name: sysdig-new-secret
+          data:
+            sysdig-new-password-key1: bXlwYXNzd29yZA==
+            sysdig-new-password-key2: bXlwYXNzd29yZA==
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: data.sysdig-new-password-key1
+          value: bXlwYXNzd29yZA==
+        documentIndex: 1
+      - equal:
+          path: data.sysdig-new-password-key2
+          value: bXlwYXNzd29yZA==
+        documentIndex: 1
+
+  - it: Check multiple extra secret
+    set:
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+      extraSecrets:
+        - name: sysdig-new-secret-1
+          data:
+            sysdig-new-password-key1: bXlwYXNzd29yZA==
+        - name: sysdig-new-secret-2
+          data:
+            sysdig-new-password-key1: bXlwYXNzd29yZA==
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: data.sysdig-new-password-key1
+          value: bXlwYXNzd29yZA==
+        documentIndex: 1
+      - equal:
+          path: data.sysdig-new-password-key1
+          value: bXlwYXNzd29yZA==
+        documentIndex: 2
+

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.63
+version: 1.15.64
 appVersion: 12.10.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/secrets.yaml
+++ b/charts/sysdig/templates/secrets.yaml
@@ -14,10 +14,12 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "sysdig.fullname" . }}
+  name: {{ .name }}
   labels:
-{{ include "sysdig.labels" . | indent 4 }}
+{{ include "sysdig.labels" $ | indent 4 }}
 type: Opaque
-data: {{ toYaml .data | nindent 2 }}
+data:
+{{ toYaml .data | indent 2 }}
 ---
 {{- end }}
+


### PR DESCRIPTION
## What this PR does / why we need it:

* replaced '.' with '$' in secret range loop otherwise context is not passed to helm define functions in sysdig chart
* added helm unit tests for 'extraSecrets' in agent chart

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)

Check Contribution guidelines in README.md for more insight.
