### PR TITLE
chore(all): Update lint-test.yaml helm and ct versions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -16,9 +16,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3.5
         with:
-          version: v3.4.0
+          version: v3.10.3
 
       - uses: actions/setup-python@v4
         with:
@@ -38,7 +38,7 @@ jobs:
           git clean -df .
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.0
+        uses: helm/chart-testing-action@v2.3.1
 
       - name: Expand templates for CI
         run: |
@@ -82,9 +82,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3.5
         with:
-          version: v3.4.0
+          version: v3.10.3
 
       - uses: actions/setup-python@v4
         with:
@@ -104,7 +104,7 @@ jobs:
           git clean -df .
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.0
+        uses: helm/chart-testing-action@v2.3.1
 
       - name: Expand templates for CI
         run: |


### PR DESCRIPTION
## What this PR does / why we need it:
The version of a few of the GitHub actions and binaries we were using in our `lint-test.yaml` workflow are over 2 years old at this point and are beginning to be troublesome due to features that are missing and exist in more recent versions. This PR updates the versions of the following:

- Actions
  - azure/setup-helm [v1 --> v3.5]
  - helm/chart-testing-action [v2.2.0 --> v2.3.1]
- Binaries
  - helm [v3.4.0 --> v3.10.3]

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.
