### PR TITLE
fix: point to sysdig quay repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
     needs: charts-to-release
     if: needs.charts-to-release.outputs.modified-charts-files
     runs-on: ubuntu-latest
-    container: quay.io/ironashram/git-chglog:0.15.1-3-g6e4e27d
+    container: quay.io/sysdig/git-chglog:0.15.1-3-g6e4e27d
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Michele Palazzi <sysdadmin@m1k.cloud>

## What this PR does / why we need it:

Use the correct repo for git-chglog image

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)


Check Contribution guidelines in README.md for more insight.
