### PR TITLE
feat(kspm-collector): Make probes configurable

### DIFF
--- a/charts/kspm-collector/CHANGELOG.md
+++ b/charts/kspm-collector/CHANGELOG.md
@@ -10,6 +10,9 @@ Manual edits are supported only below '## Change Log' and should be used
 exclusively to fix incorrect entries and not to add new ones.
 
 ## Change Log
+# v0.1.32
+### Minor changes
+* Allow to configure liveness and readiness probes
 # v0.1.31
 ### Bug Fixes
 * **kspm-collector** [a7aea8a](https://github.com/sysdiglabs/charts/commit/a7aea8af8469a0b2bda6230cfa11f1debbbf9a05): CVE-2022-32149 ([#834](https://github.com/sysdiglabs/charts/issues/834))

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.1.31
+version: 0.1.32
 appVersion: 1.16.0
 keywords:
   - monitoring

--- a/charts/kspm-collector/README.md
+++ b/charts/kspm-collector/README.md
@@ -61,8 +61,8 @@ The following table lists the configurable parameters of the Sysdig KSPM Collect
 | `affinity`                                | Node affinities. Overrides `arch` and `os` values                                       | `{}`                                                        |
 | `labels`                                  | KSPM collector specific labels (as a multi-line templated string map or as YAML)        | `{}`                                                        |
 | `port`                                    | KSPM collector port for health checks                                                   | `8080`                                                      |
-| `probes.initialDelay`                     | KSPM collector initial delay before starting k8s health checks in seconds               | `90`                                                         |
-| `probes.periodDelay`                      | KSPM collector delay beetween two consecutive k8s health checks in seconds              | `3`                                                         |
+| `readinessProbe.enabled`                  | KSPM collector readinessProbe enablement                                                | `true`                                                         |
+| `livenessProbe.enabled`                   | KSPM collector livenessProbe enablement                                                 | `true`                                                         |
 | `securityContext.runAsNonRoot`            | make KSPM collector run as non root                                                     | `true`                                                      |
 | `securityContext.runAsUser`               | make KSPM collector run as user with this ID                                            | `10001`                                                     |
 | `securityContext.runAsGroup`              | make KSPM collector run as group with this ID                                           | `10001`                                                     |

--- a/charts/kspm-collector/templates/deployment.yaml
+++ b/charts/kspm-collector/templates/deployment.yaml
@@ -62,18 +62,18 @@ spec:
           - name: http
             containerPort: {{ .Values.port }}
             protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: http
-          initialDelaySeconds: {{ .Values.probes.initialDelay }}
-          periodSeconds: {{ .Values.probes.periodDelay }}
+        {{- if .Values.readinessProbe.enabled }}
+        {{- with .Values.readinessProbe.probe }}
         readinessProbe:
-          httpGet:
-            path: /health
-            port: http
-          initialDelaySeconds: {{ .Values.probes.initialDelay }}
-          periodSeconds: {{ .Values.probes.periodDelay }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.livenessProbe.enabled }}
+        {{- with .Values.livenessProbe.probe }}
+        livenessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:

--- a/charts/kspm-collector/values.yaml
+++ b/charts/kspm-collector/values.yaml
@@ -82,9 +82,22 @@ resources:
 
 port: 8080
 
-probes:
-  initialDelay: 90
-  periodDelay: 3
+readinessProbe:
+  enabled: true
+  probe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 90
+    periodSeconds: 3
+livenessProbe:
+  enabled: true
+  probe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 90
+    periodSeconds: 3
 
 securityContext:
   runAsNonRoot: true


### PR DESCRIPTION
## What this PR does / why we need it:

Make the kspm collector probes configurable

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
