### PR TITLE
fix: exclude sysdig-stackdriver-bridge from ct install

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -65,7 +65,7 @@ jobs:
           k3s-version: v1.23.9+k3s1
 
       - name: Run chart-testing (install)
-        run: ct install --upgrade
+        run: ct install --upgrade --excluded-charts sysdig-stackdriver-bridge
 
   lint-test-fork:
     runs-on: ubuntu-latest
@@ -131,7 +131,7 @@ jobs:
           k3s-version: v1.23.9+k3s1
 
       - name: Run chart-testing (install)
-        run: ct install --upgrade
+        run: ct install --upgrade --excluded-charts sysdig-stackdriver-bridge
 
       - uses: actions/github-script@v5
         id: update-check-run


### PR DESCRIPTION
Signed-off-by: Michele Palazzi <michele.palazzi@sysdig.com>

## What this PR does / why we need it:

Avoid failures as in https://github.com/sysdiglabs/charts/pull/864

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
