### PR TITLE
fix(agent): Fix agent logPriority rendering

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.50
+version: 1.5.51
 
 appVersion: 12.10.0
 

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.51
+version: 1.5.52
 
 appVersion: 12.10.0
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -318,27 +318,3 @@ Use global sysdig tags for agent
         {{- end -}}
     {{- end -}}
 {{- end -}}
-
-{{/*
-Determine agent log priority values
-*/}}
-{{- define "agent.logPriority" -}}
-    {{- if and .Values.logPriority (hasKey .Values.sysdig.settings "log") }}
-        {{- fail "Mutually exclusive options agent.logPriority and agent.sysdig.settings.log have been set" -}}
-    {{- else if (hasKey .Values.sysdig.settings "log") }}
-        {{- $logConfigString := "log:\n" }}
-        {{- if (hasKey .Values.sysdig.settings.log "console_priority") }}
-            {{- $consolePriority := .Values.sysdig.settings.log.console_priority }}
-            {{- $logConfigString = printf "%s  %s: %s" $logConfigString "console_priority" $consolePriority }}
-        {{- end }}
-        {{- if (hasKey .Values.sysdig.settings.log "file_priority") }}
-            {{- $filePriority := .Values.sysdig.settings.log.file_priority }}
-            {{- $logConfigString = printf "%s\n  %s: %s" $logConfigString "file_priority" $filePriority }}
-        {{- end }}
-        {{- $logConfigString }}
-    {{- else if .Values.logPriority }}
-        {{- $logConfigString := "log:\n" }}
-        {{- $logConfigString = printf "%s  console_priority: %s\n  file_priority: %s\n" $logConfigString .Values.logPriority .Values.logPriority }}
-        {{- $logConfigString }}
-    {{- end }}
-{{- end }}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -52,12 +52,16 @@ data:
     k8s_coldstart:
       max_parallel_cold_starts: {{ include "agent.parallelStarts" .}}
 {{- end }}
-{{ include "agent.logPriority" . | indent 4 }}
+{{/* check for log level sanity */}}
+{{- if and .Values.logPriority (or (hasKey (default dict .Values.sysdig.settings.log) "console_priority") (hasKey (default dict .Values.sysdig.settings.log) "file_priority")) }}
+  {{- fail "Cannot set logPriority when either sysdig.settings.log.console_priority or sysdig.settings.log.file_priority are set" }}
+{{- end }}
+{{- if .Values.logPriority }}
+  {{- $_ := merge .Values.sysdig.settings (dict "log" (dict "console_priority" .Values.logPriority "file_priority" .Values.logPriority)) }}
+{{- end }}
 {{/* add in the remaining items from sysdig.settings */}}
-{{- if hasKey .Values.sysdig.settings "log" }}
-  {{ toYaml (omit .Values.sysdig.settings "log") | indent 4 }}
-{{- else if .Values.sysdig.settings }}
-  {{ toYaml .Values.sysdig.settings | indent 4 }}
+{{- if .Values.sysdig.settings }}
+{{ toYaml .Values.sysdig.settings | indent 4 }}
 {{- end }}
 {{- if .Values.leaderelection.enable }}
     k8s_delegation_election: true

--- a/charts/agent/tests/log_priority_test.yaml
+++ b/charts/agent/tests/log_priority_test.yaml
@@ -21,7 +21,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data.dragent\.yaml
-          pattern: .*log:\n(?:(?:\s+console_priority:\s*debug)|(?:\s+file_priority:\s*debug)){2}.*
+          pattern: log:\n\s{2}console_priority:\sdebug\n\s+file_priority:\sdebug
 
   - it: Set console_priority
     set:
@@ -34,7 +34,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data.dragent\.yaml
-          pattern: .*log:\n(?:\s+console_priority:\s*debug).*
+          pattern: log:\n\s{2}console_priority:\sdebug
 
   - it: Set file_priority
     set:
@@ -47,7 +47,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data.dragent\.yaml
-          pattern: .*log:\n(?:\s+file_priority:\s*debug).*
+          pattern: log:\n\s{2}file_priority:\sdebug
 
   - it: Set console_priority and file_priority
     set:
@@ -61,7 +61,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data.dragent\.yaml
-          pattern: .*log:\n(?:(?:\s+console_priority:\s*debug)|(?:\s+file_priority:\s*info)){2}.*
+          pattern: log:\n\s{2}console_priority:\sdebug\n\s{2}file_priority:\sinfo
 
   - it: Verify user cannot specify sysdig.settings.log and logPriority simultaneously
     set:
@@ -72,4 +72,31 @@ tests:
       logPriority: info
     asserts:
       - failedTemplate:
-          errorMessage: 'Mutually exclusive options agent.logPriority and agent.sysdig.settings.log have been set'
+          errorMessage: 'Cannot set logPriority when either sysdig.settings.log.console_priority or sysdig.settings.log.file_priority are set'
+
+  - it: Verify log settings are rendered when no log priority values are given
+    set:
+      sysdig:
+        settings:
+          log:
+            max_size: 100
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: log:\n\s{2}max_size:\s100
+
+  - it: Verify other log settings are rendered when logPriority is set
+    set:
+      sysdig:
+        settings:
+          log:
+            max_size: 100
+      logPriority: debug
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: log:\n\s{2}console_priority:\sdebug\n\s{2}file_priority:\sdebug\n\s{2}max_size:\s100


### PR DESCRIPTION
## What this PR does / why we need it:
The initial implementation of the logPriority
flag mistakenly discarded anything other than
the console_priority and file_priority log
keys. Additionally, there was an indention
issue with whatever the subsequent line
following the 'log' items in the sysdig.settings
dictionary This change improves and simplifies
the handling of the log settings.

New tests have been created as well :)
## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
