### PR TITLE
feat(sysdig-deploy): Deploy KSPM by Default

### DIFF
--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.41
+version: 1.5.42
 
 maintainers:
   - name: aroberts87

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.42
+version: 1.5.43
 
 maintainers:
   - name: aroberts87

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -57,7 +57,6 @@ Currently included components:
       --set global.sysdig.accessKey=<ACCESS_KEY> \
       --set global.sysdig.region=<SAAS_REGION> \
       --set nodeAnalyzer.secure.vulnerabilityManagement.newEngineOnly=true \
-      --set global.kspm.deploy=true \
       --set nodeAnalyzer.nodeAnalyzer.benchmarkRunner.deploy=false \
       --set global.clusterConfig.name=<CLUSTER_NAME> \
       sysdig/sysdig-deploy
@@ -70,7 +69,6 @@ Currently included components:
       --set global.sysdig.accessKey=<ACCESS_KEY> \
       --set global.sysdig.region=<SAAS_REGION> \
       --set nodeAnalyzer.secure.vulnerabilityManagement.newEngineOnly=true \
-      --set global.kspm.deploy=true \
       --set nodeAnalyzer.nodeAnalyzer.benchmarkRunner.deploy=false \
       --set global.clusterConfig.name=<CLUSTER_NAME> \
       --set agent.gke.autopilot=true \
@@ -184,7 +182,7 @@ The following table lists the configurable parameters of the sysdig-deploy chart
 | `global.proxy.httpProxy`                | Sets `http_proxy` on the Agent container                                                                                | `""`      |
 | `global.proxy.httpsProxy`               | Sets `https_proxy` on the Agent container                                                                               | `""`      |
 | `global.proxy.noProxy`                  | Sets `no_proxy` on the Agent container                                                                                  | `""`      |
-| `global.kspm.deploy`                    | Enables Sysdig KSPM node analyzer & KSPM collector                                                                      | `false`   |
+| `global.kspm.deploy`                    | Enables Sysdig KSPM node analyzer & KSPM collector                                                                      | `true`   |
 | `global.agentConfigmapName`             | Sets a configmap name that is used to mount the agent configmap to fetch the cluster name and agent tags                | `"sysdig-agent"`      |
 | `global.gke.autopilot`                  | If true, overrides the configuration to values for GKE Autopilot clusters                                               | `false`   |
 | `admissionController`                   | Config specific to the [Sysdig AdmissionController](#admissioncontroller)                                               | `{}`      |

--- a/charts/sysdig-deploy/tests/golden_template_test.yaml
+++ b/charts/sysdig-deploy/tests/golden_template_test.yaml
@@ -47,6 +47,8 @@ tests:
   - it: Test cpu resources overrides
     set: 
       global:
+        clusterConfig:
+          name: test
         sysdig:
           accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
       agent:

--- a/charts/sysdig-deploy/tests/golden_template_test.yaml
+++ b/charts/sysdig-deploy/tests/golden_template_test.yaml
@@ -48,7 +48,7 @@ tests:
     set: 
       global:
         clusterConfig:
-          name: test
+          name: test-k8s
         sysdig:
           accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
       agent:

--- a/charts/sysdig-deploy/tests/notes_test.yaml
+++ b/charts/sysdig-deploy/tests/notes_test.yaml
@@ -12,6 +12,8 @@ tests:
   - it: Checking region 'us2'
     set:
       global: 
+        clusterConfig:
+          name: test-k8s
         sysdig:
           region: us2
     asserts:
@@ -23,6 +25,8 @@ tests:
   - it: Checking region 'us3'
     set:
       global: 
+        clusterConfig:
+          name: test-k8s
         sysdig:
           region: us3
     asserts:
@@ -34,6 +38,8 @@ tests:
   - it: Checking region 'us4'
     set:
       global: 
+        clusterConfig:
+          name: test-k8s
         sysdig:
           region: us4
     asserts:
@@ -45,6 +51,8 @@ tests:
   - it: Checking region 'eu1'
     set:
       global: 
+        clusterConfig:
+          name: test-k8s
         sysdig:
           region: eu1
     asserts:
@@ -56,6 +64,8 @@ tests:
   - it: Checking region 'au1'
     set:
       global: 
+        clusterConfig:
+          name: test-k8s
         sysdig:
           region: au1
     asserts:
@@ -67,6 +77,8 @@ tests:
   - it: Checking incorrect region 'ap3' should fail
     set:
       global: 
+        clusterConfig:
+          name: test-k8s
         sysdig:
           region: ap3
     asserts:

--- a/charts/sysdig-deploy/tests/readme_command_test.yaml
+++ b/charts/sysdig-deploy/tests/readme_command_test.yaml
@@ -45,6 +45,8 @@ tests:
   - it: check Readme install command under "NodeAnalyzer" example 
     set:
       global:
+        clusterConfig:
+          name: test-k8s
         sysdig:
           accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
       agent:
@@ -66,6 +68,8 @@ tests:
   - it: check Readme install command under "Rapid Response" example 
     set:
       global:
+        clusterConfig:
+          name: test-k8s
         sysdig:
           accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
       rapidResponse:

--- a/charts/sysdig-deploy/values.yaml
+++ b/charts/sysdig-deploy/values.yaml
@@ -11,7 +11,7 @@ global:
     tags: {}
   proxy: {}
   kspm:
-    deploy: false
+    deploy: true
   agentConfigmapName: "sysdig-agent"
   gke:
     autopilot: false


### PR DESCRIPTION
## What this PR does / why we need it:
Enables KSPM component.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
