### PR TITLE
fix: Change username for automated changelog commits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  GITHUB_USERNAME: jenkins
+  GITHUB_USERNAME: draios-jenkins
 
 jobs:
   charts-to-release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+env:
+  GITHUB_USERNAME: jenkins
+
 jobs:
   charts-to-release:
     runs-on: ubuntu-latest
@@ -93,8 +96,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config user.name "$GITHUB_USERNAME"
+          git config user.email "$GITHUB_USERNAME@sysdig.com"
 
       - name: Run Chart Releaser
         uses: helm/chart-releaser-action@v1.4.1
@@ -137,8 +140,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config user.name "$GITHUB_USERNAME"
+          git config user.email "$GITHUB_USERNAME@sysdig.com"
 
       - name: Commit CHANGELOG.md and RELEASE-NOTES.md
         run: |


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

Right now the automated changelog commits end up looking like the person who merged the PR committed directly on master, which is not the case, with this change they will appear as @draios-jenkins as it should be since that is the token being used

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
