### PR TITLE
fix(sysdig-deploy): Fix issues with sysdig-deploy unit tests

### DIFF
--- a/.github/workflows/helm-unit-test.yaml
+++ b/.github/workflows/helm-unit-test.yaml
@@ -19,6 +19,12 @@ jobs:
       - name: Set up helm unit test plugin
         run: helm plugin install https://github.com/quintush/helm-unittest
 
+      - name: Bundle sysdig-deploy dependencies
+        run: helm dependency build ./charts/sysdig-deploy
+
+      - name: Test sysdig-deploy
+        run: helm unittest --helm3 ./charts/sysdig-deploy
+
       - name: Test node-analyzer
         run: helm unittest --helm3 ./charts/node-analyzer
 

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.58
+version: 1.5.59
 
 maintainers:
   - name: aroberts87

--- a/charts/sysdig-deploy/tests/notes_test.yaml
+++ b/charts/sysdig-deploy/tests/notes_test.yaml
@@ -27,9 +27,9 @@ tests:
           region: us3
     asserts:
       - matchRegexRaw:
-          pattern: https://us3.app.sysdig.com/#/dashboard-template/view.sysdig.agents\?last=10
+          pattern: https://app.us3.sysdig.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://us3.app.sysdig.com/secure/#/data-sources/agents
+          pattern: https://app.us3.sysdig.com/secure/#/data-sources/agents
 
   - it: Checking region 'us4'
     set:

--- a/charts/sysdig-deploy/tests/readme_command_test.yaml
+++ b/charts/sysdig-deploy/tests/readme_command_test.yaml
@@ -27,13 +27,11 @@ tests:
         template: charts/agent/templates/secrets.yaml
       - matchRegex:
           path: data.dragent\.yaml
-          pattern: |
-            k8s_cluster_name: test-k8s
+          pattern: 'k8s_cluster_name: test-k8s'
         template: charts/agent/templates/configmap.yaml
       - matchRegex:
           path: data.dragent\.yaml
-          pattern: |
-            collector: collector.sysdigcloud.com
+          pattern: 'collector: collector.sysdigcloud.com'
         template: charts/agent/templates/configmap.yaml
       - contains:
           path: spec.template.spec.initContainers[0].env
@@ -47,6 +45,7 @@ tests:
       global:
         sysdig:
           accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+          region: custom
       agent:
         collectorSettings:
           collectorHost: collector_host


### PR DESCRIPTION
## What this PR does / why we need it:
It turns out that the GitHub unit test action was not running the tests for the sysdig-deploy chart. As such, with the passing of development and bug fixes, the unit tests that were written had gotten out of sync with the current state of the charts. This change updates the tests so that they are passing again and also adds the sysdig-deploy chart to the set of charts with unit tests run when a PR is opened.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
