### PR TITLE
fix(agent): Configure GOMAXPROCS to reduce CPU throttling

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.58
+version: 1.5.59
 
 appVersion: 12.10.1
 

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -158,6 +158,11 @@ spec:
             readOnlyRootFilesystem: false
             allowPrivilegeEscalation: true
           env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: requests.cpu
+                  divisor: "1"
             - name: K8S_NODE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Signed-off-by: Stevo Slavić <stevo.slavic@form3.tech>

## What this PR does / why we need it:

We're evaluating sysdig, and sysdig container in agent DaemonSet is misbehaving, CPUThrottlingHigh is alerting for it - even though it has several resource profiles defined all with CPU limits, Go runtime (since left to default) is seeing all of CPU cores on the node and starts that many native threads, with typically node cores > agent CPU limits, this increases likelihood of agent process having CPU throttled. See related known issue with Go https://github.com/golang/go/issues/33803

This PR configures GOMAXPROCS for sysdig container to be same as CPU requests to reduce CPU throttling. This way GOMAXPROCS stays in sync with chosen profile, no additional config var is introduced.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.
