### PR TITLE
feat(agent,sysdig-deploy): Implement global plan settings

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.58
+version: 1.6.0
 
 appVersion: 12.10.1
 

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -277,19 +277,6 @@ $ helm install --namespace sysdig-agent sysdig-agent -f values.yaml sysdig/agent
 You can read more details about this
 in [Kubernetes Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
-## Secure Light Mode
-[Secure Light](https://docs.sysdig.com/en/docs/installation/sysdig-agent/agent-configuration/configure-agent-modes/#secure-light) mode offers reduced Agent resource consumption by enabling only a curated subset of Sysdig Secure features. Those features are:
- - Runtime Policies
- - Activity Audit
- - Captures
-
-Sysdig Agent version 12.10 or above is needed for Secure Light mode. 
-
-To deploy the Sysdig Agent in Secure Light mode, run:
-```bash
-$ helm install --namespace sysdig-agent sysdig-agent --set sysdig.settings.features.mode=secure_light sysdig/agent
-```
-
 ## Modifying Sysdig agent configuration
 
 The Sysdig agent uses a file called `dragent.yaml` to store the configuration.

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -277,6 +277,19 @@ $ helm install --namespace sysdig-agent sysdig-agent -f values.yaml sysdig/agent
 You can read more details about this
 in [Kubernetes Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
+## Secure Light Mode
+[Secure Light](https://docs.sysdig.com/en/docs/installation/sysdig-agent/agent-configuration/configure-agent-modes/#secure-light) mode offers reduced Agent resource consumption by enabling only a curated subset of Sysdig Secure features. Those features are:
+ - Runtime Policies
+ - Activity Audit
+ - Captures
+
+Sysdig Agent version 12.10 or above is needed for Secure Light mode. 
+
+To deploy the Sysdig Agent in Secure Light mode, run:
+```bash
+$ helm install --namespace sysdig-agent sysdig-agent --set sysdig.settings.features.mode=secure_light sysdig/agent
+```
+
 ## Modifying Sysdig agent configuration
 
 The Sysdig agent uses a file called `dragent.yaml` to store the configuration.

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -335,7 +335,7 @@ and set the agent chart parameters accordingly
     {{- if and (and (hasKey .Values.global.sysdig "secure")
                     (not .Values.global.sysdig.secure))
                     .Values.secureFeatProvided }}
-        {{ fail "Cannot unset global.sysdig.secure when agent.sysdig.settings.feature.mode is secure or secure_light" }}
+        {{ fail "Set global.sysdig.secure=true when specifying agent.sysdig.settings.feature.mode=secure or agent.sysdig.settings.feature.mode=secure_light" }}
     {{- end }}
     {{- if and (and (hasKey .Values.global.sysdig "monitor")
                     .Values.global.sysdig.monitor)

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
 {{- if $clusterName }}
     k8s_cluster_name: {{ $clusterName }}
 {{- end }}
-{{ include "agent.secureFeatures" . | indent 4 -}}
+{{- include "agent.planSettings" . | indent 4 -}}
 {{/* skip values already set in sysdig.settings */}}
 {{- $disableCaptures := include "get_if_not_in_settings" (dict "root" . "default" .Values.sysdig.disableCaptures "setting" "sysdig_capture_enabled") }}
 {{- if eq $disableCaptures "true" }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -210,6 +210,10 @@ secure:
   # true here enables Sysdig Secure: container run-time security & forensics
   enabled: true
 
+monitor:
+  # true here enables Sysdig Monitor components
+  enabled: true
+
 auditLog:
   # true here activates the K8s Audit Log feature for Sysdig Secure
   enabled: true

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
     repository: file://../admission-controller
     version: ~0.7.23
     alias: admissionController
-    condition: admissionController.enabled,global.sysdig.plan.secure
+    condition: admissionController.enabled,global.sysdig.secure
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
@@ -33,16 +33,16 @@ dependencies:
     repository: file://../node-analyzer
     version: ~1.8.27
     alias: nodeAnalyzer
-    condition: nodeAnalyzer.enabled,global.sysdig.plan.secure
+    condition: nodeAnalyzer.enabled,global.sysdig.secure
   - name: kspm-collector
     # repository: https://charts.sysdig.com
     repository: file://../kspm-collector
     version: ~0.1.32
     alias: kspmCollector
-    condition: global.kspm.deploy,global.sysdig.plan.secure
+    condition: global.kspm.deploy,global.sysdig.secure
   - name: rapid-response
     # repository: https://charts.sysdig.com
     repository: file://../rapid-response
     version: ~0.4.5
     alias: rapidResponse
-    condition: rapidResponse.enabled,global.sysdig.plan.secure
+    condition: rapidResponse.enabled,global.sysdig.secure

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.56
+version: 1.6.0
 
 maintainers:
   - name: aroberts87
@@ -21,11 +21,11 @@ dependencies:
     repository: file://../admission-controller
     version: ~0.7.23
     alias: admissionController
-    condition: admissionController.enabled
+    condition: admissionController.enabled,global.sysdig.plan.secure
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.5.58
+    version: ~1.6.0
     alias: agent
     condition: agent.enabled
   - name: node-analyzer
@@ -33,16 +33,16 @@ dependencies:
     repository: file://../node-analyzer
     version: ~1.8.27
     alias: nodeAnalyzer
-    condition: nodeAnalyzer.enabled
+    condition: nodeAnalyzer.enabled,global.sysdig.plan.secure
   - name: kspm-collector
     # repository: https://charts.sysdig.com
     repository: file://../kspm-collector
     version: ~0.1.32
     alias: kspmCollector
-    condition: global.kspm.deploy
+    condition: global.kspm.deploy,global.sysdig.plan.secure
   - name: rapid-response
     # repository: https://charts.sysdig.com
     repository: file://../rapid-response
     version: ~0.4.5
     alias: rapidResponse
-    condition: rapidResponse.enabled
+    condition: rapidResponse.enabled,global.sysdig.plan.secure

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -176,6 +176,8 @@ The following table lists the configurable parameters of the sysdig-deploy chart
 | `global.clusterConfig.name`             | Identifier for this cluster                                                                                             | `""`      |
 | `global.sysdig.accessKey`               | Sysdig Agent Access Key                                                                                                 | `""`      |
 | `global.sysdig.accessKeySecret`         | The name of a Kubernetes secret containing an 'access-key' entry                                                        | `""`      |
+| `global.sysdig.monitor`                 | Enable all Sysdig Monitor charts and components                                                                         | `true`    |
+| `global.sysdig.secure`                  | Enable all Sysdig Secure charts and components                                                                          | `true`    |
 | `global.sysdig.secureAPIToken`          | API Token to access Sysdig Secure                                                                                       | `""`      |
 | `global.sysdig.secureAPITokenSecret`    | The name of a Kubernetes secret containing API Token to access Sysdig Secure                                            | `""`      |
 | `global.sysdig.region`                  | The SaaS region for these agents. Possible values: `"us1"`, `"us2"`, `"us3"`, `"us4"`, `"eu1"`, `"au1"`, and `"custom"`. See [Regions and IP Ranges](https://docs.sysdig.com/en/docs/administration/saas-regions-and-ip-ranges/) for more information  | `"us1"`   |
@@ -202,6 +204,42 @@ The following table lists the configurable parameters of the sysdig-deploy chart
 | `kspmCollector.apiEndpoint`             | kspmCollector apiEndpoint                                                                                               | `""`      |
 | `rapidResponse`                         | Config specific to [Sysdig Rapid Response](#rapid-response)                                                             | `{}`      |
 | `rapidResponse.enabled`                 | Enable Rapid Response component in this chart                                                                           | `""`      |
+
+## Sysdig Plan Settings
+The `global.sysdig.monitor` and `global.sysdig.secure` parameters allow for easy, convenient control over deployed charts and chart configurations depending on the Sysdig plan desired.
+
+Per chart overrides are supported should modifications to these sets be desired. For example, to deploy the [kspm-collector](https://github.com/sysdiglabs/charts/tree/master/charts/kspm-collector) in addition to the other Sysdig Secure components, the following command can be used:
+```bash
+$ helm install --namespace sysdig --set global.kspm.deploy=true --set global.sysdig.secure=true sysdig sysdig/sysdig-deploy
+```
+
+### Sysdig Monitor
+
+Setting `global.sysdig.monitor=true` will deploy and configure the Sysdig Agent with all features necessary to support the Sysdig Monitor product. Disabling the setting will deploy the Sysdig Agent with the following features disabled:
+ - App Checks
+ - JMX
+ - Prometheus
+ - StatsD
+
+### Sysdig Secure
+Setting `global.sysdig.secure=true` will deploy the following charts:
+ - [agent](https://github.com/sysdiglabs/charts/tree/master/charts/agent)
+ - [node-analyzer](https://github.com/sysdiglabs/charts/tree/master/charts/node-analyzer)
+
+Disabling `global.sysdig.secure` will result in only the Sysdig Agent being deployed and all Sysdig Secure components in the Sysdig Agent being disabled.
+
+#### Secure Light Mode
+The Sysdig Agent has support for a [Secure Light](https://docs.sysdig.com/en/docs/installation/sysdig-agent/agent-configuration/configure-agent-modes/#secure-light) mode that offers reduced Agent resource consumption by enabling only a curated subset of Sysdig Secure features. Those features are:
+ - Runtime Policies
+ - Activity Audit
+ - Captures
+
+Sysdig Agent version 12.10 or above is needed for Secure Light mode. 
+
+To deploy the Sysdig Agent in Secure Light mode, run:
+```bash
+$ helm install --namespace sysdig --set agent.sysdig.settings.features.mode=secure_light sysdig sysdig/sysdig-deploy
+```
 
 ## AdmissionController
 

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -206,7 +206,7 @@ The following table lists the configurable parameters of the sysdig-deploy chart
 | `rapidResponse.enabled`                 | Enable Rapid Response component in this chart                                                                           | `""`      |
 
 ## Sysdig Plan Settings
-The `global.sysdig.monitor` and `global.sysdig.secure` parameters allow for easy, convenient control over deployed charts and chart configurations depending on the Sysdig plan desired.
+The `global.sysdig.monitor` and `global.sysdig.secure` parameters allow for easy, convenient control over deployed charts and chart configurations depending on the Sysdig plan desired. Enabling both `global.sysdig.monitor` and `global.sysdig.secure` results in a Sysdig Platform installation. 
 
 Per chart overrides are supported should modifications to these sets be desired. For example, to deploy the [kspm-collector](https://github.com/sysdiglabs/charts/tree/master/charts/kspm-collector) in addition to the other Sysdig Secure components, the following command can be used:
 ```bash
@@ -227,19 +227,6 @@ Setting `global.sysdig.secure=true` will deploy the following charts:
  - [node-analyzer](https://github.com/sysdiglabs/charts/tree/master/charts/node-analyzer)
 
 Disabling `global.sysdig.secure` will result in only the Sysdig Agent being deployed and all Sysdig Secure components in the Sysdig Agent being disabled.
-
-#### Secure Light Mode
-The Sysdig Agent has support for a [Secure Light](https://docs.sysdig.com/en/docs/installation/sysdig-agent/agent-configuration/configure-agent-modes/#secure-light) mode that offers reduced Agent resource consumption by enabling only a curated subset of Sysdig Secure features. Those features are:
- - Runtime Policies
- - Activity Audit
- - Captures
-
-Sysdig Agent version 12.10 or above is needed for Secure Light mode. 
-
-To deploy the Sysdig Agent in Secure Light mode, run:
-```bash
-$ helm install --namespace sysdig --set agent.sysdig.settings.features.mode=secure_light sysdig sysdig/sysdig-deploy
-```
 
 ## AdmissionController
 

--- a/charts/sysdig-deploy/tests/plan_settings_test.yaml
+++ b/charts/sysdig-deploy/tests/plan_settings_test.yaml
@@ -1,0 +1,229 @@
+suite: Test global.sysdig plan values to enable/disable subcharts
+templates:
+  - charts/agent/templates/configmap.yaml
+  - charts/agent/templates/daemonset.yaml
+  - charts/nodeAnalyzer/templates/configmap-benchmark-runner.yaml
+  - charts/nodeAnalyzer/templates/configmap-host-analyzer.yaml
+  - charts/nodeAnalyzer/templates/configmap-image-analyzer.yaml
+  - charts/nodeAnalyzer/templates/daemonset-node-analyzer.yaml
+tests:
+  - it: Test enabling monitor and secure plans
+    set:
+      global:
+        sysdig:
+          accessKey: "AAAA-BBBB-CCCC-DDDD"
+          monitor: true
+          secure: true
+    asserts:
+      - containsDocument:
+          kind: DaemonSet
+          apiVersion: apps/v1
+        template: charts/agent/templates/daemonset.yaml
+      - containsDocument:
+          kind: DaemonSet
+          apiVersion: apps/v1
+        template: charts/nodeAnalyzer/templates/daemonset-node-analyzer.yaml
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+        template: charts/nodeAnalyzer/templates/configmap-image-analyzer.yaml
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+        template: charts/nodeAnalyzer/templates/configmap-host-analyzer.yaml
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+        template: charts/nodeAnalyzer/templates/configmap-benchmark-runner.yaml
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: 'security:\n {2}enabled: true\n {2}k8s_audit_server_enabled: true'
+        template: charts/agent/templates/configmap.yaml
+  - it: Test enabling monitor only
+    set:
+      global:
+        sysdig:
+          accessKey: "AAAA-BBBB-CCCC-DDDD"
+          monitor: true
+          secure: false
+    asserts:
+      - containsDocument:
+          kind: DaemonSet
+          apiVersion: apps/v1
+        template: charts/agent/templates/daemonset.yaml
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: 'security:\n {2}enabled: false\n {2}k8s_audit_server_enabled: false'
+        template: charts/agent/templates/configmap.yaml
+  - it: Test enabling secure only
+    set:
+      global:
+        sysdig:
+          accessKey: "AAAA-BBBB-CCCC-DDDD"
+          monitor: false
+          secure: true
+    asserts:
+      - containsDocument:
+          kind: DaemonSet
+          apiVersion: apps/v1
+        template: charts/agent/templates/daemonset.yaml
+      - containsDocument:
+          kind: DaemonSet
+          apiVersion: apps/v1
+        template: charts/nodeAnalyzer/templates/daemonset-node-analyzer.yaml
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+        template: charts/nodeAnalyzer/templates/configmap-image-analyzer.yaml
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+        template: charts/nodeAnalyzer/templates/configmap-host-analyzer.yaml
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+        template: charts/nodeAnalyzer/templates/configmap-benchmark-runner.yaml
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: 'security:\n {2}enabled: true\n {2}k8s_audit_server_enabled: true'
+        template: charts/agent/templates/configmap.yaml
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: 'app_checks_enabled: false'
+        template: charts/agent/templates/configmap.yaml
+  - it: Test Monitor mode disable prometheus
+    set:
+      global:
+        sysdig:
+          accessKey: "AAAA-BBBB-CCCC-DDDD"
+          monitor: true
+          secure: false
+      agent:
+        sysdig:
+          settings:
+            prometheus:
+              enabled: false
+    asserts:
+      - containsDocument:
+          kind: DaemonSet
+          apiVersion: apps/v1
+        template: charts/agent/templates/daemonset.yaml
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: 'security:\n {2}enabled: false\n {2}k8s_audit_server_enabled: false'
+        template: charts/agent/templates/configmap.yaml
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: 'prometheus:\n {2}enabled: false'
+        template: charts/agent/templates/configmap.yaml
+  - it: Test Secure mode disable network_topology
+    set:
+      global:
+        sysdig:
+          accessKey: "AAAA-BBBB-CCCC-DDDD"
+          monitor: false
+          secure: true
+      agent:
+        sysdig:
+          settings:
+            network_topology:
+              enabled: false
+    asserts:
+      - containsDocument:
+          kind: DaemonSet
+          apiVersion: apps/v1
+        template: charts/agent/templates/daemonset.yaml
+      - containsDocument:
+          kind: DaemonSet
+          apiVersion: apps/v1
+        template: charts/nodeAnalyzer/templates/daemonset-node-analyzer.yaml
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+        template: charts/nodeAnalyzer/templates/configmap-image-analyzer.yaml
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+        template: charts/nodeAnalyzer/templates/configmap-host-analyzer.yaml
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+        template: charts/nodeAnalyzer/templates/configmap-benchmark-runner.yaml
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: 'security:\n {2}enabled: true\n {2}k8s_audit_server_enabled: true'
+        template: charts/agent/templates/configmap.yaml
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: 'network_topology:\n {2}enabled: false'
+        template: charts/agent/templates/configmap.yaml
+  - it: Test Secure Light mode
+    set:
+      global:
+        sysdig:
+          monitor: false
+          secure: true
+      agent:
+        sysdig:
+          settings:
+            feature:
+              mode: secure_light
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+        template: charts/agent/templates/configmap.yaml
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: 'security:\n {2}enabled: true'
+        template: charts/agent/templates/configmap.yaml
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: 'feature:\n {2}mode: secure_light'
+        template: charts/agent/templates/configmap.yaml
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: 'commandlines_capture:\n {2}enabled: false\ndrift_killer:\n {2}enabled: false\nfalcobaseline:\n {2}enabled: false\nmemdump:\n {2}enabled: false\nnetwork_topology:\n {2}enabled: false\nsecure_audit_streams:\n {2}enabled: false'
+        template: charts/agent/templates/configmap.yaml
+  - it: Try to enable secure_light with global.sysdig.secure disabled
+    set:
+      global:
+        sysdig:
+          secure: false
+      agent:
+        sysdig:
+          settings:
+            feature:
+              mode: secure_light
+    asserts:
+      - failedTemplate:
+          errorMessage: "Cannot unset global.sysdig.secure when agent.sysdig.settings.feature.mode is secure or secure_light"
+    template: charts/agent/templates/configmap.yaml
+  - it: Try to enable Agent secure_light mode with global.sysdig.monitor enabled
+    set:
+      global:
+        sysdig:
+          monitor: true
+      agent:
+        sysdig:
+          settings:
+            feature:
+              mode: secure_light
+    asserts:
+      - failedTemplate:
+          errorMessage: "Cannot set global.sysdig.monitor when agent.sysdig.settings.feature.mode is secure or secure_light"
+    template: charts/agent/templates/configmap.yaml
+  - it: Try to enable Agent secure mode with global.sysdig.monitor enabled
+    set:
+      global:
+        sysdig:
+          monitor: true
+      agent:
+        sysdig:
+          settings:
+            feature:
+              mode: secure
+    asserts:
+      - failedTemplate:
+          errorMessage: "Cannot set global.sysdig.monitor when agent.sysdig.settings.feature.mode is secure or secure_light"
+    template: charts/agent/templates/configmap.yaml

--- a/charts/sysdig-deploy/tests/plan_settings_test.yaml
+++ b/charts/sysdig-deploy/tests/plan_settings_test.yaml
@@ -197,7 +197,7 @@ tests:
               mode: secure_light
     asserts:
       - failedTemplate:
-          errorMessage: "Cannot unset global.sysdig.secure when agent.sysdig.settings.feature.mode is secure or secure_light"
+          errorMessage: "Set global.sysdig.secure=true when specifying agent.sysdig.settings.feature.mode=secure or agent.sysdig.settings.feature.mode=secure_light"
     template: charts/agent/templates/configmap.yaml
   - it: Try to enable Agent secure_light mode with global.sysdig.monitor enabled
     set:

--- a/charts/sysdig-deploy/values.yaml
+++ b/charts/sysdig-deploy/values.yaml
@@ -5,6 +5,8 @@ global:
   sysdig:
     accessKey: ""
     accessKeySecret: ""
+    monitor: true
+    secure: true
     secureAPIToken: ""
     secureAPITokenSecret: ""
     region: "us1"
@@ -18,12 +20,6 @@ global:
 
 admissionController:
   enabled: false
-
-agent:
-  enabled: true
-
-nodeAnalyzer:
-  enabled: true
 
 rapidResponse:
   enabled: false


### PR DESCRIPTION
## What this PR does / why we need it:
Introduce a new 'Sysdig Aware' subchart enable/disable feature that leverages global.sysdig.monitor and global.sysdig.secure to toggle:
1) Which subcharts of sysdig-deploy get rendered based on Sysdig deployment type
2) Which Agent settings are automatically set based on the type of deployment configured by the user.

This change also adds logic to enable secure_light mode in the Agent when specified.

The implementation here allows for the legacy <chart>.enabled values to override the new plan settings in an attempt at being backwards compatible.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
