### PR TITLE
feat(registry-scanner): Add experimental cache PVC

### DIFF
--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.1.7
+version: 0.1.8
 appVersion: 0.2.3
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -141,6 +141,8 @@ The following table lists the configurable parameters of the Sysdig Registry Sca
 | nodeSelector                       | Configure nodeSelector for scheduling the registry scanner pod.                                                                                                                                                              | <code>{}</code>                                                     |
 | tolerations                        | Configure tolerations for scheduling the registry scanner pod.                                                                                                                                                               | <code>[]</code>                                                     |
 | affinity                           | Configure affinity for scheduling the registry scanner pod.                                                                                                                                                                  | <code>{}</code>                                                     |
+| experimental.cache.enabled         | Enable the experimental cache. Expect this field to be removed in the future.                                                                                                                                                | <code>false</code>                                                  |
+| experimental.cache.size            | The size of the cache. Expect this field to be removed in the future.                                                                                                                                                        | <code>8Gi</code>                                                    |
 
 
 

--- a/charts/registry-scanner/templates/cache-pvc.yaml
+++ b/charts/registry-scanner/templates/cache-pvc.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.experimental.cache.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "registry-scanner.fullname" . }}-cache
+spec:
+  accessModes:
+  - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: {{ .Values.experimental.cache.size }}
+{{- end -}}

--- a/charts/registry-scanner/templates/cronjob.yaml
+++ b/charts/registry-scanner/templates/cronjob.yaml
@@ -62,6 +62,10 @@ spec:
             - name: ca-certs
               mountPath: "/ca-certs"
             {{- end }}
+            {{- if .Values.experimental.cache.enabled }}
+            - name: cache-storage
+              mountPath: "/tmp/sysdig-image-scanner-cache.db"
+            {{- end }}
             env:
               - name: SECURE_API_TOKEN
                 valueFrom:
@@ -166,4 +170,9 @@ spec:
           - name: report-storage
             persistentVolumeClaim:
               claimName: {{ .Values.reportToPersistentVolumeClaim }}
+          {{- end }}
+          {{- if .Values.experimental.cache.enabled }}
+          - name: cache-storage
+            persistentVolumeClaim:
+              claimName: {{ include "registry-scanner.fullname" . }}-cache
           {{- end }}

--- a/charts/registry-scanner/values.yaml
+++ b/charts/registry-scanner/values.yaml
@@ -182,3 +182,10 @@ nodeSelector: {}
 tolerations: []
 # Configure affinity for scheduling the registry scanner pod.
 affinity: {}
+
+experimental:
+  cache:
+    # Enable the experimental cache. Expect this field to be removed in the future.
+    enabled: false
+    # The size of the cache. Expect this field to be removed in the future.
+    size: 8Gi


### PR DESCRIPTION
## What this PR does / why we need it:

Adds an experimental cache PVC

⚠️ currently, the usage of this cache is not threat-safe, so we cannot use it in the per-job-scanning.
waiting to resolve it before merging