### PR TITLE
feat(kspm-collector): Custom tolerations and nodeSelector

### DIFF
--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.1.32
+version: 0.1.33
 appVersion: 1.16.0
 keywords:
   - monitoring

--- a/charts/kspm-collector/README.md
+++ b/charts/kspm-collector/README.md
@@ -44,6 +44,7 @@ The following table lists the configurable parameters of the Sysdig KSPM Collect
 | `replicas`                                | KSPM collector deployment replicas                                                      | `1`                                                         |
 | `namespaces.included`                     | Namespaces to include in the KSPM collector scans, when empty scans all                 | ``                                                          |
 | `namespaces.excluded`                     | Namespaces to exclude in the KSPM collector scans                                       | ``                                                          |
+| `nodeSelector`                            | Node Selector                                                                           | `{}`                                                        |
 | `workloads.included`                      | Workloads to include in the KSPM collector scans, when empty scans all                  | ``                                                          |
 | `workloads.excluded`                      | Workloads to exclude in the KSPM collector scans, when empty scans all                  | ``                                                          |
 | `healthIntervalMin`                       | Minutes interval for KSPM collector health status messages                              | `5`                                                         |
@@ -61,15 +62,15 @@ The following table lists the configurable parameters of the Sysdig KSPM Collect
 | `affinity`                                | Node affinities. Overrides `arch` and `os` values                                       | `{}`                                                        |
 | `labels`                                  | KSPM collector specific labels (as a multi-line templated string map or as YAML)        | `{}`                                                        |
 | `port`                                    | KSPM collector port for health checks                                                   | `8080`                                                      |
-| `readinessProbe.enabled`                  | KSPM collector readinessProbe enablement                                                | `true`                                                         |
-| `livenessProbe.enabled`                   | KSPM collector livenessProbe enablement                                                 | `true`                                                         |
+| `readinessProbe.enabled`                  | KSPM collector readinessProbe enablement                                                | `true`                                                      |
+| `livenessProbe.enabled`                   | KSPM collector livenessProbe enablement                                                 | `true`                                                      |
 | `securityContext.runAsNonRoot`            | make KSPM collector run as non root                                                     | `true`                                                      |
 | `securityContext.runAsUser`               | make KSPM collector run as user with this ID                                            | `10001`                                                     |
 | `securityContext.runAsGroup`              | make KSPM collector run as group with this ID                                           | `10001`                                                     |
 | `securityContext.readOnlyRootFilesystem`  | make KSPM collector root file system read only                                          | `true`                                                      |
-| `securityContext.allowPrivilegeEscalation`| allow KSPM collector apps to gain priviledges stronger than their parent process        | `false`                                                      |
-| `securityContext.capabilities.drop`       | Linux capabilities to be taken from KSPM collector                                      | `['all']`                                                      |
-
+| `securityContext.allowPrivilegeEscalation`| allow KSPM collector apps to gain priviledges stronger than their parent process        | `false`                                                     |
+| `securityContext.capabilities.drop`       | Linux capabilities to be taken from KSPM collector                                      | `['all']`                                                   |
+| `tolerations`                             | The tolerations for scheduling                                                          | `kubernetes.io/arch=arm64:NoSchedule`                       |
 
 
 

--- a/charts/kspm-collector/templates/_helpers.tpl
+++ b/charts/kspm-collector/templates/_helpers.tpl
@@ -158,3 +158,20 @@ Returns the namespace for installing components
 {{- define "kspmCollector.namespace" -}}
     {{- coalesce .Values.namespace .Release.Namespace -}}
 {{- end -}}
+
+{{/*
+KSPM Collector nodeSelector
+*/}}
+{{- define "kspmCollector.nodeSelector" -}}
+{{- if .Values.nodeSelector }}
+{{- $tp := typeOf .Values.nodeSelector }}
+{{- if eq $tp "string" }}
+{{- if not (regexMatch "^[a-z0-9A-Z].*(: )(.*[a-z0-9A-Z]$)?" .Values.nodeSelector) }}
+    {{- fail "nodeSelector does not seem to be of the type key:[space]value" }}
+{{- end }}
+{{ tpl .Values.nodeSelector . }}
+{{- else }}
+{{ toYaml .Values.nodeSelector }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/kspm-collector/templates/deployment.yaml
+++ b/charts/kspm-collector/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
       serviceAccountName: {{ template "kspmCollector.serviceAccountName" .}}
       securityContext:
         runAsNonRoot: true
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ include "kspmCollector.nodeSelector" . | trim | indent 8 }}
+      {{- end }}
       affinity:
       {{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}
@@ -44,10 +48,7 @@ spec:
                 values: {{- toYaml .Values.os | nindent 18 }}
       {{- end }}
       tolerations:
-      - key: kubernetes.io/arch
-        operator: Equal
-        value: arm64
-        effect: NoSchedule
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/kspm-collector/tests/nodeselector_test.yaml
+++ b/charts/kspm-collector/tests/nodeselector_test.yaml
@@ -1,0 +1,34 @@
+suite: Testing that nodeSelector is applied correctly
+templates:
+  - deployment.yaml
+tests:
+  - it: check application of kspm collector nodeSelector
+    set: 
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+      nodeSelector:
+        instancetype: cpuoptimized
+    asserts:
+    - equal:
+        path: spec.template.spec.nodeSelector.instancetype
+        value: cpuoptimized
+
+  - it: check application of incorrect kspm collector nodeSelector with yaml
+    set: 
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+      nodeSelector:
+        instancetype:cpuoptimized
+    asserts:
+    - failedTemplate:
+        errorMessage: "nodeSelector does not seem to be of the type key:[space]value"
+
+  - it: check application of incorrect kspm collector nodeSelector with yaml key is empty
+    set: 
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+      nodeSelector:
+        ":testnodeselector"
+    asserts:
+    - failedTemplate:
+        errorMessage: "nodeSelector does not seem to be of the type key:[space]value"

--- a/charts/kspm-collector/tests/taint_toleration_test.yaml
+++ b/charts/kspm-collector/tests/taint_toleration_test.yaml
@@ -1,0 +1,47 @@
+suite: Testing that tains/tolerations are applied correctly
+templates:
+  - deployment.yaml
+tests:
+  - it: check application of kspm collector tolerations
+    set: 
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64  
+        - effect: "NoSchedule"
+          key: "CriticalAddonsOnly"
+          operator: "Equal"
+          value: "true"
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - effect: NoSchedule
+              key: kubernetes.io/arch
+              operator: Equal
+              value: arm64
+            - effect: NoSchedule
+              key: CriticalAddonsOnly
+              operator: Equal
+              value: "true"
+
+  - it: check application of kspm collector tolerations (replace of default values)
+    set: 
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+      tolerations:
+        - effect: "NoSchedule"
+          key: "CriticalAddonsOnly"
+          operator: "Equal"
+          value: "true"
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - effect: NoSchedule
+              key: CriticalAddonsOnly
+              operator: Equal
+              value: "true"

--- a/charts/kspm-collector/values.yaml
+++ b/charts/kspm-collector/values.yaml
@@ -66,6 +66,8 @@ namespaces:
   included: ""
   excluded: ""
 
+nodeSelector: {}
+
 workloads:
   included: ""
   excluded: ""
@@ -108,6 +110,12 @@ securityContext:
   capabilities:
     drop:
       - all
+
+tolerations:
+  - key: kubernetes.io/arch
+    operator: Equal
+    value: arm64
+    effect: NoSchedule
 
 # arch and os will be used to template out a node affinity block matching everything in each list. If affinity is
 # defined, these fields will be ignored


### PR DESCRIPTION
## What this PR does / why we need it:

Introduced the possibility of specifying custom toleration and a nodeSelector

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
