### PR TITLE
fix(node-analyzer,sysdig-deploy): Global proxy values for host-scanner

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.8.26
+version: 1.8.27
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/configmap-host-scanner.yaml
+++ b/charts/node-analyzer/templates/configmap-host-scanner.yaml
@@ -30,13 +30,13 @@ data:
   ssl_verify_certificate: "{{ .Values.nodeAnalyzer.sslVerifyCertificate }}"
   {{- end }}
   debug: "{{ .Values.nodeAnalyzer.debug | default false }}"
-  {{- if .Values.nodeAnalyzer.httpProxy }}
-  http_proxy: {{ .Values.nodeAnalyzer.httpProxy }}
+  {{- if (.Values.nodeAnalyzer.httpProxy | default .Values.global.proxy.httpProxy) }}
+  http_proxy: {{ .Values.nodeAnalyzer.httpProxy | default .Values.global.proxy.httpProxy }}
   {{- end -}}
-  {{- if .Values.nodeAnalyzer.httpsProxy }}
-  https_proxy: {{ .Values.nodeAnalyzer.httpsProxy }}
+  {{- if (.Values.nodeAnalyzer.httpsProxy | default .Values.global.proxy.httpsProxy) }}
+  https_proxy: {{ .Values.nodeAnalyzer.httpsProxy | default .Values.global.proxy.httpsProxy }}
   {{- end -}}
-  {{- if .Values.nodeAnalyzer.noProxy }}
-  no_proxy: {{ .Values.nodeAnalyzer.noProxy }}
+  {{- if (.Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy) }}
+  no_proxy: {{ .Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy }}
   {{- end -}}
 {{- end }}

--- a/charts/node-analyzer/tests/hostscanner_test.yaml
+++ b/charts/node-analyzer/tests/hostscanner_test.yaml
@@ -150,3 +150,47 @@ tests:
           of: ConfigMap
       - isNull:
           path: data.additional_dirs_to_scan
+
+  - it: "Global proxy settings are set"
+    set:
+      clusterName: "test"
+      nodeAnalyzer.hostScanner.deploy: true
+      global.proxy.httpProxy: "http://squid.domain.local:3128"
+      global.proxy.httpsProxy: "http://squid.domain.local:3128"
+      global.proxy.noProxy: "100.64.0.0/10"
+    templates:
+      - ../templates/configmap-host-scanner.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.http_proxy
+          value: "http://squid.domain.local:3128"
+      - equal:
+          path: data.https_proxy
+          value: "http://squid.domain.local:3128"
+      - equal:
+          path: data.no_proxy
+          value: "100.64.0.0/10"
+
+  - it: "Proxy settings are set"
+    set:
+      clusterName: "test"
+      nodeAnalyzer.hostScanner.deploy: true
+      nodeAnalyzer.httpProxy: "http://squid.domain.local:3128"
+      nodeAnalyzer.httpsProxy: "http://squid.domain.local:3128"
+      nodeAnalyzer.noProxy: "100.64.0.0/10"
+    templates:
+      - ../templates/configmap-host-scanner.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.http_proxy
+          value: "http://squid.domain.local:3128"
+      - equal:
+          path: data.https_proxy
+          value: "http://squid.domain.local:3128"
+      - equal:
+          path: data.no_proxy
+          value: "100.64.0.0/10"

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.54
+version: 1.5.55
 
 maintainers:
   - name: aroberts87
@@ -31,7 +31,7 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.8.26
+    version: ~1.8.27
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: kspm-collector


### PR DESCRIPTION
## What this PR does / why we need it:
Allow the usage of global proxy settings on host-scanner component

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
