### PR TITLE
fix(admission-controller,sysdig-deploy): fix missing namespace declarations in secrets

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.7.20
+version: 0.7.21
 appVersion: 3.9.15
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.7.20  \
+      --create-namespace -n sysdig-admission-controller --version=0.7.21  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.url=SECURE_URL \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
@@ -56,7 +56,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.20
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.21
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -182,7 +182,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.20 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.21 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,sysdig.url=SECURE_URL,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -191,7 +191,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.20 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.21 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/templates/scanner/secret.yaml
+++ b/charts/admission-controller/templates/scanner/secret.yaml
@@ -13,6 +13,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "admissionController.scanner.fullname" . }}-auth
+  namespace: {{ include "admissionController.namespace" . }}
   labels: {{- include "admissionController.scanner.labels" . | nindent 4 }}
 stringData:
   AUTH_BEARER_TOKEN: {{ include "sysdig.secureAPIToken" . }}
@@ -23,6 +24,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "admissionController.scanner.fullname" . }}-ca
+  namespace: {{ include "admissionController.namespace" . }}
   labels: {{- include "admissionController.scanner.labels" . | nindent 4 }}
 data:
   root_ca_file.crt: {{ .Values.scanner.ssl.ca.cert | b64enc | quote }}

--- a/charts/admission-controller/templates/webhook/admissionregistration.yaml
+++ b/charts/admission-controller/templates/webhook/admissionregistration.yaml
@@ -70,6 +70,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "admissionController.webhook.fullname" . }}-tls
+  namespace: {{ include "admissionController.namespace" . }}
   labels:
     {{ include "admissionController.webhook.labels" . | nindent 4 }}
 data:

--- a/charts/admission-controller/templates/webhook/secret.yaml
+++ b/charts/admission-controller/templates/webhook/secret.yaml
@@ -15,6 +15,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "admissionController.webhook.fullname" . }}-ca
+  namespace: {{ include "admissionController.namespace" . }}
   labels:
     {{ include "admissionController.webhook.labels" . | nindent 4 }}
 data:

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   - name: admission-controller
     # repository: https://charts.sysdig.com
     repository: file://../admission-controller
-    version: ~0.7.20
+    version: ~0.7.21
     alias: admissionController
     condition: admissionController.enabled
   - name: agent

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.41
+version: 1.5.42
 
 maintainers:
   - name: aroberts87


### PR DESCRIPTION
## What this PR does / why we need it:

There are secrets that were missing namespace declaration which caused them to be created in the `default` namespace.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
