### PR TITLE
chore(agent,sysdig-deploy): Update chart maintainers

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.5.58
+version: 1.5.59
 
 appVersion: 12.10.1
 
@@ -22,16 +22,8 @@ sources:
   - https://app.sysdigcloud.com/#/settings/user
   - https://github.com/draios/sysdig
 maintainers:
-  - name: lachie83
-    email: lachlan@deis.com
-  - name: bencer
-    email: jorge.salamero@sysdig.com
-  - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
-  - name: airadier
-    email: alvaro.iradier@sysdig.com
-  - name: carillan81
-    email: carlos.arilla@sysdig.com
   - name: aroberts87
     email: adam.roberts@sysdig.com
+  - name: lilx1ao
+    email: zhongcheng.xiao@sysdig.com
 dependencies: []

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,17 +2,13 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.5.59
+version: 1.5.60
 
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com
-  - name: ironashram
-    email: michele.palazzi@sysdig.com
   - name: lilx1ao
     email: zhongcheng.xiao@sysdig.com
-  - name: yashgiri
-    email: yashgiri.goswami@sysdig.com
 home: https://www.sysdig.com/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 dependencies:


### PR DESCRIPTION
## What this PR does / why we need it:
Update the chart maintainers for the `sysdig-deploy` and `agent` charts to be accurate

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.
