### PR TITLE
fix(node-analyzer,sysdig-deploy): Added quotes to Runtime Scanner probe port

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.8.18
+version: 1.8.19
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -612,7 +612,7 @@ spec:
                 key: https_proxy
                 optional: true
           - name: PROBES_PORT
-            value: {{ .Values.nodeAnalyzer.runtimeScanner.probesPort }}
+            value: {{ .Values.nodeAnalyzer.runtimeScanner.probesPort | quote }}
           - name: NO_PROXY
             valueFrom:
               configMapKeyRef:

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.34
+version: 1.5.35
 
 maintainers:
   - name: aroberts87
@@ -31,7 +31,7 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.8.18
+    version: ~1.8.19
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: kspm-collector


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fix a missing quote for the port value of Runtime Scanner probe. Without it the deploy fails with the following message:
````
Error: UPGRADE FAILED: cannot patch "sysdig-agent-node-analyzer" with kind DaemonSet: "" is invalid v1.DaemonSet.Spec: v1.DaemonSetSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found 7, error found in #10 byte of ...|,"value":7002},{"nam|..., bigger context ...|"optional":true}}},{"name":"PROBES_PORT","value":7002},{"name":"NO_PROXY","valueFrom":{"configMapKey|...
````

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
