### PR TITLE
fix(admission-controller,sydig-deploy): fix priorityClassName in wrong scope for scanner deployment

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.7.21
+version: 0.7.22
 appVersion: 3.9.15
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.7.21  \
+      --create-namespace -n sysdig-admission-controller --version=0.7.22  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.url=SECURE_URL \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
@@ -56,7 +56,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.21
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.22
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -182,7 +182,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.21 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.22 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,sysdig.url=SECURE_URL,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -191,7 +191,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.21 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.22 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/templates/scanner/deployment.yaml
+++ b/charts/admission-controller/templates/scanner/deployment.yaml
@@ -115,10 +115,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.scanner.tolerations }}
       {{- if .Values.scanner.priorityClassName }}
       priorityClassName: "{{ .Values.scanner.priorityClassName }}"
       {{- end }}
+      {{- with .Values.scanner.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.46
+version: 1.5.47
 
 maintainers:
   - name: aroberts87
@@ -19,7 +19,7 @@ dependencies:
   - name: admission-controller
     # repository: https://charts.sysdig.com
     repository: file://../admission-controller
-    version: ~0.7.21
+    version: ~0.7.22
     alias: admissionController
     condition: admissionController.enabled
   - name: agent


### PR DESCRIPTION
## What this PR does / why we need it:

When trying to install sydig admission controller with scanner it fails with the following error:
`Error: INSTALLATION FAILED: template: admission-controller/templates/scanner/deployment.yaml:119:20: executing "admission-controller/templates/scanner/deployment.yaml" at <.Values.scanner.priorityClassName>: can't evaluate field Values in type []interface {}`

### To reproduce
Clone repo and cd into charts directory, run following command:
`helm install sysdig-admission-controller ./admission-controller \
--set sysdig.secureAPIToken=***** \
--set clusterName=#ClusterName# \
--set features.k8sAuditDetections=true \
--set sysdig.url=https://eu1.app.sysdig.com \
--create-namespace \
--set-string scanner.tolerations[0].value=true \
--set scanner.tolerations[0].key=CriticalAddonsOnly \
--set scanner.tolerations[0].operator=Equal \
--set scanner.tolerations[0].effect=NoSchedule`

#### Helm version
`version.BuildInfo{Version:"v3.10.3", GitCommit:"835b7334cfe2e5e27870ab3ed4135f136eecc704", GitTreeState:"clean", GoVersion:"go1.18.9"}`

#### Issue

Priority class name logic was inserted within the tolerations scope (line 118).

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
