### PR TITLE
fix(agent): Fix agent.secure.enabled flag

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.57
+version: 1.5.58
 
 appVersion: 12.10.1
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -318,3 +318,31 @@ Use global sysdig tags for agent
         {{- end -}}
     {{- end -}}
 {{- end -}}
+
+{{/*
+Determine Sysdig Secure features that need to be enabled/disabled
+*/}}
+{{- define "agent.secureFeatures" }}
+    {{- $secureBlockConfig := dict "security" (dict
+        "enabled" .Values.secure.enabled
+        "k8s_audit_server_enabled" .Values.auditLog.enabled) }}
+    {{- if .Values.auditLog.enabled }}
+        {{- range $key, $val := (dict
+                 "k8s_audit_server_url" .Values.auditLog.auditServerUrl
+                 "k8s_audit_server_port" .Values.auditLog.auditServerPort) }}
+            {{- $_ := set $secureBlockConfig.security $key $val }}
+        {{- end }}
+    {{- end }}
+    {{- if not .Values.secure.enabled }}
+        {{- range $secureFeature := (list
+            "commandlines_capture"
+            "drift_killer"
+            "falcobaseline"
+            "memdump"
+            "network_topology"
+            "secure_audit_streams") }}
+            {{- $_ := set $.Values.sysdig.settings $secureFeature (dict "enabled" false) }}
+        {{- end }}
+    {{- end }}
+    {{- toYaml $secureBlockConfig }}
+{{- end }}

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -321,6 +321,16 @@ Use global sysdig tags for agent
 
 {{/*
 Determine Sysdig Secure features that need to be enabled/disabled
+
+For secure.enabled=true, only security.enabled is set to true
+For secure.enabled=false, disable all secure features
+Set k8s_audit_server_enabled to the provided value for auditLog.enabled
+
+The logic behind enabling only security.enabled when secure.enabled=true is
+that we can then rely on the agent's defualts, or a backend push to enable
+the features the customer needs. However, when the user requests
+secure.enabled=false we need to explicitly put those config entires in the
+agent config to prevent a backend push from enabling them after installation.
 */}}
 {{- define "agent.secureFeatures" }}
     {{- $secureBlockConfig := dict "security" (dict

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -13,20 +13,7 @@ data:
 {{- if $clusterName }}
     k8s_cluster_name: {{ $clusterName }}
 {{- end }}
-{{- if or .Values.secure.enabled .Values.auditLog.enabled }}
-    security:
-  {{- if .Values.auditLog.enabled }}
-      k8s_audit_server_url: {{ .Values.auditLog.auditServerUrl }}
-      k8s_audit_server_port: {{ .Values.auditLog.auditServerPort }}
-  {{- end }}
-  {{- if .Values.secure.enabled }}
-      enabled: true
-    commandlines_capture:
-      enabled: true
-    memdump:
-      enabled: true
-  {{- end }}
-{{- end }}
+{{ include "agent.secureFeatures" . | indent 4 -}}
 {{/* skip values already set in sysdig.settings */}}
 {{- $disableCaptures := include "get_if_not_in_settings" (dict "root" . "default" .Values.sysdig.disableCaptures "setting" "sysdig_capture_enabled") }}
 {{- if eq $disableCaptures "true" }}

--- a/charts/agent/tests/secure_enable_test.yaml
+++ b/charts/agent/tests/secure_enable_test.yaml
@@ -1,0 +1,77 @@
+suite: Test enabling/disabling secure features
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: Set chart defaults (secure.enabled=true)
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: .*(?:security:\n {2}enabled:\s*true).*
+
+  - it: Set secure.enabled=true
+    set:
+      secure:
+        enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: .*(?:security:\n {2}enabled:\s*true).*
+
+  - it: Set secure.enabled=false
+    set:
+      secure:
+        enabled: false
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: .*(?:security:\n {2}enabled:\s*false).*
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: commandlines_capture:\n\ {2}enabled:\ false
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: drift_killer:\n\ {2}enabled:\ false
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: falcobaseline:\n {2}enabled:\ false
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: memdump:\n\ {2}enabled:\ false
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: network_topology:\n\ {2}enabled:\ false
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: secure_audit_streams:\n\ {2}enabled:\ false
+
+  - it: Set secure.enabled=true and auditLog.enabled=true
+    set:
+      secure:
+        enabled: true
+      auditLog:
+        enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: security:\n\ {2}enabled:\ true\n\ {2}k8s_audit_server_enabled:\ true\n\ {2}k8s_audit_server_port:\ 7765\n\ {2}k8s_audit_server_url:\ 0\.0\.0\.0
+
+  - it: Set secure.enabled=false and auditLog.enabled=true
+    set:
+      secure:
+        enabled: false
+      auditLog:
+        enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: security:\n\ {2}enabled:\ false\n {2}k8s_audit_server_enabled:\ true\n\ {2}k8s_audit_server_port:\ 7765\n\ {2}k8s_audit_server_url:\ 0\.0\.0\.0

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -212,7 +212,7 @@ secure:
 
 auditLog:
   # true here activates the K8s Audit Log feature for Sysdig Secure
-  enabled: false
+  enabled: true
   auditServerUrl: 0.0.0.0
   auditServerPort: 7765
 


### PR DESCRIPTION
## What this PR does / why we need it:
Setting `agent.secure.enabled=false` was not explicitly disabling the secure features in the generated agent configuration. Instead, the behavior was left up to the agent process's defaults, or a backend config push. This behavior is not desirable as a user who explicitly set `agent.secure.enabled=false` could have ended up with secure components running anyway. This fix ensures that setting `agent.secure.enabled=false` explicitly generates the configuration entries to force all secure components to be disabled.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
