### PR TITLE
feat(agent,node-analyzer,rapid-response): add Rancher-specific tolerations

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.56
+version: 1.5.57
 
 appVersion: 12.10.1
 

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -195,7 +195,8 @@ sysdig:
   disableCaptures: false
 
   # Advanced settings. Any option in here will be directly translated into dragent.yaml in the Configmap
-  settings: {}
+  settings:
+    {}
     ### Example: Agent tags
     # tags: linux:ubuntu,dept:dev,local:nyc
     ### Example: Proxy configuration (see https://docs.sysdig.com/en/enable-http-proxy-for-agents.html)
@@ -246,7 +247,8 @@ extraVolumes:
   #     - mountPath: /opt/draios/secret
   #       name: sysdig-new-secret
 
-extraSecrets: []
+extraSecrets:
+  []
   # Allow passing extra secrets that can be mounted via extraVolumes
   #
   # extraSecrets:
@@ -261,6 +263,8 @@ tolerations:
     key: node-role.kubernetes.io/master
   - effect: NoSchedule
     key: node-role.kubernetes.io/control-plane
+  - effect: NoExecute
+    key: node-role.kubernetes.io/etcd
 
 leaderelection:
   enable: false

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -263,6 +263,8 @@ tolerations:
     key: node-role.kubernetes.io/master
   - effect: NoSchedule
     key: node-role.kubernetes.io/control-plane
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/controlplane
     operator: Equal
     value: "true"
   - effect: NoExecute

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -263,8 +263,12 @@ tolerations:
     key: node-role.kubernetes.io/master
   - effect: NoSchedule
     key: node-role.kubernetes.io/control-plane
+    operator: Equal
+    value: "true"
   - effect: NoExecute
     key: node-role.kubernetes.io/etcd
+    operator: Equal
+    value: "true"
 
 leaderelection:
   enable: false

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.8.25
+version: 1.8.26
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -106,8 +106,12 @@ nodeAnalyzer:
       key: node-role.kubernetes.io/master
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
+      operator: Equal
+      value: "true"
     - effect: NoExecute
       key: node-role.kubernetes.io/etcd
+      operator: Equal
+      value: "true"
 
   # Set nodeAnalyzer daemonset priorityClassName
   priorityClassName:

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -106,6 +106,8 @@ nodeAnalyzer:
       key: node-role.kubernetes.io/master
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
+    - effect: NoExecute
+      key: node-role.kubernetes.io/etcd
 
   # Set nodeAnalyzer daemonset priorityClassName
   priorityClassName:

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -106,6 +106,8 @@ nodeAnalyzer:
       key: node-role.kubernetes.io/master
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/controlplane
       operator: Equal
       value: "true"
     - effect: NoExecute

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rapid-response/values.yaml
+++ b/charts/rapid-response/values.yaml
@@ -60,7 +60,8 @@ rapidResponse:
   # Import custom CA certificates
   ssl:
     ca:
-      certs: []
+      certs:
+        []
         # Example of certificate
         # - |
         #     -----BEGIN CERTIFICATE-----
@@ -164,14 +165,16 @@ rapidResponse:
 
   # Allow sysdig to run on Kubernetes 1.6 masters.
   tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+    - effect: NoExecute
+      key: node-role.kubernetes.io/etcd
 
 tests:
   rbac:
-  # true here enables creation of rbac resources
+    # true here enables creation of rbac resources
     create: true
   serviceAccount:
     # true here enables creation of service account

--- a/charts/rapid-response/values.yaml
+++ b/charts/rapid-response/values.yaml
@@ -169,8 +169,12 @@ rapidResponse:
       key: node-role.kubernetes.io/master
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
+      operator: Equal
+      value: "true"
     - effect: NoExecute
       key: node-role.kubernetes.io/etcd
+      operator: Equal
+      value: "true"
 
 tests:
   rbac:

--- a/charts/rapid-response/values.yaml
+++ b/charts/rapid-response/values.yaml
@@ -169,6 +169,8 @@ rapidResponse:
       key: node-role.kubernetes.io/master
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/controlplane
       operator: Equal
       value: "true"
     - effect: NoExecute

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.5.56
+    version: ~1.5.57
     alias: agent
     condition: agent.enabled
   - name: node-analyzer
@@ -43,6 +43,6 @@ dependencies:
   - name: rapid-response
     # repository: https://charts.sysdig.com
     repository: file://../rapid-response
-    version: ~0.4.2
+    version: ~0.4.3
     alias: rapidResponse
     condition: rapidResponse.enabled

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.50
+version: 1.5.51
 
 maintainers:
   - name: aroberts87
@@ -31,7 +31,7 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.8.25
+    version: ~1.8.26
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: kspm-collector

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.69
+version: 1.15.70
 appVersion: 12.10.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -357,8 +357,14 @@ nodeAnalyzer:
       key: node-role.kubernetes.io/master
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/controlplane
+      operator: Equal
+      value: "true"
     - effect: NoExecute
       key: node-role.kubernetes.io/etcd
+      operator: Equal
+      value: "true"
 
   # Set nodeAnalyzer daemonset priorityClassName
   priorityClassName:

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -189,7 +189,8 @@ sysdig:
   disableCaptures: false
 
   # Advanced settings. Any option in here will be directly translated into dragent.yaml in the Configmap
-  settings: {}
+  settings:
+    {}
     ### Example: Agent tags
     # tags: linux:ubuntu,dept:dev,local:nyc
     ### Example: Proxy configuration (see https://docs.sysdig.com/en/enable-http-proxy-for-agents.html)
@@ -337,7 +338,6 @@ nodeAnalyzer:
   # * On-Prem: sysdig.my.company.com
   apiEndpoint: ""
 
-
   # Can be set to false to allow insecure connections to the Sysdig backend,
   # such as for on-premise installs that use self-signed certificates.
   # By default, certificates are always verified.
@@ -357,6 +357,8 @@ nodeAnalyzer:
       key: node-role.kubernetes.io/master
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
+    - effect: NoExecute
+      key: node-role.kubernetes.io/etcd
 
   # Set nodeAnalyzer daemonset priorityClassName
   priorityClassName:
@@ -595,7 +597,8 @@ kspmCollector:
 
   env: {}
 
-customAppChecks: {}
+customAppChecks:
+  {}
   # Allow passing custom app checks for Sysdig Agent.
   # Example:
   #
@@ -633,7 +636,8 @@ extraVolumes:
   #     - mountPath: /opt/draios/secret
   #       name: sysdig-new-secret
 
-extraSecrets: []
+extraSecrets:
+  []
   # Allow passing extra secrets that can be mounted via extraVolumes
   #
   # extraSecrets:
@@ -648,6 +652,8 @@ tolerations:
     key: node-role.kubernetes.io/master
   - effect: NoSchedule
     key: node-role.kubernetes.io/control-plane
+  - effect: NoExecute
+    key: node-role.kubernetes.io/etcd
 
 leaderelection:
   enable: false

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -652,6 +652,8 @@ tolerations:
     key: node-role.kubernetes.io/master
   - effect: NoSchedule
     key: node-role.kubernetes.io/control-plane
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/controlplane
     operator: Equal
     value: "true"
   - effect: NoExecute

--- a/charts/sysdig/values.yaml
+++ b/charts/sysdig/values.yaml
@@ -652,8 +652,12 @@ tolerations:
     key: node-role.kubernetes.io/master
   - effect: NoSchedule
     key: node-role.kubernetes.io/control-plane
+    operator: Equal
+    value: "true"
   - effect: NoExecute
     key: node-role.kubernetes.io/etcd
+    operator: Equal
+    value: "true"
 
 leaderelection:
   enable: false


### PR DESCRIPTION
## What this PR does / why we need it:

Add Rancher-specific tolerations to various components to allow them to run in control-plane or etcd nodes by default

Successfully tested on a Rancher cluster

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
