### PR TITLE
fix(node-analyzer): Bump kspm node analyzer

### DIFF
--- a/charts/sysdig-deploy/CHANGELOG.md
+++ b/charts/sysdig-deploy/CHANGELOG.md
@@ -10,6 +10,9 @@ Manual edits are supported only below '## Change Log' and should be used
 exclusively to fix incorrect entries and not to add new ones.
 
 ## Change Log
+# v1.5.50
+### Bug Fixes
+* **node-analyzer,sydig-deploy** [7693f02](https://github.com/sysdiglabs/charts/commit/771c5846a79dd78a3a69ba20553a1c8f3e93b2ed): Make the readinessProbe and livenessProbe configurable for kspm node-analyzer ([#888](https://github.com/sysdiglabs/charts/issues/888))
 # v1.5.49
 ### Chores
 * **sysdig-deploy** [70d5764](https://github.com/sysdiglabs/charts/commit/70d57645b53c5e038bd0b2d2f7ef587ec78ef5c9): Automatic version bump due to updated dependencies ([#883](https://github.com/sysdiglabs/charts/issues/883))

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.49
+version: 1.5.50
 
 maintainers:
   - name: aroberts87
@@ -31,7 +31,7 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.8.24
+    version: ~1.8.25
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: kspm-collector


### PR DESCRIPTION
## What this PR does / why we need it:

Bump the kspm node analyzer with the configurable probes

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
