### PR TITLE
chore(agent,sysdig,sysdig-deploy): Update sysdig, agent, and sysdig-deploy chart CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # request review from agent team members for changes to sysdig chart
-/charts/sysdig/         @aroberts87 @ironashram @yashgiri @lilx1ao
-/charts/agent/          @aroberts87 @ironashram @yashgiri @lilx1ao
-/charts/sysdig-deploy/  @aroberts87 @ironashram @yashgiri @lilx1ao
+/charts/sysdig/         @sysdiglabs/team-tools-agent
+/charts/agent/          @sysdiglabs/team-tools-agent
+/charts/sysdig-deploy/  @sysdiglabs/team-tools-agent
 
 /charts/admission-controller @sysdiglabs/cloud-native
 /charts/cloud-connector @sysdiglabs/cloud-native


### PR DESCRIPTION
## What this PR does / why we need it:
Update the CODEOWNERS file to use the @sysdiglabs/team-tools-agent GitHub team
handle for the sysdig, agent, and sysdig-deploy charts. This is an improvement over explicitly
listing out usernames.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.
