### PR TITLE
feat(admission-controller,agent,common,kspm-collector,node-analyzer,rapid-response,sysdig-deploy): Improve region resolution in all charts

### DIFF
--- a/.github/workflows/helm-unit-test.yaml
+++ b/.github/workflows/helm-unit-test.yaml
@@ -19,8 +19,14 @@ jobs:
       - name: Set up helm unit test plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest --version=0.3.0
 
-      - name: Bundle sysdig-deploy dependencies
-        run: helm dependency build ./charts/sysdig-deploy
+      - name: Bundle chart dependencies
+        run: |
+          helm dependency build ./charts/admission-controller
+          helm dependency build ./charts/agent
+          helm dependency build ./charts/kspm-collector
+          helm dependency build ./charts/node-analyzer
+          helm dependency build ./charts/rapid-response
+          helm dependency build ./charts/sysdig-deploy
 
       - name: Test admission-controller
         run: helm unittest --strict ./charts/admission-controller

--- a/.github/workflows/helm-unit-test.yaml
+++ b/.github/workflows/helm-unit-test.yaml
@@ -20,13 +20,7 @@ jobs:
         run: helm plugin install https://github.com/helm-unittest/helm-unittest --version=0.3.0
 
       - name: Bundle chart dependencies
-        run: |
-          helm dependency build ./charts/admission-controller
-          helm dependency build ./charts/agent
-          helm dependency build ./charts/kspm-collector
-          helm dependency build ./charts/node-analyzer
-          helm dependency build ./charts/rapid-response
-          helm dependency build ./charts/sysdig-deploy
+        run: make deps
 
       - name: Test admission-controller
         run: helm unittest --strict ./charts/admission-controller

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -140,7 +140,7 @@ jobs:
           k3s-version: v1.23.9+k3s1
 
       - name: Run chart-testing (install)
-        run: ct install --upgrade --excluded-charts common sysdig-stackdriver-bridge
+        run: ct install --upgrade --excluded-charts common,sysdig-stackdriver-bridge,sysdig-mcm-navmenu
 
       - uses: actions/github-script@v6
         id: update-check-run

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -73,7 +73,8 @@ jobs:
           k3s-version: v1.23.9+k3s1
 
       - name: Run chart-testing (install)
-        run: ct install --upgrade --excluded-charts sysdig-stackdriver-bridge,sysdig-mcm-navmenu
+        run: ct install --upgrade --excluded-charts common,sysdig-stackdriver-bridge,sysdig-mcm-navmenu
+
 
   lint-test-fork:
     runs-on: ubuntu-latest
@@ -139,7 +140,7 @@ jobs:
           k3s-version: v1.23.9+k3s1
 
       - name: Run chart-testing (install)
-        run: ct install --upgrade --excluded-charts sysdig-stackdriver-bridge
+        run: ct install --upgrade --excluded-charts common sysdig-stackdriver-bridge
 
       - uses: actions/github-script@v6
         id: update-check-run

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,9 @@ unit-test-rs: deps-unittest
 		xargs -L1 dirname | \
 		xargs -I% sh -c \
 			"helm dependency build % ; helm unittest --strict %"
+
+deps:
+	find ./charts -name "Chart.yaml" | \
+		xargs -L1 dirname | \
+		xargs -I% sh -c \
+			"helm dependency build %"

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.10.1
+version: 0.11.0
 appVersion: 3.9.22
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -17,3 +17,8 @@ maintainers:
     email: miguel.baztan@sysdig.com
   - name: jprieto92
     email: javier.prieto@sysdig.com
+dependencies:
+  - name: common
+    # repository: https://charts.sysdig.com
+    repository: file://../common
+    version: ~1.0.0

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: 3.9.22
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.10.0  \
+      --create-namespace -n sysdig-admission-controller --version=0.10.1  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
 ```
@@ -55,7 +55,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.10.0
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.10.1
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -184,7 +184,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.10.0 \
+    --create-namespace -n sysdig-admission-controller --version=0.10.1 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -193,7 +193,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.10.0 \
+    --create-namespace -n sysdig-admission-controller --version=0.10.1 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.10.1  \
+      --create-namespace -n sysdig-admission-controller --version=0.11.0  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
 ```
@@ -55,7 +55,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.10.1
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.11.0
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -184,7 +184,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.10.1 \
+    --create-namespace -n sysdig-admission-controller --version=0.11.0 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -193,7 +193,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.10.1 \
+    --create-namespace -n sysdig-admission-controller --version=0.11.0 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/templates/_helpers.tpl
+++ b/charts/admission-controller/templates/_helpers.tpl
@@ -116,18 +116,8 @@ Determine Secure endpoint based on provided region or .Values.sysdig.apiEndpoint
 {{- define "admissionController.apiEndpoint" -}}
     {{- if (or .Values.sysdig.apiEndpoint (eq .Values.global.sysdig.region "custom"))  -}}
         {{- required "A valid Sysdig API endpoint (.sysdig.apiEndpoint) is required" .Values.sysdig.apiEndpoint -}}
-    {{- else if (eq .Values.global.sysdig.region "us1") -}}
-        {{- "secure.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us2") -}}
-        {{- "us2.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us3") -}}
-        {{- "app.us3.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us4") -}}
-        {{- "app.us4.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "eu1") -}}
-        {{- "eu1.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "au1") -}}
-        {{- "app.au1.sysdig.com" -}}
+    {{- else if hasKey ((include "sysdig.regions" .) | fromYaml) .Values.global.sysdig.region }}
+        {{- include "sysdig.secureApiEndpoint" . }}
     {{- end -}}
 {{- end -}}
 

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.9.2
+version: 1.9.3
 
 appVersion: 12.15.0
 

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -26,4 +26,8 @@ maintainers:
     email: adam.roberts@sysdig.com
   - name: lilx1ao
     email: zhongcheng.xiao@sysdig.com
-dependencies: []
+dependencies:
+  - name: common
+    # repository: https://charts.sysdig.com
+    repository: file://../common
+    version: ~1.0.0

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.9.3
+version: 1.10.0
 
 appVersion: 12.15.0
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -247,19 +247,9 @@ Determine collector endpoint based on provided region
 {{- define "agent.collectorEndpoint" -}}
     {{- if (or .Values.collectorSettings.collectorHost (eq .Values.global.sysdig.region "custom")) -}}
         {{- required "collectorSettings.collectorHost is required for custom regions" (.Values.collectorSettings.collectorHost) -}}
-    {{- else if (eq .Values.global.sysdig.region "us1") -}}
-        {{- "collector.sysdigcloud.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us2") -}}
-        {{- "ingest-us2.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us3") -}}
-        {{- "ingest.us3.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us4") -}}
-        {{- "ingest.us4.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "eu1") -}}
-        {{- "ingest-eu1.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "au1") -}}
-        {{- "ingest.au1.sysdig.com" -}}
-    {{- else -}}
+    {{- else if hasKey ((include "sysdig.regions" .) | fromYaml) .Values.global.sysdig.region }}
+        {{- include "sysdig.collectorEndpoint" . }}
+    {{- else }}
         {{- fail (printf "global.sysdig.region=%s provided is not recognized." .Values.global.sysdig.region ) -}}
     {{- end -}}
 {{- end -}}
@@ -270,18 +260,8 @@ Determine sysdig monitor endpoint based on provided region
 {{- define "monitorUrl" -}}
     {{- if (or .Values.collectorSettings.collectorHost (eq .Values.global.sysdig.region "custom")) -}}
         {{- required "collectorSettings.collectorHost is required for custom regions" (.Values.collectorSettings.collectorHost) -}}
-    {{- else if (eq .Values.global.sysdig.region "us1") -}}
-        {{- "app.sysdigcloud.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us2") -}}
-        {{- "us2.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us3") -}}
-        {{- "app.us3.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us4") -}}
-        {{- "app.us4.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "eu1") -}}
-        {{- "eu1.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "au1") -}}
-        {{- "app.au1.sysdig.com" -}}
+    {{- else if hasKey ((include "sysdig.regions" .) | fromYaml) .Values.global.sysdig.region }}
+        {{- include "sysdig.monitorApiEndpoint" . }}
     {{- else -}}
         {{- fail (printf "global.sysdig.region=%s provided is not recognized." .Values.global.sysdig.region ) -}}
     {{- end -}}
@@ -293,18 +273,8 @@ Determine sysdig secure endpoint based on provided region
 {{- define "secureUrl" -}}
     {{- if (or .Values.collectorSettings.collectorHost (eq .Values.global.sysdig.region "custom")) -}}
         {{- required "collectorSettings.collectorHost is required for custom regions" (.Values.collectorSettings.collectorHost) -}}
-    {{- else if (eq .Values.global.sysdig.region "us1") -}}
-        {{- "secure.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us2") -}}
-        {{- "us2.app.sysdig.com/secure" -}}
-    {{- else if (eq .Values.global.sysdig.region "us3") -}}
-        {{- "app.us3.sysdig.com/secure" -}}
-    {{- else if (eq .Values.global.sysdig.region "us4") -}}
-        {{- "app.us4.sysdig.com/secure" -}}
-    {{- else if (eq .Values.global.sysdig.region "eu1") -}}
-        {{- "eu1.app.sysdig.com/secure" -}}
-    {{- else if (eq .Values.global.sysdig.region "au1") -}}
-        {{- "app.au1.sysdig.com/secure" -}}
+    {{- else if hasKey ((include "sysdig.regions" .) | fromYaml) .Values.global.sysdig.region -}}
+        {{- include "sysdig.secureUi" . }}
     {{- else -}}
         {{- fail (printf "global.sysdig.region=%s provided is not recognized." .Values.global.sysdig.region ) -}}
     {{- end -}}

--- a/charts/agent/tests/api_endpoint_region_test.yaml
+++ b/charts/agent/tests/api_endpoint_region_test.yaml
@@ -79,7 +79,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.au-syd.monitoring.cloud.ibm.com
 
   - it: Checking region 'br-sao-monitor'
@@ -91,7 +91,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.br-sao.monitoring.cloud.ibm.com
 
   - it: Checking region 'ca-tor-monitor'
@@ -103,7 +103,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.ca-tor.monitoring.cloud.ibm.com
 
   - it: Checking region 'eu-de-monitor'
@@ -115,7 +115,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.eu-de.monitoring.cloud.ibm.com
 
   - it: Checking region 'eu-gb-monitor'
@@ -127,7 +127,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.eu-gb.monitoring.cloud.ibm.com
 
   - it: Checking region 'jp-osa-monitor'
@@ -139,7 +139,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.jp-osa.monitoring.cloud.ibm.com
 
   - it: Checking region 'jp-tok-monitor'
@@ -151,7 +151,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.jp-tok.monitoring.cloud.ibm.com
 
   - it: Checking region 'us-east-monitor'
@@ -163,7 +163,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.us-east.monitoring.cloud.ibm.com
 
   - it: Checking region 'us-south-monitor'
@@ -175,7 +175,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.us-south.monitoring.cloud.ibm.com
 
   - it: Checking region 'au-syd-private-monitor'
@@ -187,7 +187,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.au-syd.monitoring.cloud.ibm.com
 
   - it: Checking region 'br-sao-private-monitor'
@@ -199,7 +199,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.br-sao.monitoring.cloud.ibm.com
 
   - it: Checking region 'ca-tor-private-monitor'
@@ -211,7 +211,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.ca-tor.monitoring.cloud.ibm.com
 
   - it: Checking region 'eu-de-private-monitor'
@@ -223,7 +223,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.eu-de.monitoring.cloud.ibm.com
 
   - it: Checking region 'eu-gb-private-monitor'
@@ -235,7 +235,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.eu-gb.monitoring.cloud.ibm.com
 
   - it: Checking region 'jp-osa-private-monitor'
@@ -247,7 +247,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.jp-osa.monitoring.cloud.ibm.com
 
   - it: Checking region 'jp-tok-private-monitor'
@@ -259,7 +259,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.jp-tok.monitoring.cloud.ibm.com
 
   - it: Checking region 'us-east-private-monitor'
@@ -271,7 +271,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.us-east.monitoring.cloud.ibm.com
 
   - it: Checking region 'us-south-private-monitor'
@@ -283,7 +283,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.us-south.monitoring.cloud.ibm.com
 
   - it: Checking region 'au-syd-secure'
@@ -295,7 +295,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.au-syd.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'br-sao-secure'
@@ -307,7 +307,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.br-sao.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'ca-tor-secure'
@@ -319,7 +319,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.ca-tor.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'eu-de-secure'
@@ -331,7 +331,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.eu-de.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'eu-gb-secure'
@@ -343,7 +343,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.eu-gb.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'jp-osa-secure'
@@ -355,7 +355,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.jp-osa.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'jp-tok-secure'
@@ -367,7 +367,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.jp-tok.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'us-east-secure'
@@ -379,7 +379,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.us-east.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'us-south-secure'
@@ -391,7 +391,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.us-south.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'au-syd-private-secure'
@@ -403,7 +403,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.au-syd.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'br-sao-private-secure'
@@ -415,7 +415,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.br-sao.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'ca-tor-private-secure'
@@ -427,7 +427,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.ca-tor.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'eu-de-private-secure'
@@ -439,7 +439,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.eu-de.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'eu-gb-private-secure'
@@ -451,7 +451,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.eu-gb.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'jp-osa-private-secure'
@@ -463,7 +463,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.jp-osa.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'jp-tok-private-secure'
@@ -475,7 +475,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.jp-tok.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'us-east-private-secure'
@@ -487,7 +487,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.us-east.sysdig-secure.cloud.ibm.com
 
   - it: Checking region 'us-south-private-secure'
@@ -499,7 +499,7 @@ tests:
       - isKind:
           of: ConfigMap
       - matchRegex:
-          path: data.dragent\.yaml
+          path: data['dragent.yaml']
           pattern: ingest.private.us-south.sysdig-secure.cloud.ibm.com
 
   - it: Checking wrong region input

--- a/charts/agent/tests/api_endpoint_region_test.yaml
+++ b/charts/agent/tests/api_endpoint_region_test.yaml
@@ -70,11 +70,11 @@ tests:
           path: data['dragent.yaml']
           pattern: .*ingest\.au1\.sysdig\.com.*
 
-  - it: Checking region 'au-syd'
+  - it: Checking region 'au-syd-monitor'
     set:
       global:
         sysdig:
-          region: au-syd
+          region: au-syd-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -82,11 +82,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.au-syd.monitoring.cloud.ibm.com
 
-  - it: Checking region 'br-sao'
+  - it: Checking region 'br-sao-monitor'
     set:
       global:
         sysdig:
-          region: br-sao
+          region: br-sao-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -94,11 +94,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.br-sao.monitoring.cloud.ibm.com
 
-  - it: Checking region 'ca-tor'
+  - it: Checking region 'ca-tor-monitor'
     set:
       global:
         sysdig:
-          region: ca-tor
+          region: ca-tor-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -106,11 +106,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.ca-tor.monitoring.cloud.ibm.com
 
-  - it: Checking region 'eu-de'
+  - it: Checking region 'eu-de-monitor'
     set:
       global:
         sysdig:
-          region: eu-de
+          region: eu-de-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -118,11 +118,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.eu-de.monitoring.cloud.ibm.com
 
-  - it: Checking region 'eu-gb'
+  - it: Checking region 'eu-gb-monitor'
     set:
       global:
         sysdig:
-          region: eu-gb
+          region: eu-gb-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -130,11 +130,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.eu-gb.monitoring.cloud.ibm.com
 
-  - it: Checking region 'jp-osa'
+  - it: Checking region 'jp-osa-monitor'
     set:
       global:
         sysdig:
-          region: jp-osa
+          region: jp-osa-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -142,11 +142,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.jp-osa.monitoring.cloud.ibm.com
 
-  - it: Checking region 'jp-tok'
+  - it: Checking region 'jp-tok-monitor'
     set:
       global:
         sysdig:
-          region: jp-tok
+          region: jp-tok-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -154,11 +154,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.jp-tok.monitoring.cloud.ibm.com
 
-  - it: Checking region 'us-east'
+  - it: Checking region 'us-east-monitor'
     set:
       global:
         sysdig:
-          region: us-east
+          region: us-east-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -166,11 +166,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.us-east.monitoring.cloud.ibm.com
 
-  - it: Checking region 'us-south'
+  - it: Checking region 'us-south-monitor'
     set:
       global:
         sysdig:
-          region: us-south
+          region: us-south-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -178,11 +178,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.us-south.monitoring.cloud.ibm.com
 
-  - it: Checking region 'au-syd-private'
+  - it: Checking region 'au-syd-private-monitor'
     set:
       global:
         sysdig:
-          region: au-syd-private
+          region: au-syd-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -190,11 +190,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.private.au-syd.monitoring.cloud.ibm.com
 
-  - it: Checking region 'br-sao-private'
+  - it: Checking region 'br-sao-private-monitor'
     set:
       global:
         sysdig:
-          region: br-sao-private
+          region: br-sao-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -202,11 +202,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.private.br-sao.monitoring.cloud.ibm.com
 
-  - it: Checking region 'ca-tor-private'
+  - it: Checking region 'ca-tor-private-monitor'
     set:
       global:
         sysdig:
-          region: ca-tor-private
+          region: ca-tor-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -214,11 +214,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.private.ca-tor.monitoring.cloud.ibm.com
 
-  - it: Checking region 'eu-de-private'
+  - it: Checking region 'eu-de-private-monitor'
     set:
       global:
         sysdig:
-          region: eu-de-private
+          region: eu-de-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -226,11 +226,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.private.eu-de.monitoring.cloud.ibm.com
 
-  - it: Checking region 'eu-gb-private'
+  - it: Checking region 'eu-gb-private-monitor'
     set:
       global:
         sysdig:
-          region: eu-gb-private
+          region: eu-gb-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -238,11 +238,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.private.eu-gb.monitoring.cloud.ibm.com
 
-  - it: Checking region 'jp-osa-private'
+  - it: Checking region 'jp-osa-private-monitor'
     set:
       global:
         sysdig:
-          region: jp-osa-private
+          region: jp-osa-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -250,11 +250,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.private.jp-osa.monitoring.cloud.ibm.com
 
-  - it: Checking region 'jp-tok-private'
+  - it: Checking region 'jp-tok-private-monitor'
     set:
       global:
         sysdig:
-          region: jp-tok-private
+          region: jp-tok-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -262,11 +262,11 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.private.jp-tok.monitoring.cloud.ibm.com
 
-  - it: Checking region 'us-east-private'
+  - it: Checking region 'us-east-private-monitor'
     set:
       global:
         sysdig:
-          region: us-east-private
+          region: us-east-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -274,17 +274,233 @@ tests:
           path: data.dragent\.yaml
           pattern: ingest.private.us-east.monitoring.cloud.ibm.com
 
-  - it: Checking region 'us-south-private'
+  - it: Checking region 'us-south-private-monitor'
     set:
       global:
         sysdig:
-          region: us-south-private
+          region: us-south-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
       - matchRegex:
           path: data.dragent\.yaml
           pattern: ingest.private.us-south.monitoring.cloud.ibm.com
+
+  - it: Checking region 'au-syd-secure'
+    set:
+      global:
+        sysdig:
+          region: au-syd-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.au-syd.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao-secure'
+    set:
+      global:
+        sysdig:
+          region: br-sao-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.br-sao.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-secure'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.ca-tor.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-de-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.eu-de.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.eu-gb.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.jp-osa.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.jp-tok.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east-secure'
+    set:
+      global:
+        sysdig:
+          region: us-east-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.us-east.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south-secure'
+    set:
+      global:
+        sysdig:
+          region: us-south-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.us-south.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'au-syd-private-secure'
+    set:
+      global:
+        sysdig:
+          region: au-syd-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.au-syd.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao-private-secure'
+    set:
+      global:
+        sysdig:
+          region: br-sao-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.br-sao.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-private-secure'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.ca-tor.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de-private-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-de-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.eu-de.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-private-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.eu-gb.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-private-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.jp-osa.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-private-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.jp-tok.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east-private-secure'
+    set:
+      global:
+        sysdig:
+          region: us-east-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.us-east.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south-private-secure'
+    set:
+      global:
+        sysdig:
+          region: us-south-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.us-south.sysdig-secure.cloud.ibm.com
 
   - it: Checking wrong region input
     set:

--- a/charts/agent/tests/api_endpoint_region_test.yaml
+++ b/charts/agent/tests/api_endpoint_region_test.yaml
@@ -1,4 +1,4 @@
-suite: Test agent configmap collector value set by api_endpoint for all regions (us1,us2,us3,us4,eu1,au1)
+suite: Test agent configmap collector value set by api_endpoint for all regions
 templates:
   - templates/configmap.yaml
 tests:
@@ -69,6 +69,222 @@ tests:
       - matchRegex:
           path: data['dragent.yaml']
           pattern: .*ingest\.au1\.sysdig\.com.*
+
+  - it: Checking region 'au-syd'
+    set:
+      global:
+        sysdig:
+          region: au-syd
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.au-syd.monitoring.cloud.ibm.com
+
+  - it: Checking region 'br-sao'
+    set:
+      global:
+        sysdig:
+          region: br-sao
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.br-sao.monitoring.cloud.ibm.com
+
+  - it: Checking region 'ca-tor'
+    set:
+      global:
+        sysdig:
+          region: ca-tor
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.ca-tor.monitoring.cloud.ibm.com
+
+  - it: Checking region 'eu-de'
+    set:
+      global:
+        sysdig:
+          region: eu-de
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.eu-de.monitoring.cloud.ibm.com
+
+  - it: Checking region 'eu-gb'
+    set:
+      global:
+        sysdig:
+          region: eu-gb
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.eu-gb.monitoring.cloud.ibm.com
+
+  - it: Checking region 'jp-osa'
+    set:
+      global:
+        sysdig:
+          region: jp-osa
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.jp-osa.monitoring.cloud.ibm.com
+
+  - it: Checking region 'jp-tok'
+    set:
+      global:
+        sysdig:
+          region: jp-tok
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.jp-tok.monitoring.cloud.ibm.com
+
+  - it: Checking region 'us-east'
+    set:
+      global:
+        sysdig:
+          region: us-east
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.us-east.monitoring.cloud.ibm.com
+
+  - it: Checking region 'us-south'
+    set:
+      global:
+        sysdig:
+          region: us-south
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.us-south.monitoring.cloud.ibm.com
+
+  - it: Checking region 'au-syd-private'
+    set:
+      global:
+        sysdig:
+          region: au-syd-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.au-syd.monitoring.cloud.ibm.com
+
+  - it: Checking region 'br-sao-private'
+    set:
+      global:
+        sysdig:
+          region: br-sao-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.br-sao.monitoring.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-private'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.ca-tor.monitoring.cloud.ibm.com
+
+  - it: Checking region 'eu-de-private'
+    set:
+      global:
+        sysdig:
+          region: eu-de-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.eu-de.monitoring.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-private'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.eu-gb.monitoring.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-private'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.jp-osa.monitoring.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-private'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.jp-tok.monitoring.cloud.ibm.com
+
+  - it: Checking region 'us-east-private'
+    set:
+      global:
+        sysdig:
+          region: us-east-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.us-east.monitoring.cloud.ibm.com
+
+  - it: Checking region 'us-south-private'
+    set:
+      global:
+        sysdig:
+          region: us-south-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.dragent\.yaml
+          pattern: ingest.private.us-south.monitoring.cloud.ibm.com
 
   - it: Checking wrong region input
     set:

--- a/charts/agent/tests/api_endpoint_region_test.yaml
+++ b/charts/agent/tests/api_endpoint_region_test.yaml
@@ -296,7 +296,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.au-syd.sysdig-secure.cloud.ibm.com
+          pattern: ingest.au-syd.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'br-sao-secure'
     set:
@@ -308,7 +308,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.br-sao.sysdig-secure.cloud.ibm.com
+          pattern: ingest.br-sao.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'ca-tor-secure'
     set:
@@ -320,7 +320,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.ca-tor.sysdig-secure.cloud.ibm.com
+          pattern: ingest.ca-tor.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-de-secure'
     set:
@@ -332,7 +332,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.eu-de.sysdig-secure.cloud.ibm.com
+          pattern: ingest.eu-de.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-gb-secure'
     set:
@@ -344,7 +344,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.eu-gb.sysdig-secure.cloud.ibm.com
+          pattern: ingest.eu-gb.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-osa-secure'
     set:
@@ -356,7 +356,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.jp-osa.sysdig-secure.cloud.ibm.com
+          pattern: ingest.jp-osa.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-tok-secure'
     set:
@@ -368,7 +368,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.jp-tok.sysdig-secure.cloud.ibm.com
+          pattern: ingest.jp-tok.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-east-secure'
     set:
@@ -380,7 +380,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.us-east.sysdig-secure.cloud.ibm.com
+          pattern: ingest.us-east.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-south-secure'
     set:
@@ -392,7 +392,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.us-south.sysdig-secure.cloud.ibm.com
+          pattern: ingest.us-south.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'au-syd-private-secure'
     set:
@@ -404,7 +404,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.au-syd.sysdig-secure.cloud.ibm.com
+          pattern: ingest.private.au-syd.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'br-sao-private-secure'
     set:
@@ -416,7 +416,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.br-sao.sysdig-secure.cloud.ibm.com
+          pattern: ingest.private.br-sao.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'ca-tor-private-secure'
     set:
@@ -428,7 +428,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.ca-tor.sysdig-secure.cloud.ibm.com
+          pattern: ingest.private.ca-tor.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-de-private-secure'
     set:
@@ -440,7 +440,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.eu-de.sysdig-secure.cloud.ibm.com
+          pattern: ingest.private.eu-de.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-gb-private-secure'
     set:
@@ -452,7 +452,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.eu-gb.sysdig-secure.cloud.ibm.com
+          pattern: ingest.private.eu-gb.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-osa-private-secure'
     set:
@@ -464,7 +464,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.jp-osa.sysdig-secure.cloud.ibm.com
+          pattern: ingest.private.jp-osa.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-tok-private-secure'
     set:
@@ -476,7 +476,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.jp-tok.sysdig-secure.cloud.ibm.com
+          pattern: ingest.private.jp-tok.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-east-private-secure'
     set:
@@ -488,7 +488,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.us-east.sysdig-secure.cloud.ibm.com
+          pattern: ingest.private.us-east.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-south-private-secure'
     set:
@@ -500,7 +500,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.us-south.sysdig-secure.cloud.ibm.com
+          pattern: ingest.private.us-south.security-compliance-secure.cloud.ibm.com
 
   - it: Checking wrong region input
     set:

--- a/charts/agent/tests/notes_test.yaml
+++ b/charts/agent/tests/notes_test.yaml
@@ -1,4 +1,4 @@
-suite: Test links in the notes section for regions (us1,us2,us3,us4,eu1,au1)
+suite: Test links in the notes section for regions
 templates:
   - templates/NOTES.txt
 tests:
@@ -63,6 +63,204 @@ tests:
           pattern: https://app.au1.sysdig.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://app.au1.sysdig.com/secure/#/data-sources/agents
+
+  - it: Checking region 'au-syd'
+    set:
+      global:
+        sysdig:
+          region: au-syd
+    asserts:
+      - matchRegexRaw:
+          pattern: https://au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'br-sao'
+    set:
+      global:
+        sysdig:
+          region: br-sao
+    asserts:
+      - matchRegexRaw:
+          pattern: https://br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'ca-tor'
+    set:
+      global:
+        sysdig:
+          region: ca-tor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-de'
+    set:
+      global:
+        sysdig:
+          region: eu-de
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-gb'
+    set:
+      global:
+        sysdig:
+          region: eu-gb
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-osa'
+    set:
+      global:
+        sysdig:
+          region: jp-osa
+    asserts:
+      - matchRegexRaw:
+          pattern: https://jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-tok'
+    set:
+      global:
+        sysdig:
+          region: jp-tok
+    asserts:
+      - matchRegexRaw:
+          pattern: https://jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-east'
+    set:
+      global:
+        sysdig:
+          region: us-east
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-south'
+    set:
+      global:
+        sysdig:
+          region: us-south
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'au-syd-private'
+    set:
+      global:
+        sysdig:
+          region: au-syd-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'br-sao-private'
+    set:
+      global:
+        sysdig:
+          region: br-sao-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'ca-tor-private'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-de-private'
+    set:
+      global:
+        sysdig:
+          region: eu-de-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-gb-private'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-osa-private'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-tok-private'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-east-private'
+    set:
+      global:
+        sysdig:
+          region: us-east-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-south-private'
+    set:
+      global:
+        sysdig:
+          region: us-south-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking incorrect region 'ap3' should fail
     set:

--- a/charts/agent/tests/notes_test.yaml
+++ b/charts/agent/tests/notes_test.yaml
@@ -73,7 +73,7 @@ tests:
       - matchRegexRaw:
           pattern: https://au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://au-syd.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'br-sao-monitor'
     set:
@@ -84,7 +84,7 @@ tests:
       - matchRegexRaw:
           pattern: https://br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://br-sao.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'ca-tor-monitor'
     set:
@@ -95,7 +95,7 @@ tests:
       - matchRegexRaw:
           pattern: https://ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://ca-tor.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-de-monitor'
     set:
@@ -106,7 +106,7 @@ tests:
       - matchRegexRaw:
           pattern: https://eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://eu-de.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-gb-monitor'
     set:
@@ -117,7 +117,7 @@ tests:
       - matchRegexRaw:
           pattern: https://eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://eu-gb.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-osa-monitor'
     set:
@@ -128,7 +128,7 @@ tests:
       - matchRegexRaw:
           pattern: https://jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://jp-osa.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-tok-monitor'
     set:
@@ -139,7 +139,7 @@ tests:
       - matchRegexRaw:
           pattern: https://jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://jp-tok.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-east-monitor'
     set:
@@ -150,7 +150,7 @@ tests:
       - matchRegexRaw:
           pattern: https://us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://us-east.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-south-monitor'
     set:
@@ -161,7 +161,7 @@ tests:
       - matchRegexRaw:
           pattern: https://us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://us-south.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'au-syd-private-monitor'
     set:
@@ -172,7 +172,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.au-syd.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'br-sao-private-monitor'
     set:
@@ -183,7 +183,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.br-sao.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'ca-tor-private-monitor'
     set:
@@ -194,7 +194,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.ca-tor.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-de-private-monitor'
     set:
@@ -205,7 +205,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.eu-de.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-gb-private-monitor'
     set:
@@ -216,7 +216,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.eu-gb.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-osa-private-monitor'
     set:
@@ -227,7 +227,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.jp-osa.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-tok-private-monitor'
     set:
@@ -238,7 +238,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.jp-tok.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-east-private-monitor'
     set:
@@ -249,7 +249,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.us-east.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-south-private-monitor'
     set:
@@ -260,7 +260,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.us-south.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'au-syd-secure'
     set:
@@ -271,7 +271,7 @@ tests:
       - matchRegexRaw:
           pattern: https://au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://au-syd.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'br-sao-secure'
     set:
@@ -282,7 +282,7 @@ tests:
       - matchRegexRaw:
           pattern: https://br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://br-sao.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'ca-tor-secure'
     set:
@@ -293,7 +293,7 @@ tests:
       - matchRegexRaw:
           pattern: https://ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://ca-tor.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-de-secure'
     set:
@@ -304,7 +304,7 @@ tests:
       - matchRegexRaw:
           pattern: https://eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://eu-de.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-gb-secure'
     set:
@@ -315,7 +315,7 @@ tests:
       - matchRegexRaw:
           pattern: https://eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://eu-gb.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-osa-secure'
     set:
@@ -326,7 +326,7 @@ tests:
       - matchRegexRaw:
           pattern: https://jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://jp-osa.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-tok-secure'
     set:
@@ -337,7 +337,7 @@ tests:
       - matchRegexRaw:
           pattern: https://jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://jp-tok.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-east-secure'
     set:
@@ -348,7 +348,7 @@ tests:
       - matchRegexRaw:
           pattern: https://us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://us-east.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-south-secure'
     set:
@@ -359,7 +359,7 @@ tests:
       - matchRegexRaw:
           pattern: https://us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://us-south.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'au-syd-private-secure'
     set:
@@ -370,7 +370,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.au-syd.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'br-sao-private-secure'
     set:
@@ -381,7 +381,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.br-sao.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'ca-tor-private-secure'
     set:
@@ -392,7 +392,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.ca-tor.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-de-private-secure'
     set:
@@ -403,7 +403,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.eu-de.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-gb-private-secure'
     set:
@@ -414,7 +414,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.eu-gb.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-osa-private-secure'
     set:
@@ -425,7 +425,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.jp-osa.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-tok-private-secure'
     set:
@@ -436,7 +436,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.jp-tok.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-east-private-secure'
     set:
@@ -447,7 +447,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.us-east.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-south-private-secure'
     set:
@@ -458,7 +458,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.us-south.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking incorrect region 'ap3' should fail
     set:

--- a/charts/agent/tests/notes_test.yaml
+++ b/charts/agent/tests/notes_test.yaml
@@ -64,198 +64,396 @@ tests:
       - matchRegexRaw:
           pattern: https://app.au1.sysdig.com/secure/#/data-sources/agents
 
-  - it: Checking region 'au-syd'
+  - it: Checking region 'au-syd-monitor'
     set:
       global:
         sysdig:
-          region: au-syd
+          region: au-syd-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'br-sao'
+  - it: Checking region 'br-sao-monitor'
     set:
       global:
         sysdig:
-          region: br-sao
+          region: br-sao-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'ca-tor'
+  - it: Checking region 'ca-tor-monitor'
     set:
       global:
         sysdig:
-          region: ca-tor
+          region: ca-tor-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'eu-de'
+  - it: Checking region 'eu-de-monitor'
     set:
       global:
         sysdig:
-          region: eu-de
+          region: eu-de-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'eu-gb'
+  - it: Checking region 'eu-gb-monitor'
     set:
       global:
         sysdig:
-          region: eu-gb
+          region: eu-gb-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'jp-osa'
+  - it: Checking region 'jp-osa-monitor'
     set:
       global:
         sysdig:
-          region: jp-osa
+          region: jp-osa-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'jp-tok'
+  - it: Checking region 'jp-tok-monitor'
     set:
       global:
         sysdig:
-          region: jp-tok
+          region: jp-tok-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'us-east'
+  - it: Checking region 'us-east-monitor'
     set:
       global:
         sysdig:
-          region: us-east
+          region: us-east-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'us-south'
+  - it: Checking region 'us-south-monitor'
     set:
       global:
         sysdig:
-          region: us-south
+          region: us-south-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'au-syd-private'
+  - it: Checking region 'au-syd-private-monitor'
     set:
       global:
         sysdig:
-          region: au-syd-private
+          region: au-syd-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'br-sao-private'
+  - it: Checking region 'br-sao-private-monitor'
     set:
       global:
         sysdig:
-          region: br-sao-private
+          region: br-sao-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'ca-tor-private'
+  - it: Checking region 'ca-tor-private-monitor'
     set:
       global:
         sysdig:
-          region: ca-tor-private
+          region: ca-tor-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'eu-de-private'
+  - it: Checking region 'eu-de-private-monitor'
     set:
       global:
         sysdig:
-          region: eu-de-private
+          region: eu-de-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'eu-gb-private'
+  - it: Checking region 'eu-gb-private-monitor'
     set:
       global:
         sysdig:
-          region: eu-gb-private
+          region: eu-gb-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'jp-osa-private'
+  - it: Checking region 'jp-osa-private-monitor'
     set:
       global:
         sysdig:
-          region: jp-osa-private
+          region: jp-osa-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'jp-tok-private'
+  - it: Checking region 'jp-tok-private-monitor'
     set:
       global:
         sysdig:
-          region: jp-tok-private
+          region: jp-tok-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'us-east-private'
+  - it: Checking region 'us-east-private-monitor'
     set:
       global:
         sysdig:
-          region: us-east-private
+          region: us-east-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'us-south-private'
+  - it: Checking region 'us-south-private-monitor'
     set:
       global:
         sysdig:
-          region: us-south-private
+          region: us-south-private-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'au-syd-secure'
+    set:
+      global:
+        sysdig:
+          region: au-syd-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'br-sao-secure'
+    set:
+      global:
+        sysdig:
+          region: br-sao-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'ca-tor-secure'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-de-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-de-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-gb-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-osa-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-tok-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-east-secure'
+    set:
+      global:
+        sysdig:
+          region: us-east-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-south-secure'
+    set:
+      global:
+        sysdig:
+          region: us-south-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'au-syd-private-secure'
+    set:
+      global:
+        sysdig:
+          region: au-syd-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'br-sao-private-secure'
+    set:
+      global:
+        sysdig:
+          region: br-sao-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'ca-tor-private-secure'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-de-private-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-de-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-gb-private-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-osa-private-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-tok-private-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-east-private-secure'
+    set:
+      global:
+        sysdig:
+          region: us-east-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-south-private-secure'
+    set:
+      global:
+        sysdig:
+          region: us-south-private-secure
     asserts:
       - matchRegexRaw:
           pattern: https://private.us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10

--- a/charts/cluster-scanner/Chart.yaml
+++ b/charts/cluster-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.3
+version: 0.2.0
 
 appVersion: "0.1.0"
 home: https://www.sysdig.com/
@@ -20,4 +20,8 @@ maintainers:
     email: yashgiri.goswami@sysdig.com
   - name: provok
     email: vittorio.camisa@sysdig.com
-dependencies: []
+dependencies:
+  - name: common
+    # repository: https://charts.sysdig.com
+    repository: file://../common
+    version: ~1.0.0

--- a/charts/cluster-scanner/Chart.yaml
+++ b/charts/cluster-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.2.0
+version: 0.3.0
 
 appVersion: "0.1.0"
 home: https://www.sysdig.com/

--- a/charts/cluster-scanner/README.md
+++ b/charts/cluster-scanner/README.md
@@ -25,7 +25,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-      --create-namespace -n sysdig --version=0.1.3  \
+      --create-namespace -n sysdig --version=0.2.0  \
       --set global.clusterConfig.name=CLUSTER_NAME \
       --set global.sysdig.region=SYSDIG_REGION \
       --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -55,7 +55,7 @@ To install the chart with the release name `cluster-scanner`, run:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-       --create-namespace -n sysdig --version=0.1.3 \
+       --create-namespace -n sysdig --version=0.2.0 \
        --set global.clusterConfig.name=CLUSTER_NAME \
        --set global.sysdig.region=SYSDIG_REGION \
        --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -146,7 +146,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.1.3 \
+    --create-namespace -n sysdig --version=0.2.0 \
     --set global.sysdig.region="us1"
 ```
 
@@ -155,7 +155,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.1.3 \
+    --create-namespace -n sysdig --version=0.2.0 \
     --values values.yaml
 ```
 

--- a/charts/cluster-scanner/README.md
+++ b/charts/cluster-scanner/README.md
@@ -25,7 +25,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-      --create-namespace -n sysdig --version=0.2.0  \
+      --create-namespace -n sysdig --version=0.3.0  \
       --set global.clusterConfig.name=CLUSTER_NAME \
       --set global.sysdig.region=SYSDIG_REGION \
       --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -55,7 +55,7 @@ To install the chart with the release name `cluster-scanner`, run:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-       --create-namespace -n sysdig --version=0.2.0 \
+       --create-namespace -n sysdig --version=0.3.0 \
        --set global.clusterConfig.name=CLUSTER_NAME \
        --set global.sysdig.region=SYSDIG_REGION \
        --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -146,7 +146,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.2.0 \
+    --create-namespace -n sysdig --version=0.3.0 \
     --set global.sysdig.region="us1"
 ```
 
@@ -155,7 +155,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.2.0 \
+    --create-namespace -n sysdig --version=0.3.0 \
     --values values.yaml
 ```
 

--- a/charts/cluster-scanner/templates/NOTES.txt
+++ b/charts/cluster-scanner/templates/NOTES.txt
@@ -4,7 +4,7 @@ It consists of the Runtime Status Integrator and Image Sbom Extractor components
 
 After successful installation you can access the Cluster Scanner features as follows:
 
-Log in to Sysdig Secure (at the URL: {{ include "cluster-scanner.apiHost" . }}) and check that the features are working as expected.
+Log in to Sysdig Secure (at the URL:  https://{{ include "cluster-scanner.apiHost" . }}) and check that the features are working as expected.
   1. Select Scanning > Image Results.
   2. Check for scanned container image results that originate with the Sysdig Cluster Scanner.
 

--- a/charts/cluster-scanner/templates/NOTES.txt
+++ b/charts/cluster-scanner/templates/NOTES.txt
@@ -4,7 +4,7 @@ It consists of the Runtime Status Integrator and Image Sbom Extractor components
 
 After successful installation you can access the Cluster Scanner features as follows:
 
-Log in to Sysdig Secure (at the URL:  https://{{ include "cluster-scanner.apiHost" . }}) and check that the features are working as expected.
+Log in to Sysdig Secure (at the URL:  {{- if (not (or (hasPrefix "https://" (include "cluster-scanner.apiHost" .)) (hasPrefix "http://" (include "cluster-scanner.apiHost" .)))) -}}https://{{- end -}}{{ include "cluster-scanner.apiHost" . }}) and check that the features are working as expected.
   1. Select Scanning > Image Results.
   2. Check for scanned container image results that originate with the Sysdig Cluster Scanner.
 

--- a/charts/cluster-scanner/templates/_helpers.tpl
+++ b/charts/cluster-scanner/templates/_helpers.tpl
@@ -174,24 +174,12 @@ ise_cache_local_ttl: {{ .ttl }}
 Determine sysdig secure endpoint based on provided region
 */}}
 {{- define "cluster-scanner.apiHost" -}}
-    {{- if .Values.global.sysdig.apiHost -}}
-        {{- .Values.global.sysdig.apiHost -}}
-    {{- else if (eq .Values.global.sysdig.region "us1") -}}
-        {{- "https://secure.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us2") -}}
-        {{- "https://us2.app.sysdig.com/secure" -}}
-    {{- else if (eq .Values.global.sysdig.region "us3") -}}
-        {{- "https://app.us3.sysdig.com/secure" -}}
-    {{- else if (eq .Values.global.sysdig.region "us4") -}}
-        {{- "https://app.us4.sysdig.com/secure" -}}
-    {{- else if (eq .Values.global.sysdig.region "eu1") -}}
-        {{- "https://eu1.app.sysdig.com/secure" -}}
-    {{- else if (eq .Values.global.sysdig.region "au1") -}}
-        {{- "https://app.au1.sysdig.com/secure" -}}
-    {{- else -}}
-        {{- if (ne .Values.global.sysdig.region "custom") -}}
-            {{- fail (printf "global.sysdig.region=%s provided is not recognized." .Values.global.sysdig.region ) -}}
-        {{- end -}}
+    {{- if (or .Values.global.sysdig.apiHost (eq .Values.global.sysdig.region "custom"))  -}}
+        {{- required "A valid Sysdig API endpoint (.global.sysdig.apiHost) is required" .Values.global.sysdig.apiHost -}}
+    {{- else if hasKey ((include "sysdig.regions" .) | fromYaml) .Values.global.sysdig.region }}
+        {{- include "sysdig.secureApiEndpoint" . }}
+    {{- else }}
+        {{- fail (printf "global.sysdig.region=%s provided is not recognized." .Values.global.sysdig.region ) -}}
     {{- end -}}
 {{- end -}}
 

--- a/charts/cluster-scanner/templates/configmap.yaml
+++ b/charts/cluster-scanner/templates/configmap.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
    {{- include "cluster-scanner.labels" . | nindent 4 }}
 data:
+  {{- if or (hasPrefix "https://" (include "cluster-scanner.apiHost" .)) (hasPrefix "http://" (include "cluster-scanner.apiHost" .)) }}
   sysdig_host: {{ include "cluster-scanner.apiHost" . }}
+  {{ else }}
+  sysdig_host: https://{{ include "cluster-scanner.apiHost" . }}
+  {{ end -}}
   sysdig_verify_certificate: {{ .Values.sslVerifyCertificate | quote }}
   cluster_name: {{ .Values.global.clusterConfig.name }}
   root_namespace: {{ .Values.rootNamespace }}

--- a/charts/cluster-scanner/tests/notes_test.yaml
+++ b/charts/cluster-scanner/tests/notes_test.yaml
@@ -1,0 +1,386 @@
+suite: Test links in the notes section for regions
+templates:
+  - templates/NOTES.txt
+tests:
+  - it: Checking default value no region specified (us1)
+    asserts:
+      - matchRegexRaw:
+          pattern: https://secure.sysdig.com
+
+  - it: Checking region 'us2'
+    set:
+      global:
+        sysdig:
+          region: us2
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us2.app.sysdig.com
+
+  - it: Checking region 'us3'
+    set:
+      global:
+        sysdig:
+          region: us3
+    asserts:
+      - matchRegexRaw:
+          pattern: https://app.us3.sysdig.com
+
+  - it: Checking region 'us4'
+    set:
+      global:
+        sysdig:
+          region: us4
+    asserts:
+      - matchRegexRaw:
+          pattern: https://app.us4.sysdig.com
+
+  - it: Checking region 'eu1'
+    set:
+      global:
+        sysdig:
+          region: eu1
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu1.app.sysdig.com
+
+  - it: Checking region 'au1'
+    set:
+      global:
+        sysdig:
+          region: au1
+    asserts:
+      - matchRegexRaw:
+          pattern: https://app.au1.sysdig.com
+
+  - it: Checking region 'au-syd-monitor'
+    set:
+      global:
+        sysdig:
+          region: au-syd-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://au-syd.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao-monitor'
+    set:
+      global:
+        sysdig:
+          region: br-sao-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://br-sao.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-monitor'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://ca-tor.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de-monitor'
+    set:
+      global:
+        sysdig:
+          region: eu-de-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu-de.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-monitor'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu-gb.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-monitor'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://jp-osa.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-monitor'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://jp-tok.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east-monitor'
+    set:
+      global:
+        sysdig:
+          region: us-east-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us-east.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south-monitor'
+    set:
+      global:
+        sysdig:
+          region: us-south-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us-south.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'au-syd-private-monitor'
+    set:
+      global:
+        sysdig:
+          region: au-syd-private-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.au-syd.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao-private-monitor'
+    set:
+      global:
+        sysdig:
+          region: br-sao-private-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.br-sao.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-private-monitor'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-private-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.ca-tor.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de-private-monitor'
+    set:
+      global:
+        sysdig:
+          region: eu-de-private-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.eu-de.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-private-monitor'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-private-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.eu-gb.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-private-monitor'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-private-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.jp-osa.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-private-monitor'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-private-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.jp-tok.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east-private-monitor'
+    set:
+      global:
+        sysdig:
+          region: us-east-private-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.us-east.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south-private-monitor'
+    set:
+      global:
+        sysdig:
+          region: us-south-private-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.us-south.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'au-syd-secure'
+    set:
+      global:
+        sysdig:
+          region: au-syd-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://au-syd.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao-secure'
+    set:
+      global:
+        sysdig:
+          region: br-sao-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://br-sao.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-secure'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://ca-tor.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-de-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu-de.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu-gb.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://jp-osa.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://jp-tok.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east-secure'
+    set:
+      global:
+        sysdig:
+          region: us-east-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us-east.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south-secure'
+    set:
+      global:
+        sysdig:
+          region: us-south-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us-south.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'au-syd-private-secure'
+    set:
+      global:
+        sysdig:
+          region: au-syd-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.au-syd.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao-private-secure'
+    set:
+      global:
+        sysdig:
+          region: br-sao-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.br-sao.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-private-secure'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.ca-tor.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de-private-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-de-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.eu-de.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-private-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.eu-gb.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-private-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.jp-osa.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-private-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.jp-tok.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east-private-secure'
+    set:
+      global:
+        sysdig:
+          region: us-east-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.us-east.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south-private-secure'
+    set:
+      global:
+        sysdig:
+          region: us-south-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.us-south.security-compliance-secure.cloud.ibm.com
+
+  - it: Checking incorrect region 'ap3' should fail
+    set:
+      global:
+        sysdig:
+          region: ap3
+    asserts:
+      - failedTemplate:
+          errorMessage: "raw: global.sysdig.region=ap3 provided is not recognized."

--- a/charts/cluster-scanner/tests/notes_test.yaml
+++ b/charts/cluster-scanner/tests/notes_test.yaml
@@ -376,6 +376,36 @@ tests:
       - matchRegexRaw:
           pattern: https://private.us-south.security-compliance-secure.cloud.ibm.com
 
+  - it: Checking custom region without protocol specified
+    set:
+      global:
+        sysdig:
+          region: custom
+          apiHost: test.endpoint.tbd
+    asserts:
+      - matchRegexRaw:
+          pattern: https://test.endpoint.tbd
+
+  - it: Checking custom region with HTTPS protocol specified
+    set:
+      global:
+        sysdig:
+          region: custom
+          apiHost: https://test.endpoint.tbd
+    asserts:
+      - matchRegexRaw:
+          pattern: https://test.endpoint.tbd
+
+  - it: Checking custom region with HTTP protocol specified
+    set:
+      global:
+        sysdig:
+          region: custom
+          apiHost: http://test.endpoint.tbd
+    asserts:
+      - matchRegexRaw:
+          pattern: http://test.endpoint.tbd
+
   - it: Checking incorrect region 'ap3' should fail
     set:
       global:

--- a/charts/common/.helmignore
+++ b/charts/common/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: common
+description: Library Chart for Sysdig components to share common data
+
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: library
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+maintainers:
+  - name: aroberts87
+    email: adam.roberts@sysdig.com

--- a/charts/common/templates/_regions.tpl
+++ b/charts/common/templates/_regions.tpl
@@ -25,148 +25,148 @@
                                    "secureUi"           "app.us4.sysdig.com/secure")
                       "au-syd-monitor"   (dict "collectorEndpoint"  "ingest.au-syd.monitoring.cloud.ibm.com"
                                                "monitorApiEndpoint" "au-syd.monitoring.cloud.ibm.com"
-                                               "secureApiEndpoint"  "au-syd.sysdig-secure.cloud.ibm.com"
-                                               "secureUi"           "au-syd.sysdig-secure.cloud.ibm.com")
+                                               "secureApiEndpoint"  "au-syd.security-compliance-secure.cloud.ibm.com"
+                                               "secureUi"           "au-syd.security-compliance-secure.cloud.ibm.com")
                       "br-sao-monitor"   (dict "collectorEndpoint"  "ingest.br-sao.monitoring.cloud.ibm.com"
                                                "monitorApiEndpoint" "br-sao.monitoring.cloud.ibm.com"
-                                               "secureApiEndpoint"  "br-sao.sysdig-secure.cloud.ibm.com"
-                                               "secureUi"           "br-sao.sysdig-secure.cloud.ibm.com")
+                                               "secureApiEndpoint"  "br-sao.security-compliance-secure.cloud.ibm.com"
+                                               "secureUi"           "br-sao.security-compliance-secure.cloud.ibm.com")
                       "ca-tor-monitor"   (dict "collectorEndpoint"  "ingest.ca-tor.monitoring.cloud.ibm.com"
                                                "monitorApiEndpoint" "ca-tor.monitoring.cloud.ibm.com"
-                                               "secureApiEndpoint"  "ca-tor.sysdig-secure.cloud.ibm.com"
-                                               "secureUi"           "ca-tor.sysdig-secure.cloud.ibm.com")
+                                               "secureApiEndpoint"  "ca-tor.security-compliance-secure.cloud.ibm.com"
+                                               "secureUi"           "ca-tor.security-compliance-secure.cloud.ibm.com")
                       "eu-de-monitor"    (dict "collectorEndpoint"  "ingest.eu-de.monitoring.cloud.ibm.com"
                                                "monitorApiEndpoint" "eu-de.monitoring.cloud.ibm.com"
-                                               "secureApiEndpoint"  "eu-de.sysdig-secure.cloud.ibm.com"
-                                               "secureUi"           "eu-de.sysdig-secure.cloud.ibm.com")
+                                               "secureApiEndpoint"  "eu-de.security-compliance-secure.cloud.ibm.com"
+                                               "secureUi"           "eu-de.security-compliance-secure.cloud.ibm.com")
                       "eu-gb-monitor"    (dict "collectorEndpoint"  "ingest.eu-gb.monitoring.cloud.ibm.com"
                                                "monitorApiEndpoint" "eu-gb.monitoring.cloud.ibm.com"
-                                               "secureApiEndpoint"  "eu-gb.sysdig-secure.cloud.ibm.com"
-                                               "secureUi"           "eu-gb.sysdig-secure.cloud.ibm.com")
+                                               "secureApiEndpoint"  "eu-gb.security-compliance-secure.cloud.ibm.com"
+                                               "secureUi"           "eu-gb.security-compliance-secure.cloud.ibm.com")
                       "jp-osa-monitor"   (dict "collectorEndpoint"  "ingest.jp-osa.monitoring.cloud.ibm.com"
                                                "monitorApiEndpoint" "jp-osa.monitoring.cloud.ibm.com"
-                                               "secureApiEndpoint"  "jp-osa.sysdig-secure.cloud.ibm.com"
-                                               "secureUi"           "jp-osa.sysdig-secure.cloud.ibm.com")
+                                               "secureApiEndpoint"  "jp-osa.security-compliance-secure.cloud.ibm.com"
+                                               "secureUi"           "jp-osa.security-compliance-secure.cloud.ibm.com")
                       "jp-tok-monitor"   (dict "collectorEndpoint"  "ingest.jp-tok.monitoring.cloud.ibm.com"
                                                "monitorApiEndpoint" "jp-tok.monitoring.cloud.ibm.com"
-                                               "secureApiEndpoint"  "jp-tok.sysdig-secure.cloud.ibm.com"
-                                               "secureUi"           "jp-tok.sysdig-secure.cloud.ibm.com")
+                                               "secureApiEndpoint"  "jp-tok.security-compliance-secure.cloud.ibm.com"
+                                               "secureUi"           "jp-tok.security-compliance-secure.cloud.ibm.com")
                       "us-east-monitor"  (dict "collectorEndpoint"  "ingest.us-east.monitoring.cloud.ibm.com"
                                                "monitorApiEndpoint" "us-east.monitoring.cloud.ibm.com"
-                                               "secureApiEndpoint"  "us-east.sysdig-secure.cloud.ibm.com"
-                                               "secureUi"           "us-east.sysdig-secure.cloud.ibm.com")
+                                               "secureApiEndpoint"  "us-east.security-compliance-secure.cloud.ibm.com"
+                                               "secureUi"           "us-east.security-compliance-secure.cloud.ibm.com")
                       "us-south-monitor" (dict "collectorEndpoint"  "ingest.us-south.monitoring.cloud.ibm.com"
                                                "monitorApiEndpoint" "us-south.monitoring.cloud.ibm.com"
-                                               "secureApiEndpoint"  "us-south.sysdig-secure.cloud.ibm.com"
-                                               "secureUi"           "us-south.sysdig-secure.cloud.ibm.com")
+                                               "secureApiEndpoint"  "us-south.security-compliance-secure.cloud.ibm.com"
+                                               "secureUi"           "us-south.security-compliance-secure.cloud.ibm.com")
                       "au-syd-private-monitor"   (dict "collectorEndpoint"  "ingest.private.au-syd.monitoring.cloud.ibm.com"
                                                        "monitorApiEndpoint" "private.au-syd.monitoring.cloud.ibm.com"
-                                                       "secureApiEndpoint"  "private.au-syd.sysdig-secure.cloud.ibm.com"
-                                                       "secureUi"           "private.au-syd.sysdig-secure.cloud.ibm.com")
+                                                       "secureApiEndpoint"  "private.au-syd.security-compliance-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.au-syd.security-compliance-secure.cloud.ibm.com")
                       "br-sao-private-monitor"   (dict "collectorEndpoint"  "ingest.private.br-sao.monitoring.cloud.ibm.com"
                                                        "monitorApiEndpoint" "private.br-sao.monitoring.cloud.ibm.com"
-                                                       "secureApiEndpoint"  "private.br-sao.sysdig-secure.cloud.ibm.com"
-                                                       "secureUi"           "private.br-sao.sysdig-secure.cloud.ibm.com")
+                                                       "secureApiEndpoint"  "private.br-sao.security-compliance-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.br-sao.security-compliance-secure.cloud.ibm.com")
                       "ca-tor-private-monitor"   (dict "collectorEndpoint"  "ingest.private.ca-tor.monitoring.cloud.ibm.com"
                                                        "monitorApiEndpoint" "private.ca-tor.monitoring.cloud.ibm.com"
-                                                       "secureApiEndpoint"  "private.ca-tor.sysdig-secure.cloud.ibm.com"
-                                                       "secureUi"           "private.ca-tor.sysdig-secure.cloud.ibm.com")
+                                                       "secureApiEndpoint"  "private.ca-tor.security-compliance-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.ca-tor.security-compliance-secure.cloud.ibm.com")
                       "eu-de-private-monitor"    (dict "collectorEndpoint"  "ingest.private.eu-de.monitoring.cloud.ibm.com"
                                                        "monitorApiEndpoint" "private.eu-de.monitoring.cloud.ibm.com"
-                                                       "secureApiEndpoint"  "private.eu-de.sysdig-secure.cloud.ibm.com"
-                                                       "secureUi"           "private.eu-de.sysdig-secure.cloud.ibm.com")
+                                                       "secureApiEndpoint"  "private.eu-de.security-compliance-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.eu-de.security-compliance-secure.cloud.ibm.com")
                       "eu-gb-private-monitor"    (dict "collectorEndpoint"  "ingest.private.eu-gb.monitoring.cloud.ibm.com"
                                                        "monitorApiEndpoint" "private.eu-gb.monitoring.cloud.ibm.com"
-                                                       "secureApiEndpoint"  "private.eu-gb.sysdig-secure.cloud.ibm.com"
-                                                       "secureUi"           "private.eu-gb.sysdig-secure.cloud.ibm.com")
+                                                       "secureApiEndpoint"  "private.eu-gb.security-compliance-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.eu-gb.security-compliance-secure.cloud.ibm.com")
                       "jp-osa-private-monitor"   (dict "collectorEndpoint"  "ingest.private.jp-osa.monitoring.cloud.ibm.com"
                                                        "monitorApiEndpoint" "private.jp-osa.monitoring.cloud.ibm.com"
-                                                       "secureApiEndpoint"  "private.jp-osa.sysdig-secure.cloud.ibm.com"
-                                                       "secureUi"           "private.jp-osa.sysdig-secure.cloud.ibm.com")
+                                                       "secureApiEndpoint"  "private.jp-osa.security-compliance-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.jp-osa.security-compliance-secure.cloud.ibm.com")
                       "jp-tok-private-monitor"   (dict "collectorEndpoint"  "ingest.private.jp-tok.monitoring.cloud.ibm.com"
                                                        "monitorApiEndpoint" "private.jp-tok.monitoring.cloud.ibm.com"
-                                                       "secureApiEndpoint"  "private.jp-tok.sysdig-secure.cloud.ibm.com"
-                                                       "secureUi"           "private.jp-tok.sysdig-secure.cloud.ibm.com")
+                                                       "secureApiEndpoint"  "private.jp-tok.security-compliance-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.jp-tok.security-compliance-secure.cloud.ibm.com")
                       "us-east-private-monitor"  (dict "collectorEndpoint"  "ingest.private.us-east.monitoring.cloud.ibm.com"
                                                        "monitorApiEndpoint" "private.us-east.monitoring.cloud.ibm.com"
-                                                       "secureApiEndpoint"  "private.us-east.sysdig-secure.cloud.ibm.com"
-                                                       "secureUi"           "private.us-east.sysdig-secure.cloud.ibm.com")
+                                                       "secureApiEndpoint"  "private.us-east.security-compliance-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.us-east.security-compliance-secure.cloud.ibm.com")
                       "us-south-private-monitor" (dict "collectorEndpoint"  "ingest.private.us-south.monitoring.cloud.ibm.com"
                                                        "monitorApiEndpoint" "private.us-south.monitoring.cloud.ibm.com"
-                                                       "secureApiEndpoint"  "private.us-south.sysdig-secure.cloud.ibm.com"
-                                                       "secureUi"           "private.us-south.sysdig-secure.cloud.ibm.com")
-                      "au-syd-secure"   (dict "collectorEndpoint"  "ingest.au-syd.sysdig-secure.cloud.ibm.com"
+                                                       "secureApiEndpoint"  "private.us-south.security-compliance-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.us-south.security-compliance-secure.cloud.ibm.com")
+                      "au-syd-secure"   (dict "collectorEndpoint"  "ingest.au-syd.security-compliance-secure.cloud.ibm.com"
                                               "monitorApiEndpoint" "au-syd.monitoring.cloud.ibm.com"
-                                              "secureApiEndpoint"  "au-syd.sysdig-secure.cloud.ibm.com"
-                                              "secureUi"           "au-syd.sysdig-secure.cloud.ibm.com")
-                      "br-sao-secure"   (dict "collectorEndpoint"  "ingest.br-sao.sysdig-secure.cloud.ibm.com"
+                                              "secureApiEndpoint"  "au-syd.security-compliance-secure.cloud.ibm.com"
+                                              "secureUi"           "au-syd.security-compliance-secure.cloud.ibm.com")
+                      "br-sao-secure"   (dict "collectorEndpoint"  "ingest.br-sao.security-compliance-secure.cloud.ibm.com"
                                               "monitorApiEndpoint" "br-sao.monitoring.cloud.ibm.com"
-                                              "secureApiEndpoint"  "br-sao.sysdig-secure.cloud.ibm.com"
-                                              "secureUi"           "br-sao.sysdig-secure.cloud.ibm.com")
-                      "ca-tor-secure"   (dict "collectorEndpoint"  "ingest.ca-tor.sysdig-secure.cloud.ibm.com"
+                                              "secureApiEndpoint"  "br-sao.security-compliance-secure.cloud.ibm.com"
+                                              "secureUi"           "br-sao.security-compliance-secure.cloud.ibm.com")
+                      "ca-tor-secure"   (dict "collectorEndpoint"  "ingest.ca-tor.security-compliance-secure.cloud.ibm.com"
                                               "monitorApiEndpoint" "ca-tor.monitoring.cloud.ibm.com"
-                                              "secureApiEndpoint"  "ca-tor.sysdig-secure.cloud.ibm.com"
-                                              "secureUi"           "ca-tor.sysdig-secure.cloud.ibm.com")
-                      "eu-de-secure"    (dict "collectorEndpoint"  "ingest.eu-de.sysdig-secure.cloud.ibm.com"
+                                              "secureApiEndpoint"  "ca-tor.security-compliance-secure.cloud.ibm.com"
+                                              "secureUi"           "ca-tor.security-compliance-secure.cloud.ibm.com")
+                      "eu-de-secure"    (dict "collectorEndpoint"  "ingest.eu-de.security-compliance-secure.cloud.ibm.com"
                                               "monitorApiEndpoint" "eu-de.monitoring.cloud.ibm.com"
-                                              "secureApiEndpoint"  "eu-de.sysdig-secure.cloud.ibm.com"
-                                              "secureUi"           "eu-de.sysdig-secure.cloud.ibm.com")
-                      "eu-gb-secure"    (dict "collectorEndpoint"  "ingest.eu-gb.sysdig-secure.cloud.ibm.com"
+                                              "secureApiEndpoint"  "eu-de.security-compliance-secure.cloud.ibm.com"
+                                              "secureUi"           "eu-de.security-compliance-secure.cloud.ibm.com")
+                      "eu-gb-secure"    (dict "collectorEndpoint"  "ingest.eu-gb.security-compliance-secure.cloud.ibm.com"
                                               "monitorApiEndpoint" "eu-gb.monitoring.cloud.ibm.com"
-                                              "secureApiEndpoint"  "eu-gb.sysdig-secure.cloud.ibm.com"
-                                              "secureUi"           "eu-gb.sysdig-secure.cloud.ibm.com")
-                      "jp-osa-secure"   (dict "collectorEndpoint"  "ingest.jp-osa.sysdig-secure.cloud.ibm.com"
+                                              "secureApiEndpoint"  "eu-gb.security-compliance-secure.cloud.ibm.com"
+                                              "secureUi"           "eu-gb.security-compliance-secure.cloud.ibm.com")
+                      "jp-osa-secure"   (dict "collectorEndpoint"  "ingest.jp-osa.security-compliance-secure.cloud.ibm.com"
                                               "monitorApiEndpoint" "jp-osa.monitoring.cloud.ibm.com"
-                                              "secureApiEndpoint"  "jp-osa.sysdig-secure.cloud.ibm.com"
-                                              "secureUi"           "jp-osa.sysdig-secure.cloud.ibm.com")
-                      "jp-tok-secure"   (dict "collectorEndpoint"  "ingest.jp-tok.sysdig-secure.cloud.ibm.com"
+                                              "secureApiEndpoint"  "jp-osa.security-compliance-secure.cloud.ibm.com"
+                                              "secureUi"           "jp-osa.security-compliance-secure.cloud.ibm.com")
+                      "jp-tok-secure"   (dict "collectorEndpoint"  "ingest.jp-tok.security-compliance-secure.cloud.ibm.com"
                                               "monitorApiEndpoint" "jp-tok.monitoring.cloud.ibm.com"
-                                              "secureApiEndpoint"  "jp-tok.sysdig-secure.cloud.ibm.com"
-                                              "secureUi"           "jp-tok.sysdig-secure.cloud.ibm.com")
-                      "us-east-secure"  (dict "collectorEndpoint"  "ingest.us-east.sysdig-secure.cloud.ibm.com"
+                                              "secureApiEndpoint"  "jp-tok.security-compliance-secure.cloud.ibm.com"
+                                              "secureUi"           "jp-tok.security-compliance-secure.cloud.ibm.com")
+                      "us-east-secure"  (dict "collectorEndpoint"  "ingest.us-east.security-compliance-secure.cloud.ibm.com"
                                               "monitorApiEndpoint" "us-east.monitoring.cloud.ibm.com"
-                                              "secureApiEndpoint"  "us-east.sysdig-secure.cloud.ibm.com"
-                                              "secureUi"           "us-east.sysdig-secure.cloud.ibm.com")
-                      "us-south-secure" (dict "collectorEndpoint"  "ingest.us-south.sysdig-secure.cloud.ibm.com"
+                                              "secureApiEndpoint"  "us-east.security-compliance-secure.cloud.ibm.com"
+                                              "secureUi"           "us-east.security-compliance-secure.cloud.ibm.com")
+                      "us-south-secure" (dict "collectorEndpoint"  "ingest.us-south.security-compliance-secure.cloud.ibm.com"
                                               "monitorApiEndpoint" "us-south.monitoring.cloud.ibm.com"
-                                              "secureApiEndpoint"  "us-south.sysdig-secure.cloud.ibm.com"
-                                              "secureUi"           "us-south.sysdig-secure.cloud.ibm.com")
-                      "au-syd-private-secure"   (dict "collectorEndpoint"  "ingest.private.au-syd.sysdig-secure.cloud.ibm.com"
+                                              "secureApiEndpoint"  "us-south.security-compliance-secure.cloud.ibm.com"
+                                              "secureUi"           "us-south.security-compliance-secure.cloud.ibm.com")
+                      "au-syd-private-secure"   (dict "collectorEndpoint"  "ingest.private.au-syd.security-compliance-secure.cloud.ibm.com"
                                                       "monitorApiEndpoint" "private.au-syd.monitoring.cloud.ibm.com"
-                                                      "secureApiEndpoint"  "private.au-syd.sysdig-secure.cloud.ibm.com"
-                                                      "secureUi"           "private.au-syd.sysdig-secure.cloud.ibm.com")
-                      "br-sao-private-secure"   (dict "collectorEndpoint"  "ingest.private.br-sao.sysdig-secure.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.au-syd.security-compliance-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.au-syd.security-compliance-secure.cloud.ibm.com")
+                      "br-sao-private-secure"   (dict "collectorEndpoint"  "ingest.private.br-sao.security-compliance-secure.cloud.ibm.com"
                                                       "monitorApiEndpoint" "private.br-sao.monitoring.cloud.ibm.com"
-                                                      "secureApiEndpoint"  "private.br-sao.sysdig-secure.cloud.ibm.com"
-                                                      "secureUi"           "private.br-sao.sysdig-secure.cloud.ibm.com")
-                      "ca-tor-private-secure"   (dict "collectorEndpoint"  "ingest.private.ca-tor.sysdig-secure.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.br-sao.security-compliance-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.br-sao.security-compliance-secure.cloud.ibm.com")
+                      "ca-tor-private-secure"   (dict "collectorEndpoint"  "ingest.private.ca-tor.security-compliance-secure.cloud.ibm.com"
                                                       "monitorApiEndpoint" "private.ca-tor.monitoring.cloud.ibm.com"
-                                                      "secureApiEndpoint"  "private.ca-tor.sysdig-secure.cloud.ibm.com"
-                                                      "secureUi"           "private.ca-tor.sysdig-secure.cloud.ibm.com")
-                      "eu-de-private-secure"    (dict "collectorEndpoint"  "ingest.private.eu-de.sysdig-secure.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.ca-tor.security-compliance-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.ca-tor.security-compliance-secure.cloud.ibm.com")
+                      "eu-de-private-secure"    (dict "collectorEndpoint"  "ingest.private.eu-de.security-compliance-secure.cloud.ibm.com"
                                                       "monitorApiEndpoint" "private.eu-de.monitoring.cloud.ibm.com"
-                                                      "secureApiEndpoint"  "private.eu-de.sysdig-secure.cloud.ibm.com"
-                                                      "secureUi"           "private.eu-de.sysdig-secure.cloud.ibm.com")
-                      "eu-gb-private-secure"    (dict "collectorEndpoint"  "ingest.private.eu-gb.sysdig-secure.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.eu-de.security-compliance-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.eu-de.security-compliance-secure.cloud.ibm.com")
+                      "eu-gb-private-secure"    (dict "collectorEndpoint"  "ingest.private.eu-gb.security-compliance-secure.cloud.ibm.com"
                                                       "monitorApiEndpoint" "private.eu-gb.monitoring.cloud.ibm.com"
-                                                      "secureApiEndpoint"  "private.eu-gb.sysdig-secure.cloud.ibm.com"
-                                                      "secureUi"           "private.eu-gb.sysdig-secure.cloud.ibm.com")
-                      "jp-osa-private-secure"   (dict "collectorEndpoint"  "ingest.private.jp-osa.sysdig-secure.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.eu-gb.security-compliance-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.eu-gb.security-compliance-secure.cloud.ibm.com")
+                      "jp-osa-private-secure"   (dict "collectorEndpoint"  "ingest.private.jp-osa.security-compliance-secure.cloud.ibm.com"
                                                       "monitorApiEndpoint" "private.jp-osa.monitoring.cloud.ibm.com"
-                                                      "secureApiEndpoint"  "private.jp-osa.sysdig-secure.cloud.ibm.com"
-                                                      "secureUi"           "private.jp-osa.sysdig-secure.cloud.ibm.com")
-                      "jp-tok-private-secure"   (dict "collectorEndpoint"  "ingest.private.jp-tok.sysdig-secure.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.jp-osa.security-compliance-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.jp-osa.security-compliance-secure.cloud.ibm.com")
+                      "jp-tok-private-secure"   (dict "collectorEndpoint"  "ingest.private.jp-tok.security-compliance-secure.cloud.ibm.com"
                                                       "monitorApiEndpoint" "private.jp-tok.monitoring.cloud.ibm.com"
-                                                      "secureApiEndpoint"  "private.jp-tok.sysdig-secure.cloud.ibm.com"
-                                                      "secureUi"           "private.jp-tok.sysdig-secure.cloud.ibm.com")
-                      "us-east-private-secure"  (dict "collectorEndpoint"  "ingest.private.us-east.sysdig-secure.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.jp-tok.security-compliance-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.jp-tok.security-compliance-secure.cloud.ibm.com")
+                      "us-east-private-secure"  (dict "collectorEndpoint"  "ingest.private.us-east.security-compliance-secure.cloud.ibm.com"
                                                       "monitorApiEndpoint" "private.us-east.monitoring.cloud.ibm.com"
-                                                      "secureApiEndpoint"  "private.us-east.sysdig-secure.cloud.ibm.com"
-                                                      "secureUi"           "private.us-east.sysdig-secure.cloud.ibm.com")
-                      "us-south-private-secure" (dict "collectorEndpoint"  "ingest.private.us-south.sysdig-secure.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.us-east.security-compliance-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.us-east.security-compliance-secure.cloud.ibm.com")
+                      "us-south-private-secure" (dict "collectorEndpoint"  "ingest.private.us-south.security-compliance-secure.cloud.ibm.com"
                                                       "monitorApiEndpoint" "private.us-south.monitoring.cloud.ibm.com"
-                                                      "secureApiEndpoint"  "private.us-south.sysdig-secure.cloud.ibm.com"
-                                                      "secureUi"           "private.us-south.sysdig-secure.cloud.ibm.com") }}
+                                                      "secureApiEndpoint"  "private.us-south.security-compliance-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.us-south.security-compliance-secure.cloud.ibm.com") }}
 
   {{- toYaml $regions }}
 {{- end }}

--- a/charts/common/templates/_regions.tpl
+++ b/charts/common/templates/_regions.tpl
@@ -1,0 +1,127 @@
+{{- define "sysdig.regions" -}}
+  {{- $regions := dict "au1" (dict "collectorEndpoint"  "ingest.au1.sysdig.com"
+                                   "monitorApiEndpoint" "app.au1.sysdig.com"
+                                   "secureApiEndpoint"  "app.au1.sysdig.com"
+                                   "secureUi"           "app.au1.sysdig.com/secure")
+                       "eu1" (dict "collectorEndpoint"  "ingest-eu1.app.sysdig.com"
+                                   "monitorApiEndpoint" "eu1.app.sysdig.com"
+                                   "secureApiEndpoint"  "eu1.app.sysdig.com"
+                                   "secureUi"           "eu1.app.sysdig.com/secure")
+                       "us1" (dict "collectorEndpoint"  "collector.sysdigcloud.com"
+                                   "monitorApiEndpoint" "app.sysdigcloud.com"
+                                   "secureApiEndpoint"  "secure.sysdig.com"
+                                   "secureUi"           "secure.sysdig.com")
+                       "us2" (dict "collectorEndpoint"  "ingest-us2.app.sysdig.com"
+                                   "monitorApiEndpoint" "us2.app.sysdig.com"
+                                   "secureApiEndpoint"  "us2.app.sysdig.com"
+                                   "secureUi"           "us2.app.sysdig.com/secure")
+                       "us3" (dict "collectorEndpoint"  "ingest.us3.sysdig.com"
+                                   "monitorApiEndpoint" "app.us3.sysdig.com"
+                                   "secureApiEndpoint"  "app.us3.sysdig.com"
+                                   "secureUi"           "app.us3.sysdig.com/secure")
+                       "us4" (dict "collectorEndpoint"  "ingest.us4.sysdig.com"
+                                   "monitorApiEndpoint" "app.us4.sysdig.com"
+                                   "secureApiEndpoint"  "app.us4.sysdig.com"
+                                   "secureUi"           "app.us4.sysdig.com/secure")
+                      "au-syd" (dict "collectorEndpoint"    "ingest.au-syd.monitoring.cloud.ibm.com"
+                                     "monitorApiEndpoint"   "au-syd.monitoring.cloud.ibm.com"
+                                     "secureApiEndpoint"    "au-syd.sysdig-secure.cloud.ibm.com"
+                                     "secureUi"             "au-syd.sysdig-secure.cloud.ibm.com")
+                      "br-sao" (dict "collectorEndpoint"    "ingest.br-sao.monitoring.cloud.ibm.com"
+                                     "monitorApiEndpoint"   "br-sao.monitoring.cloud.ibm.com"
+                                     "secureApiEndpoint"    "br-sao.sysdig-secure.cloud.ibm.com"
+                                     "secureUi"             "br-sao.sysdig-secure.cloud.ibm.com")
+                      "ca-tor" (dict "collectorEndpoint"    "ingest.ca-tor.monitoring.cloud.ibm.com"
+                                     "monitorApiEndpoint"   "ca-tor.monitoring.cloud.ibm.com"
+                                     "secureApiEndpoint"    "ca-tor.sysdig-secure.cloud.ibm.com"
+                                     "secureUi"             "ca-tor.sysdig-secure.cloud.ibm.com")
+                      "eu-de" (dict "collectorEndpoint"     "ingest.eu-de.monitoring.cloud.ibm.com"
+                                    "monitorApiEndpoint"    "eu-de.monitoring.cloud.ibm.com"
+                                    "secureApiEndpoint"     "eu-de.sysdig-secure.cloud.ibm.com"
+                                    "secureUi"              "eu-de.sysdig-secure.cloud.ibm.com")
+                      "eu-gb" (dict "collectorEndpoint"     "ingest.eu-gb.monitoring.cloud.ibm.com"
+                                    "monitorApiEndpoint"    "eu-gb.monitoring.cloud.ibm.com"
+                                    "secureApiEndpoint"     "eu-gb.sysdig-secure.cloud.ibm.com"
+                                    "secureUi"              "eu-gb.sysdig-secure.cloud.ibm.com")
+                      "jp-osa" (dict "collectorEndpoint"    "ingest.jp-osa.monitoring.cloud.ibm.com"
+                                     "monitorApiEndpoint"   "jp-osa.monitoring.cloud.ibm.com"
+                                     "secureApiEndpoint"    "jp-osa.sysdig-secure.cloud.ibm.com"
+                                     "secureUi"             "jp-osa.sysdig-secure.cloud.ibm.com")
+                      "jp-tok" (dict "collectorEndpoint"    "ingest.jp-tok.monitoring.cloud.ibm.com"
+                                     "monitorApiEndpoint"   "jp-tok.monitoring.cloud.ibm.com"
+                                     "secureApiEndpoint"    "jp-tok.sysdig-secure.cloud.ibm.com"
+                                     "secureUi"             "jp-tok.sysdig-secure.cloud.ibm.com")
+                      "us-east" (dict "collectorEndpoint"   "ingest.us-east.monitoring.cloud.ibm.com"
+                                      "monitorApiEndpoint"  "us-east.monitoring.cloud.ibm.com"
+                                      "secureApiEndpoint"   "us-east.sysdig-secure.cloud.ibm.com"
+                                      "secureUi"            "us-east.sysdig-secure.cloud.ibm.com")
+                      "us-south" (dict "collectorEndpoint"  "ingest.us-south.monitoring.cloud.ibm.com"
+                                       "monitorApiEndpoint" "us-south.monitoring.cloud.ibm.com"
+                                       "secureApiEndpoint"  "us-south.sysdig-secure.cloud.ibm.com"
+                                       "secureUi"           "us-south.sysdig-secure.cloud.ibm.com")
+                      "au-syd-private" (dict "collectorEndpoint"    "ingest.private.au-syd.monitoring.cloud.ibm.com"
+                                             "monitorApiEndpoint"   "private.au-syd.monitoring.cloud.ibm.com"
+                                             "secureApiEndpoint"    "private.au-syd.sysdig-secure.cloud.ibm.com"
+                                             "secureUi"             "private.au-syd.sysdig-secure.cloud.ibm.com")
+                      "br-sao-private" (dict "collectorEndpoint"    "ingest.private.br-sao.monitoring.cloud.ibm.com"
+                                             "monitorApiEndpoint"   "private.br-sao.monitoring.cloud.ibm.com"
+                                             "secureApiEndpoint"    "private.br-sao.sysdig-secure.cloud.ibm.com"
+                                             "secureUi"             "private.br-sao.sysdig-secure.cloud.ibm.com")
+                      "ca-tor-private" (dict "collectorEndpoint"    "ingest.private.ca-tor.monitoring.cloud.ibm.com"
+                                             "monitorApiEndpoint"   "private.ca-tor.monitoring.cloud.ibm.com"
+                                             "secureApiEndpoint"    "private.ca-tor.sysdig-secure.cloud.ibm.com"
+                                             "secureUi"             "private.ca-tor.sysdig-secure.cloud.ibm.com")
+                      "eu-de-private" (dict "collectorEndpoint"     "ingest.private.eu-de.monitoring.cloud.ibm.com"
+                                            "monitorApiEndpoint"    "private.eu-de.monitoring.cloud.ibm.com"
+                                            "secureApiEndpoint"     "private.eu-de.sysdig-secure.cloud.ibm.com"
+                                            "secureUi"              "private.eu-de.sysdig-secure.cloud.ibm.com")
+                      "eu-gb-private" (dict "collectorEndpoint"     "ingest.private.eu-gb.monitoring.cloud.ibm.com"
+                                            "monitorApiEndpoint"    "private.eu-gb.monitoring.cloud.ibm.com"
+                                            "secureApiEndpoint"     "private.eu-gb.sysdig-secure.cloud.ibm.com"
+                                            "secureUi"              "private.eu-gb.sysdig-secure.cloud.ibm.com")
+                      "jp-osa-private" (dict "collectorEndpoint"    "ingest.private.jp-osa.monitoring.cloud.ibm.com"
+                                             "monitorApiEndpoint"   "private.jp-osa.monitoring.cloud.ibm.com"
+                                             "secureApiEndpoint"    "private.jp-osa.sysdig-secure.cloud.ibm.com"
+                                             "secureUi"             "private.jp-osa.sysdig-secure.cloud.ibm.com")
+                      "jp-tok-private" (dict "collectorEndpoint"    "ingest.private.jp-tok.monitoring.cloud.ibm.com"
+                                             "monitorApiEndpoint"   "private.jp-tok.monitoring.cloud.ibm.com"
+                                             "secureApiEndpoint"    "private.jp-tok.sysdig-secure.cloud.ibm.com"
+                                             "secureUi"             "private.jp-tok.sysdig-secure.cloud.ibm.com")
+                      "us-east-private" (dict "collectorEndpoint"   "ingest.private.us-east.monitoring.cloud.ibm.com"
+                                              "monitorApiEndpoint"  "private.us-east.monitoring.cloud.ibm.com"
+                                              "secureApiEndpoint"   "private.us-east.sysdig-secure.cloud.ibm.com"
+                                              "secureUi"            "private.us-east.sysdig-secure.cloud.ibm.com")
+                      "us-south-private" (dict "collectorEndpoint"  "ingest.private.us-south.monitoring.cloud.ibm.com"
+                                               "monitorApiEndpoint" "private.us-south.monitoring.cloud.ibm.com"
+                                               "secureApiEndpoint"  "private.us-south.sysdig-secure.cloud.ibm.com"
+                                               "secureUi"           "private.us-south.sysdig-secure.cloud.ibm.com") }}
+  {{- toYaml $regions }}
+{{- end }}
+
+{{- define "sysdig.collectorEndpoint" }}
+  {{- $regions := fromYaml (include "sysdig.regions" .) }}
+  {{- if hasKey $regions .Values.global.sysdig.region }}
+    {{- get (get $regions .Values.global.sysdig.region) "collectorEndpoint"  }}
+  {{- end }}
+{{- end }}
+
+{{- define "sysdig.monitorApiEndpoint" }}
+  {{- $regions := fromYaml (include "sysdig.regions" .) }}
+  {{- if hasKey $regions .Values.global.sysdig.region }}
+    {{- get (get $regions .Values.global.sysdig.region) "monitorApiEndpoint" }}
+  {{- end }}
+{{- end }}
+
+{{- define "sysdig.secureApiEndpoint" }}
+  {{- $regions := fromYaml (include "sysdig.regions" .) }}
+  {{- if hasKey $regions .Values.global.sysdig.region }}
+    {{- get (get $regions .Values.global.sysdig.region) "secureApiEndpoint" }}
+  {{- end }}
+{{- end }}
+
+{{- define "sysdig.secureUi" }}
+  {{- $regions := fromYaml (include "sysdig.regions" .) }}
+  {{- if hasKey $regions .Values.global.sysdig.region }}
+    {{- get (get $regions .Values.global.sysdig.region) "secureUi" }}
+  {{- end }}
+{{- end }}

--- a/charts/common/templates/_regions.tpl
+++ b/charts/common/templates/_regions.tpl
@@ -23,78 +23,151 @@
                                    "monitorApiEndpoint" "app.us4.sysdig.com"
                                    "secureApiEndpoint"  "app.us4.sysdig.com"
                                    "secureUi"           "app.us4.sysdig.com/secure")
-                      "au-syd" (dict "collectorEndpoint"    "ingest.au-syd.monitoring.cloud.ibm.com"
-                                     "monitorApiEndpoint"   "au-syd.monitoring.cloud.ibm.com"
-                                     "secureApiEndpoint"    "au-syd.sysdig-secure.cloud.ibm.com"
-                                     "secureUi"             "au-syd.sysdig-secure.cloud.ibm.com")
-                      "br-sao" (dict "collectorEndpoint"    "ingest.br-sao.monitoring.cloud.ibm.com"
-                                     "monitorApiEndpoint"   "br-sao.monitoring.cloud.ibm.com"
-                                     "secureApiEndpoint"    "br-sao.sysdig-secure.cloud.ibm.com"
-                                     "secureUi"             "br-sao.sysdig-secure.cloud.ibm.com")
-                      "ca-tor" (dict "collectorEndpoint"    "ingest.ca-tor.monitoring.cloud.ibm.com"
-                                     "monitorApiEndpoint"   "ca-tor.monitoring.cloud.ibm.com"
-                                     "secureApiEndpoint"    "ca-tor.sysdig-secure.cloud.ibm.com"
-                                     "secureUi"             "ca-tor.sysdig-secure.cloud.ibm.com")
-                      "eu-de" (dict "collectorEndpoint"     "ingest.eu-de.monitoring.cloud.ibm.com"
-                                    "monitorApiEndpoint"    "eu-de.monitoring.cloud.ibm.com"
-                                    "secureApiEndpoint"     "eu-de.sysdig-secure.cloud.ibm.com"
-                                    "secureUi"              "eu-de.sysdig-secure.cloud.ibm.com")
-                      "eu-gb" (dict "collectorEndpoint"     "ingest.eu-gb.monitoring.cloud.ibm.com"
-                                    "monitorApiEndpoint"    "eu-gb.monitoring.cloud.ibm.com"
-                                    "secureApiEndpoint"     "eu-gb.sysdig-secure.cloud.ibm.com"
-                                    "secureUi"              "eu-gb.sysdig-secure.cloud.ibm.com")
-                      "jp-osa" (dict "collectorEndpoint"    "ingest.jp-osa.monitoring.cloud.ibm.com"
-                                     "monitorApiEndpoint"   "jp-osa.monitoring.cloud.ibm.com"
-                                     "secureApiEndpoint"    "jp-osa.sysdig-secure.cloud.ibm.com"
-                                     "secureUi"             "jp-osa.sysdig-secure.cloud.ibm.com")
-                      "jp-tok" (dict "collectorEndpoint"    "ingest.jp-tok.monitoring.cloud.ibm.com"
-                                     "monitorApiEndpoint"   "jp-tok.monitoring.cloud.ibm.com"
-                                     "secureApiEndpoint"    "jp-tok.sysdig-secure.cloud.ibm.com"
-                                     "secureUi"             "jp-tok.sysdig-secure.cloud.ibm.com")
-                      "us-east" (dict "collectorEndpoint"   "ingest.us-east.monitoring.cloud.ibm.com"
-                                      "monitorApiEndpoint"  "us-east.monitoring.cloud.ibm.com"
-                                      "secureApiEndpoint"   "us-east.sysdig-secure.cloud.ibm.com"
-                                      "secureUi"            "us-east.sysdig-secure.cloud.ibm.com")
-                      "us-south" (dict "collectorEndpoint"  "ingest.us-south.monitoring.cloud.ibm.com"
-                                       "monitorApiEndpoint" "us-south.monitoring.cloud.ibm.com"
-                                       "secureApiEndpoint"  "us-south.sysdig-secure.cloud.ibm.com"
-                                       "secureUi"           "us-south.sysdig-secure.cloud.ibm.com")
-                      "au-syd-private" (dict "collectorEndpoint"    "ingest.private.au-syd.monitoring.cloud.ibm.com"
-                                             "monitorApiEndpoint"   "private.au-syd.monitoring.cloud.ibm.com"
-                                             "secureApiEndpoint"    "private.au-syd.sysdig-secure.cloud.ibm.com"
-                                             "secureUi"             "private.au-syd.sysdig-secure.cloud.ibm.com")
-                      "br-sao-private" (dict "collectorEndpoint"    "ingest.private.br-sao.monitoring.cloud.ibm.com"
-                                             "monitorApiEndpoint"   "private.br-sao.monitoring.cloud.ibm.com"
-                                             "secureApiEndpoint"    "private.br-sao.sysdig-secure.cloud.ibm.com"
-                                             "secureUi"             "private.br-sao.sysdig-secure.cloud.ibm.com")
-                      "ca-tor-private" (dict "collectorEndpoint"    "ingest.private.ca-tor.monitoring.cloud.ibm.com"
-                                             "monitorApiEndpoint"   "private.ca-tor.monitoring.cloud.ibm.com"
-                                             "secureApiEndpoint"    "private.ca-tor.sysdig-secure.cloud.ibm.com"
-                                             "secureUi"             "private.ca-tor.sysdig-secure.cloud.ibm.com")
-                      "eu-de-private" (dict "collectorEndpoint"     "ingest.private.eu-de.monitoring.cloud.ibm.com"
-                                            "monitorApiEndpoint"    "private.eu-de.monitoring.cloud.ibm.com"
-                                            "secureApiEndpoint"     "private.eu-de.sysdig-secure.cloud.ibm.com"
-                                            "secureUi"              "private.eu-de.sysdig-secure.cloud.ibm.com")
-                      "eu-gb-private" (dict "collectorEndpoint"     "ingest.private.eu-gb.monitoring.cloud.ibm.com"
-                                            "monitorApiEndpoint"    "private.eu-gb.monitoring.cloud.ibm.com"
-                                            "secureApiEndpoint"     "private.eu-gb.sysdig-secure.cloud.ibm.com"
-                                            "secureUi"              "private.eu-gb.sysdig-secure.cloud.ibm.com")
-                      "jp-osa-private" (dict "collectorEndpoint"    "ingest.private.jp-osa.monitoring.cloud.ibm.com"
-                                             "monitorApiEndpoint"   "private.jp-osa.monitoring.cloud.ibm.com"
-                                             "secureApiEndpoint"    "private.jp-osa.sysdig-secure.cloud.ibm.com"
-                                             "secureUi"             "private.jp-osa.sysdig-secure.cloud.ibm.com")
-                      "jp-tok-private" (dict "collectorEndpoint"    "ingest.private.jp-tok.monitoring.cloud.ibm.com"
-                                             "monitorApiEndpoint"   "private.jp-tok.monitoring.cloud.ibm.com"
-                                             "secureApiEndpoint"    "private.jp-tok.sysdig-secure.cloud.ibm.com"
-                                             "secureUi"             "private.jp-tok.sysdig-secure.cloud.ibm.com")
-                      "us-east-private" (dict "collectorEndpoint"   "ingest.private.us-east.monitoring.cloud.ibm.com"
-                                              "monitorApiEndpoint"  "private.us-east.monitoring.cloud.ibm.com"
-                                              "secureApiEndpoint"   "private.us-east.sysdig-secure.cloud.ibm.com"
-                                              "secureUi"            "private.us-east.sysdig-secure.cloud.ibm.com")
-                      "us-south-private" (dict "collectorEndpoint"  "ingest.private.us-south.monitoring.cloud.ibm.com"
-                                               "monitorApiEndpoint" "private.us-south.monitoring.cloud.ibm.com"
-                                               "secureApiEndpoint"  "private.us-south.sysdig-secure.cloud.ibm.com"
-                                               "secureUi"           "private.us-south.sysdig-secure.cloud.ibm.com") }}
+                      "au-syd-monitor"   (dict "collectorEndpoint"  "ingest.au-syd.monitoring.cloud.ibm.com"
+                                               "monitorApiEndpoint" "au-syd.monitoring.cloud.ibm.com"
+                                               "secureApiEndpoint"  "au-syd.sysdig-secure.cloud.ibm.com"
+                                               "secureUi"           "au-syd.sysdig-secure.cloud.ibm.com")
+                      "br-sao-monitor"   (dict "collectorEndpoint"  "ingest.br-sao.monitoring.cloud.ibm.com"
+                                               "monitorApiEndpoint" "br-sao.monitoring.cloud.ibm.com"
+                                               "secureApiEndpoint"  "br-sao.sysdig-secure.cloud.ibm.com"
+                                               "secureUi"           "br-sao.sysdig-secure.cloud.ibm.com")
+                      "ca-tor-monitor"   (dict "collectorEndpoint"  "ingest.ca-tor.monitoring.cloud.ibm.com"
+                                               "monitorApiEndpoint" "ca-tor.monitoring.cloud.ibm.com"
+                                               "secureApiEndpoint"  "ca-tor.sysdig-secure.cloud.ibm.com"
+                                               "secureUi"           "ca-tor.sysdig-secure.cloud.ibm.com")
+                      "eu-de-monitor"    (dict "collectorEndpoint"  "ingest.eu-de.monitoring.cloud.ibm.com"
+                                               "monitorApiEndpoint" "eu-de.monitoring.cloud.ibm.com"
+                                               "secureApiEndpoint"  "eu-de.sysdig-secure.cloud.ibm.com"
+                                               "secureUi"           "eu-de.sysdig-secure.cloud.ibm.com")
+                      "eu-gb-monitor"    (dict "collectorEndpoint"  "ingest.eu-gb.monitoring.cloud.ibm.com"
+                                               "monitorApiEndpoint" "eu-gb.monitoring.cloud.ibm.com"
+                                               "secureApiEndpoint"  "eu-gb.sysdig-secure.cloud.ibm.com"
+                                               "secureUi"           "eu-gb.sysdig-secure.cloud.ibm.com")
+                      "jp-osa-monitor"   (dict "collectorEndpoint"  "ingest.jp-osa.monitoring.cloud.ibm.com"
+                                               "monitorApiEndpoint" "jp-osa.monitoring.cloud.ibm.com"
+                                               "secureApiEndpoint"  "jp-osa.sysdig-secure.cloud.ibm.com"
+                                               "secureUi"           "jp-osa.sysdig-secure.cloud.ibm.com")
+                      "jp-tok-monitor"   (dict "collectorEndpoint"  "ingest.jp-tok.monitoring.cloud.ibm.com"
+                                               "monitorApiEndpoint" "jp-tok.monitoring.cloud.ibm.com"
+                                               "secureApiEndpoint"  "jp-tok.sysdig-secure.cloud.ibm.com"
+                                               "secureUi"           "jp-tok.sysdig-secure.cloud.ibm.com")
+                      "us-east-monitor"  (dict "collectorEndpoint"  "ingest.us-east.monitoring.cloud.ibm.com"
+                                               "monitorApiEndpoint" "us-east.monitoring.cloud.ibm.com"
+                                               "secureApiEndpoint"  "us-east.sysdig-secure.cloud.ibm.com"
+                                               "secureUi"           "us-east.sysdig-secure.cloud.ibm.com")
+                      "us-south-monitor" (dict "collectorEndpoint"  "ingest.us-south.monitoring.cloud.ibm.com"
+                                               "monitorApiEndpoint" "us-south.monitoring.cloud.ibm.com"
+                                               "secureApiEndpoint"  "us-south.sysdig-secure.cloud.ibm.com"
+                                               "secureUi"           "us-south.sysdig-secure.cloud.ibm.com")
+                      "au-syd-private-monitor"   (dict "collectorEndpoint"  "ingest.private.au-syd.monitoring.cloud.ibm.com"
+                                                       "monitorApiEndpoint" "private.au-syd.monitoring.cloud.ibm.com"
+                                                       "secureApiEndpoint"  "private.au-syd.sysdig-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.au-syd.sysdig-secure.cloud.ibm.com")
+                      "br-sao-private-monitor"   (dict "collectorEndpoint"  "ingest.private.br-sao.monitoring.cloud.ibm.com"
+                                                       "monitorApiEndpoint" "private.br-sao.monitoring.cloud.ibm.com"
+                                                       "secureApiEndpoint"  "private.br-sao.sysdig-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.br-sao.sysdig-secure.cloud.ibm.com")
+                      "ca-tor-private-monitor"   (dict "collectorEndpoint"  "ingest.private.ca-tor.monitoring.cloud.ibm.com"
+                                                       "monitorApiEndpoint" "private.ca-tor.monitoring.cloud.ibm.com"
+                                                       "secureApiEndpoint"  "private.ca-tor.sysdig-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.ca-tor.sysdig-secure.cloud.ibm.com")
+                      "eu-de-private-monitor"    (dict "collectorEndpoint"  "ingest.private.eu-de.monitoring.cloud.ibm.com"
+                                                       "monitorApiEndpoint" "private.eu-de.monitoring.cloud.ibm.com"
+                                                       "secureApiEndpoint"  "private.eu-de.sysdig-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.eu-de.sysdig-secure.cloud.ibm.com")
+                      "eu-gb-private-monitor"    (dict "collectorEndpoint"  "ingest.private.eu-gb.monitoring.cloud.ibm.com"
+                                                       "monitorApiEndpoint" "private.eu-gb.monitoring.cloud.ibm.com"
+                                                       "secureApiEndpoint"  "private.eu-gb.sysdig-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.eu-gb.sysdig-secure.cloud.ibm.com")
+                      "jp-osa-private-monitor"   (dict "collectorEndpoint"  "ingest.private.jp-osa.monitoring.cloud.ibm.com"
+                                                       "monitorApiEndpoint" "private.jp-osa.monitoring.cloud.ibm.com"
+                                                       "secureApiEndpoint"  "private.jp-osa.sysdig-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.jp-osa.sysdig-secure.cloud.ibm.com")
+                      "jp-tok-private-monitor"   (dict "collectorEndpoint"  "ingest.private.jp-tok.monitoring.cloud.ibm.com"
+                                                       "monitorApiEndpoint" "private.jp-tok.monitoring.cloud.ibm.com"
+                                                       "secureApiEndpoint"  "private.jp-tok.sysdig-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.jp-tok.sysdig-secure.cloud.ibm.com")
+                      "us-east-private-monitor"  (dict "collectorEndpoint"  "ingest.private.us-east.monitoring.cloud.ibm.com"
+                                                       "monitorApiEndpoint" "private.us-east.monitoring.cloud.ibm.com"
+                                                       "secureApiEndpoint"  "private.us-east.sysdig-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.us-east.sysdig-secure.cloud.ibm.com")
+                      "us-south-private-monitor" (dict "collectorEndpoint"  "ingest.private.us-south.monitoring.cloud.ibm.com"
+                                                       "monitorApiEndpoint" "private.us-south.monitoring.cloud.ibm.com"
+                                                       "secureApiEndpoint"  "private.us-south.sysdig-secure.cloud.ibm.com"
+                                                       "secureUi"           "private.us-south.sysdig-secure.cloud.ibm.com")
+                      "au-syd-secure"   (dict "collectorEndpoint"  "ingest.au-syd.sysdig-secure.cloud.ibm.com"
+                                              "monitorApiEndpoint" "au-syd.monitoring.cloud.ibm.com"
+                                              "secureApiEndpoint"  "au-syd.sysdig-secure.cloud.ibm.com"
+                                              "secureUi"           "au-syd.sysdig-secure.cloud.ibm.com")
+                      "br-sao-secure"   (dict "collectorEndpoint"  "ingest.br-sao.sysdig-secure.cloud.ibm.com"
+                                              "monitorApiEndpoint" "br-sao.monitoring.cloud.ibm.com"
+                                              "secureApiEndpoint"  "br-sao.sysdig-secure.cloud.ibm.com"
+                                              "secureUi"           "br-sao.sysdig-secure.cloud.ibm.com")
+                      "ca-tor-secure"   (dict "collectorEndpoint"  "ingest.ca-tor.sysdig-secure.cloud.ibm.com"
+                                              "monitorApiEndpoint" "ca-tor.monitoring.cloud.ibm.com"
+                                              "secureApiEndpoint"  "ca-tor.sysdig-secure.cloud.ibm.com"
+                                              "secureUi"           "ca-tor.sysdig-secure.cloud.ibm.com")
+                      "eu-de-secure"    (dict "collectorEndpoint"  "ingest.eu-de.sysdig-secure.cloud.ibm.com"
+                                              "monitorApiEndpoint" "eu-de.monitoring.cloud.ibm.com"
+                                              "secureApiEndpoint"  "eu-de.sysdig-secure.cloud.ibm.com"
+                                              "secureUi"           "eu-de.sysdig-secure.cloud.ibm.com")
+                      "eu-gb-secure"    (dict "collectorEndpoint"  "ingest.eu-gb.sysdig-secure.cloud.ibm.com"
+                                              "monitorApiEndpoint" "eu-gb.monitoring.cloud.ibm.com"
+                                              "secureApiEndpoint"  "eu-gb.sysdig-secure.cloud.ibm.com"
+                                              "secureUi"           "eu-gb.sysdig-secure.cloud.ibm.com")
+                      "jp-osa-secure"   (dict "collectorEndpoint"  "ingest.jp-osa.sysdig-secure.cloud.ibm.com"
+                                              "monitorApiEndpoint" "jp-osa.monitoring.cloud.ibm.com"
+                                              "secureApiEndpoint"  "jp-osa.sysdig-secure.cloud.ibm.com"
+                                              "secureUi"           "jp-osa.sysdig-secure.cloud.ibm.com")
+                      "jp-tok-secure"   (dict "collectorEndpoint"  "ingest.jp-tok.sysdig-secure.cloud.ibm.com"
+                                              "monitorApiEndpoint" "jp-tok.monitoring.cloud.ibm.com"
+                                              "secureApiEndpoint"  "jp-tok.sysdig-secure.cloud.ibm.com"
+                                              "secureUi"           "jp-tok.sysdig-secure.cloud.ibm.com")
+                      "us-east-secure"  (dict "collectorEndpoint"  "ingest.us-east.sysdig-secure.cloud.ibm.com"
+                                              "monitorApiEndpoint" "us-east.monitoring.cloud.ibm.com"
+                                              "secureApiEndpoint"  "us-east.sysdig-secure.cloud.ibm.com"
+                                              "secureUi"           "us-east.sysdig-secure.cloud.ibm.com")
+                      "us-south-secure" (dict "collectorEndpoint"  "ingest.us-south.sysdig-secure.cloud.ibm.com"
+                                              "monitorApiEndpoint" "us-south.monitoring.cloud.ibm.com"
+                                              "secureApiEndpoint"  "us-south.sysdig-secure.cloud.ibm.com"
+                                              "secureUi"           "us-south.sysdig-secure.cloud.ibm.com")
+                      "au-syd-private-secure"   (dict "collectorEndpoint"  "ingest.private.au-syd.sysdig-secure.cloud.ibm.com"
+                                                      "monitorApiEndpoint" "private.au-syd.monitoring.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.au-syd.sysdig-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.au-syd.sysdig-secure.cloud.ibm.com")
+                      "br-sao-private-secure"   (dict "collectorEndpoint"  "ingest.private.br-sao.sysdig-secure.cloud.ibm.com"
+                                                      "monitorApiEndpoint" "private.br-sao.monitoring.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.br-sao.sysdig-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.br-sao.sysdig-secure.cloud.ibm.com")
+                      "ca-tor-private-secure"   (dict "collectorEndpoint"  "ingest.private.ca-tor.sysdig-secure.cloud.ibm.com"
+                                                      "monitorApiEndpoint" "private.ca-tor.monitoring.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.ca-tor.sysdig-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.ca-tor.sysdig-secure.cloud.ibm.com")
+                      "eu-de-private-secure"    (dict "collectorEndpoint"  "ingest.private.eu-de.sysdig-secure.cloud.ibm.com"
+                                                      "monitorApiEndpoint" "private.eu-de.monitoring.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.eu-de.sysdig-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.eu-de.sysdig-secure.cloud.ibm.com")
+                      "eu-gb-private-secure"    (dict "collectorEndpoint"  "ingest.private.eu-gb.sysdig-secure.cloud.ibm.com"
+                                                      "monitorApiEndpoint" "private.eu-gb.monitoring.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.eu-gb.sysdig-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.eu-gb.sysdig-secure.cloud.ibm.com")
+                      "jp-osa-private-secure"   (dict "collectorEndpoint"  "ingest.private.jp-osa.sysdig-secure.cloud.ibm.com"
+                                                      "monitorApiEndpoint" "private.jp-osa.monitoring.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.jp-osa.sysdig-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.jp-osa.sysdig-secure.cloud.ibm.com")
+                      "jp-tok-private-secure"   (dict "collectorEndpoint"  "ingest.private.jp-tok.sysdig-secure.cloud.ibm.com"
+                                                      "monitorApiEndpoint" "private.jp-tok.monitoring.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.jp-tok.sysdig-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.jp-tok.sysdig-secure.cloud.ibm.com")
+                      "us-east-private-secure"  (dict "collectorEndpoint"  "ingest.private.us-east.sysdig-secure.cloud.ibm.com"
+                                                      "monitorApiEndpoint" "private.us-east.monitoring.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.us-east.sysdig-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.us-east.sysdig-secure.cloud.ibm.com")
+                      "us-south-private-secure" (dict "collectorEndpoint"  "ingest.private.us-south.sysdig-secure.cloud.ibm.com"
+                                                      "monitorApiEndpoint" "private.us-south.monitoring.cloud.ibm.com"
+                                                      "secureApiEndpoint"  "private.us-south.sysdig-secure.cloud.ibm.com"
+                                                      "secureUi"           "private.us-south.sysdig-secure.cloud.ibm.com") }}
+
   {{- toYaml $regions }}
 {{- end }}
 

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.2.3
+version: 0.3.0
 appVersion: 1.25.0
 
 keywords:

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.2.2
+version: 0.2.3
 appVersion: 1.25.0
 
 keywords:

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -20,4 +20,8 @@ sources:
 maintainers:
   - name: chen-shmilovich-sysdig
     email: chen.shmilovich@sysdig.com
-dependencies: []
+dependencies:
+  - name: common
+    # repository: https://charts.sysdig.com
+    repository: file://../common
+    version: ~1.0.0

--- a/charts/kspm-collector/templates/_helpers.tpl
+++ b/charts/kspm-collector/templates/_helpers.tpl
@@ -111,18 +111,8 @@ Determine collector endpoint based on provided region or .Values.apiEndpoint
 {{- define "kspmCollector.apiEndpoint" -}}
     {{- if .Values.apiEndpoint -}}
         {{- .Values.apiEndpoint -}}
-    {{- else if (eq .Values.global.sysdig.region "us1") -}}
-        {{- "secure.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us2") -}}
-        {{- "us2.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us3") -}}
-        {{- "app.us3.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us4") -}}
-        {{- "app.us4.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "eu1") -}}
-        {{- "eu1.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "au1") -}}
-        {{- "app.au1.sysdig.com" -}}
+    {{- else if hasKey ((include "sysdig.regions" .) | fromYaml) .Values.global.sysdig.region }}
+        {{- include "sysdig.secureApiEndpoint" . }}
     {{- end -}}
 {{- end -}}
 

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.9.2
+version: 1.9.3
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -30,4 +30,8 @@ maintainers:
     email: carlos.arilla@sysdig.com
   - name: yashgiri
     email: yashgiri.goswami@sysdig.com
-dependencies: []
+dependencies:
+  - name: common
+    # repository: https://charts.sysdig.com
+    repository: file://../common
+    version: ~1.0.0

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.9.3
+version: 1.10.0
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/_helpers.tpl
+++ b/charts/node-analyzer/templates/_helpers.tpl
@@ -188,18 +188,8 @@ Determine collector endpoint based on provided region or .Values.nodeAnalyzer.ap
 {{- define "nodeAnalyzer.apiEndpoint" -}}
     {{- if (or .Values.nodeAnalyzer.apiEndpoint (eq .Values.global.sysdig.region "custom"))  -}}
         {{- required "A valid apiEndpoint is required" .Values.nodeAnalyzer.apiEndpoint -}}
-    {{- else if (eq .Values.global.sysdig.region "us1") -}}
-        {{- "secure.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us2") -}}
-        {{- "us2.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us3") -}}
-        {{- "app.us3.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us4") -}}
-        {{- "app.us4.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "eu1") -}}
-        {{- "eu1.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "au1") -}}
-        {{- "app.au1.sysdig.com" -}}
+    {{- else if hasKey ((include "sysdig.regions" .) | fromYaml) .Values.global.sysdig.region }}
+        {{- include "sysdig.secureApiEndpoint" . }}
     {{- else -}}
         {{- fail (printf "global.sysdig.region=%s provided is not recognized." .Values.global.sysdig.region ) -}}
     {{- end -}}

--- a/charts/node-analyzer/tests/collector_endpoint_region_test.yaml
+++ b/charts/node-analyzer/tests/collector_endpoint_region_test.yaml
@@ -70,11 +70,11 @@ tests:
           path: data.collector_endpoint
           value: https://app.au1.sysdig.com
 
-  - it: Checking region 'au-syd'
+  - it: Checking region 'au-syd-monitor'
     set:
       global:
         sysdig:
-          region: au-syd
+          region: au-syd-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -82,11 +82,11 @@ tests:
           path: data.collector_endpoint
           value: https://au-syd.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'br-sao'
+  - it: Checking region 'br-sao-monitor'
     set:
       global:
         sysdig:
-          region: br-sao
+          region: br-sao-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -94,11 +94,11 @@ tests:
           path: data.collector_endpoint
           value: https://br-sao.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'ca-tor'
+  - it: Checking region 'ca-tor-monitor'
     set:
       global:
         sysdig:
-          region: ca-tor
+          region: ca-tor-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -106,11 +106,11 @@ tests:
           path: data.collector_endpoint
           value: https://ca-tor.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'eu-de'
+  - it: Checking region 'eu-de-monitor'
     set:
       global:
         sysdig:
-          region: eu-de
+          region: eu-de-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -118,11 +118,11 @@ tests:
           path: data.collector_endpoint
           value: https://eu-de.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'eu-gb'
+  - it: Checking region 'eu-gb-monitor'
     set:
       global:
         sysdig:
-          region: eu-gb
+          region: eu-gb-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -130,11 +130,11 @@ tests:
           path: data.collector_endpoint
           value: https://eu-gb.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'jp-osa'
+  - it: Checking region 'jp-osa-monitor'
     set:
       global:
         sysdig:
-          region: jp-osa
+          region: jp-osa-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -142,11 +142,11 @@ tests:
           path: data.collector_endpoint
           value: https://jp-osa.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'jp-tok'
+  - it: Checking region 'jp-tok-monitor'
     set:
       global:
         sysdig:
-          region: jp-tok
+          region: jp-tok-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -154,11 +154,11 @@ tests:
           path: data.collector_endpoint
           value: https://jp-tok.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'us-east'
+  - it: Checking region 'us-east-monitor'
     set:
       global:
         sysdig:
-          region: us-east
+          region: us-east-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -166,11 +166,11 @@ tests:
           path: data.collector_endpoint
           value: https://us-east.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'us-south'
+  - it: Checking region 'us-south-monitor'
     set:
       global:
         sysdig:
-          region: us-south
+          region: us-south-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -178,11 +178,11 @@ tests:
           path: data.collector_endpoint
           value: https://us-south.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'au-syd-private'
+  - it: Checking region 'au-syd-private-monitor'
     set:
       global:
         sysdig:
-          region: au-syd-private
+          region: au-syd-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -190,11 +190,11 @@ tests:
           path: data.collector_endpoint
           value: https://private.au-syd.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'br-sao-private'
+  - it: Checking region 'br-sao-private-monitor'
     set:
       global:
         sysdig:
-          region: br-sao-private
+          region: br-sao-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -202,11 +202,11 @@ tests:
           path: data.collector_endpoint
           value: https://private.br-sao.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'ca-tor-private'
+  - it: Checking region 'ca-tor-private-monitor'
     set:
       global:
         sysdig:
-          region: ca-tor-private
+          region: ca-tor-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -214,11 +214,11 @@ tests:
           path: data.collector_endpoint
           value: https://private.ca-tor.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'eu-de-private'
+  - it: Checking region 'eu-de-private-monitor'
     set:
       global:
         sysdig:
-          region: eu-de-private
+          region: eu-de-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -226,11 +226,11 @@ tests:
           path: data.collector_endpoint
           value: https://private.eu-de.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'eu-gb-private'
+  - it: Checking region 'eu-gb-private-monitor'
     set:
       global:
         sysdig:
-          region: eu-gb-private
+          region: eu-gb-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -238,11 +238,11 @@ tests:
           path: data.collector_endpoint
           value: https://private.eu-gb.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'jp-osa-private'
+  - it: Checking region 'jp-osa-private-monitor'
     set:
       global:
         sysdig:
-          region: jp-osa-private
+          region: jp-osa-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -250,11 +250,11 @@ tests:
           path: data.collector_endpoint
           value: https://private.jp-osa.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'jp-tok-private'
+  - it: Checking region 'jp-tok-private-monitor'
     set:
       global:
         sysdig:
-          region: jp-tok-private
+          region: jp-tok-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -262,11 +262,11 @@ tests:
           path: data.collector_endpoint
           value: https://private.jp-tok.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'us-east-private'
+  - it: Checking region 'us-east-private-monitor'
     set:
       global:
         sysdig:
-          region: us-east-private
+          region: us-east-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -274,11 +274,227 @@ tests:
           path: data.collector_endpoint
           value: https://private.us-east.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'us-south-private'
+  - it: Checking region 'us-south-private-monitor'
     set:
       global:
         sysdig:
-          region: us-south-private
+          region: us-south-private-monitor
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.us-south.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'au-syd-secure'
+    set:
+      global:
+        sysdig:
+          region: au-syd-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://au-syd.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao-secure'
+    set:
+      global:
+        sysdig:
+          region: br-sao-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://br-sao.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-secure'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://ca-tor.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-de-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://eu-de.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://eu-gb.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://jp-osa.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://jp-tok.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east-secure'
+    set:
+      global:
+        sysdig:
+          region: us-east-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://us-east.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south-secure'
+    set:
+      global:
+        sysdig:
+          region: us-south-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://us-south.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'au-syd-private-secure'
+    set:
+      global:
+        sysdig:
+          region: au-syd-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.au-syd.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao-private-secure'
+    set:
+      global:
+        sysdig:
+          region: br-sao-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.br-sao.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-private-secure'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.ca-tor.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de-private-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-de-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.eu-de.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-private-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.eu-gb.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-private-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.jp-osa.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-private-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.jp-tok.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east-private-secure'
+    set:
+      global:
+        sysdig:
+          region: us-east-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.us-east.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south-private-secure'
+    set:
+      global:
+        sysdig:
+          region: us-south-private-secure
     asserts:
       - isKind:
           of: ConfigMap

--- a/charts/node-analyzer/tests/collector_endpoint_region_test.yaml
+++ b/charts/node-analyzer/tests/collector_endpoint_region_test.yaml
@@ -80,7 +80,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://au-syd.sysdig-secure.cloud.ibm.com
+          value: https://au-syd.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'br-sao-monitor'
     set:
@@ -92,7 +92,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://br-sao.sysdig-secure.cloud.ibm.com
+          value: https://br-sao.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'ca-tor-monitor'
     set:
@@ -104,7 +104,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://ca-tor.sysdig-secure.cloud.ibm.com
+          value: https://ca-tor.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-de-monitor'
     set:
@@ -116,7 +116,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://eu-de.sysdig-secure.cloud.ibm.com
+          value: https://eu-de.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-gb-monitor'
     set:
@@ -128,7 +128,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://eu-gb.sysdig-secure.cloud.ibm.com
+          value: https://eu-gb.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-osa-monitor'
     set:
@@ -140,7 +140,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://jp-osa.sysdig-secure.cloud.ibm.com
+          value: https://jp-osa.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-tok-monitor'
     set:
@@ -152,7 +152,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://jp-tok.sysdig-secure.cloud.ibm.com
+          value: https://jp-tok.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-east-monitor'
     set:
@@ -164,7 +164,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://us-east.sysdig-secure.cloud.ibm.com
+          value: https://us-east.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-south-monitor'
     set:
@@ -176,7 +176,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://us-south.sysdig-secure.cloud.ibm.com
+          value: https://us-south.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'au-syd-private-monitor'
     set:
@@ -188,7 +188,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.au-syd.sysdig-secure.cloud.ibm.com
+          value: https://private.au-syd.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'br-sao-private-monitor'
     set:
@@ -200,7 +200,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.br-sao.sysdig-secure.cloud.ibm.com
+          value: https://private.br-sao.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'ca-tor-private-monitor'
     set:
@@ -212,7 +212,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.ca-tor.sysdig-secure.cloud.ibm.com
+          value: https://private.ca-tor.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-de-private-monitor'
     set:
@@ -224,7 +224,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.eu-de.sysdig-secure.cloud.ibm.com
+          value: https://private.eu-de.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-gb-private-monitor'
     set:
@@ -236,7 +236,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.eu-gb.sysdig-secure.cloud.ibm.com
+          value: https://private.eu-gb.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-osa-private-monitor'
     set:
@@ -248,7 +248,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.jp-osa.sysdig-secure.cloud.ibm.com
+          value: https://private.jp-osa.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-tok-private-monitor'
     set:
@@ -260,7 +260,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.jp-tok.sysdig-secure.cloud.ibm.com
+          value: https://private.jp-tok.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-east-private-monitor'
     set:
@@ -272,7 +272,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.us-east.sysdig-secure.cloud.ibm.com
+          value: https://private.us-east.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-south-private-monitor'
     set:
@@ -284,7 +284,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.us-south.sysdig-secure.cloud.ibm.com
+          value: https://private.us-south.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'au-syd-secure'
     set:
@@ -296,7 +296,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://au-syd.sysdig-secure.cloud.ibm.com
+          value: https://au-syd.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'br-sao-secure'
     set:
@@ -308,7 +308,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://br-sao.sysdig-secure.cloud.ibm.com
+          value: https://br-sao.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'ca-tor-secure'
     set:
@@ -320,7 +320,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://ca-tor.sysdig-secure.cloud.ibm.com
+          value: https://ca-tor.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-de-secure'
     set:
@@ -332,7 +332,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://eu-de.sysdig-secure.cloud.ibm.com
+          value: https://eu-de.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-gb-secure'
     set:
@@ -344,7 +344,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://eu-gb.sysdig-secure.cloud.ibm.com
+          value: https://eu-gb.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-osa-secure'
     set:
@@ -356,7 +356,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://jp-osa.sysdig-secure.cloud.ibm.com
+          value: https://jp-osa.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-tok-secure'
     set:
@@ -368,7 +368,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://jp-tok.sysdig-secure.cloud.ibm.com
+          value: https://jp-tok.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-east-secure'
     set:
@@ -380,7 +380,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://us-east.sysdig-secure.cloud.ibm.com
+          value: https://us-east.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-south-secure'
     set:
@@ -392,7 +392,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://us-south.sysdig-secure.cloud.ibm.com
+          value: https://us-south.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'au-syd-private-secure'
     set:
@@ -404,7 +404,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.au-syd.sysdig-secure.cloud.ibm.com
+          value: https://private.au-syd.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'br-sao-private-secure'
     set:
@@ -416,7 +416,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.br-sao.sysdig-secure.cloud.ibm.com
+          value: https://private.br-sao.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'ca-tor-private-secure'
     set:
@@ -428,7 +428,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.ca-tor.sysdig-secure.cloud.ibm.com
+          value: https://private.ca-tor.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-de-private-secure'
     set:
@@ -440,7 +440,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.eu-de.sysdig-secure.cloud.ibm.com
+          value: https://private.eu-de.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-gb-private-secure'
     set:
@@ -452,7 +452,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.eu-gb.sysdig-secure.cloud.ibm.com
+          value: https://private.eu-gb.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-osa-private-secure'
     set:
@@ -464,7 +464,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.jp-osa.sysdig-secure.cloud.ibm.com
+          value: https://private.jp-osa.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-tok-private-secure'
     set:
@@ -476,7 +476,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.jp-tok.sysdig-secure.cloud.ibm.com
+          value: https://private.jp-tok.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-east-private-secure'
     set:
@@ -488,7 +488,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.us-east.sysdig-secure.cloud.ibm.com
+          value: https://private.us-east.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-south-private-secure'
     set:
@@ -500,7 +500,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.collector_endpoint
-          value: https://private.us-south.sysdig-secure.cloud.ibm.com
+          value: https://private.us-south.security-compliance-secure.cloud.ibm.com
 
   - it: Checking wrong region input
     set:

--- a/charts/node-analyzer/tests/collector_endpoint_region_test.yaml
+++ b/charts/node-analyzer/tests/collector_endpoint_region_test.yaml
@@ -70,6 +70,222 @@ tests:
           path: data.collector_endpoint
           value: https://app.au1.sysdig.com
 
+  - it: Checking region 'au-syd'
+    set:
+      global:
+        sysdig:
+          region: au-syd
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://au-syd.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao'
+    set:
+      global:
+        sysdig:
+          region: br-sao
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://br-sao.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor'
+    set:
+      global:
+        sysdig:
+          region: ca-tor
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://ca-tor.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de'
+    set:
+      global:
+        sysdig:
+          region: eu-de
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://eu-de.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb'
+    set:
+      global:
+        sysdig:
+          region: eu-gb
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://eu-gb.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa'
+    set:
+      global:
+        sysdig:
+          region: jp-osa
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://jp-osa.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok'
+    set:
+      global:
+        sysdig:
+          region: jp-tok
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://jp-tok.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east'
+    set:
+      global:
+        sysdig:
+          region: us-east
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://us-east.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south'
+    set:
+      global:
+        sysdig:
+          region: us-south
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://us-south.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'au-syd-private'
+    set:
+      global:
+        sysdig:
+          region: au-syd-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.au-syd.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao-private'
+    set:
+      global:
+        sysdig:
+          region: br-sao-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.br-sao.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-private'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.ca-tor.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de-private'
+    set:
+      global:
+        sysdig:
+          region: eu-de-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.eu-de.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-private'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.eu-gb.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-private'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.jp-osa.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-private'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.jp-tok.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east-private'
+    set:
+      global:
+        sysdig:
+          region: us-east-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.us-east.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south-private'
+    set:
+      global:
+        sysdig:
+          region: us-south-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.collector_endpoint
+          value: https://private.us-south.sysdig-secure.cloud.ibm.com
+
   - it: Checking wrong region input
     set:
       global:

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -39,4 +39,8 @@ maintainers:
     email: adam.roberts@sysdig.com
   - name: dark-vex
     email: daniele.delorenzi@sysdig.com
-dependencies: []
+dependencies:
+  - name: common
+    # repository: https://charts.sysdig.com
+    repository: file://../common
+    version: ~1.0.0

--- a/charts/rapid-response/templates/_helpers.tpl
+++ b/charts/rapid-response/templates/_helpers.tpl
@@ -165,18 +165,8 @@ Determine collector endpoint based on provided region or .Values.rapidResponse.a
 {{- define "rapidResponse.apiEndpoint" -}}
     {{- if .Values.rapidResponse.apiEndpoint -}}
         {{- .Values.rapidResponse.apiEndpoint -}}
-    {{- else if (eq .Values.global.sysdig.region "us1") -}}
-        {{- "secure.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us2") -}}
-        {{- "us2.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us3") -}}
-        {{- "app.us3.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us4") -}}
-        {{- "app.us4.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "eu1") -}}
-        {{- "eu1.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "au1") -}}
-        {{- "app.au1.sysdig.com" -}}
+    {{- else if hasKey ((include "sysdig.regions" .) | fromYaml) .Values.global.sysdig.region }}
+        {{- include "sysdig.secureApiEndpoint" . }}
     {{- else -}}
         {{- fail (printf "global.sysdig.region=%s provided is not recognized." .Values.global.sysdig.region ) -}}
     {{- end -}}

--- a/charts/rapid-response/tests/api_endpoint_region_test.yaml
+++ b/charts/rapid-response/tests/api_endpoint_region_test.yaml
@@ -70,11 +70,11 @@ tests:
           path: data.api_endpoint
           value: https://app.au1.sysdig.com
 
-  - it: Checking region 'au-syd'
+  - it: Checking region 'au-syd-monitor'
     set:
       global:
         sysdig:
-          region: au-syd
+          region: au-syd-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -82,11 +82,11 @@ tests:
           path: data.api_endpoint
           value: https://au-syd.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'br-sao'
+  - it: Checking region 'br-sao-monitor'
     set:
       global:
         sysdig:
-          region: br-sao
+          region: br-sao-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -94,11 +94,11 @@ tests:
           path: data.api_endpoint
           value: https://br-sao.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'ca-tor'
+  - it: Checking region 'ca-tor-monitor'
     set:
       global:
         sysdig:
-          region: ca-tor
+          region: ca-tor-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -106,11 +106,11 @@ tests:
           path: data.api_endpoint
           value: https://ca-tor.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'eu-de'
+  - it: Checking region 'eu-de-monitor'
     set:
       global:
         sysdig:
-          region: eu-de
+          region: eu-de-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -118,11 +118,11 @@ tests:
           path: data.api_endpoint
           value: https://eu-de.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'eu-gb'
+  - it: Checking region 'eu-gb-monitor'
     set:
       global:
         sysdig:
-          region: eu-gb
+          region: eu-gb-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -130,11 +130,11 @@ tests:
           path: data.api_endpoint
           value: https://eu-gb.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'jp-osa'
+  - it: Checking region 'jp-osa-monitor'
     set:
       global:
         sysdig:
-          region: jp-osa
+          region: jp-osa-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -142,11 +142,11 @@ tests:
           path: data.api_endpoint
           value: https://jp-osa.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'jp-tok'
+  - it: Checking region 'jp-tok-monitor'
     set:
       global:
         sysdig:
-          region: jp-tok
+          region: jp-tok-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -154,11 +154,11 @@ tests:
           path: data.api_endpoint
           value: https://jp-tok.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'us-east'
+  - it: Checking region 'us-east-monitor'
     set:
       global:
         sysdig:
-          region: us-east
+          region: us-east-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -166,11 +166,11 @@ tests:
           path: data.api_endpoint
           value: https://us-east.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'us-south'
+  - it: Checking region 'us-south-monitor'
     set:
       global:
         sysdig:
-          region: us-south
+          region: us-south-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -178,11 +178,11 @@ tests:
           path: data.api_endpoint
           value: https://us-south.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'au-syd-private'
+  - it: Checking region 'au-syd-private-monitor'
     set:
       global:
         sysdig:
-          region: au-syd-private
+          region: au-syd-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -190,11 +190,11 @@ tests:
           path: data.api_endpoint
           value: https://private.au-syd.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'br-sao-private'
+  - it: Checking region 'br-sao-private-monitor'
     set:
       global:
         sysdig:
-          region: br-sao-private
+          region: br-sao-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -202,11 +202,11 @@ tests:
           path: data.api_endpoint
           value: https://private.br-sao.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'ca-tor-private'
+  - it: Checking region 'ca-tor-private-monitor'
     set:
       global:
         sysdig:
-          region: ca-tor-private
+          region: ca-tor-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -214,11 +214,11 @@ tests:
           path: data.api_endpoint
           value: https://private.ca-tor.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'eu-de-private'
+  - it: Checking region 'eu-de-private-monitor'
     set:
       global:
         sysdig:
-          region: eu-de-private
+          region: eu-de-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -226,11 +226,11 @@ tests:
           path: data.api_endpoint
           value: https://private.eu-de.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'eu-gb-private'
+  - it: Checking region 'eu-gb-private-monitor'
     set:
       global:
         sysdig:
-          region: eu-gb-private
+          region: eu-gb-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -238,11 +238,11 @@ tests:
           path: data.api_endpoint
           value: https://private.eu-gb.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'jp-osa-private'
+  - it: Checking region 'jp-osa-private-monitor'
     set:
       global:
         sysdig:
-          region: jp-osa-private
+          region: jp-osa-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -250,11 +250,11 @@ tests:
           path: data.api_endpoint
           value: https://private.jp-osa.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'jp-tok-private'
+  - it: Checking region 'jp-tok-private-monitor'
     set:
       global:
         sysdig:
-          region: jp-tok-private
+          region: jp-tok-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -262,11 +262,11 @@ tests:
           path: data.api_endpoint
           value: https://private.jp-tok.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'us-east-private'
+  - it: Checking region 'us-east-private-monitor'
     set:
       global:
         sysdig:
-          region: us-east-private
+          region: us-east-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -274,11 +274,11 @@ tests:
           path: data.api_endpoint
           value: https://private.us-east.sysdig-secure.cloud.ibm.com
 
-  - it: Checking region 'us-south-private'
+  - it: Checking region 'us-south-private-monitor'
     set:
       global:
         sysdig:
-          region: us-south-private
+          region: us-south-private-monitor
     asserts:
       - isKind:
           of: ConfigMap
@@ -286,6 +286,221 @@ tests:
           path: data.api_endpoint
           value: https://private.us-south.sysdig-secure.cloud.ibm.com
 
+  - it: Checking region 'au-syd-secure'
+    set:
+      global:
+        sysdig:
+          region: au-syd-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://au-syd.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao-secure'
+    set:
+      global:
+        sysdig:
+          region: br-sao-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://br-sao.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-secure'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://ca-tor.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-de-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://eu-de.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://eu-gb.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://jp-osa.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://jp-tok.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east-secure'
+    set:
+      global:
+        sysdig:
+          region: us-east-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://us-east.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south-secure'
+    set:
+      global:
+        sysdig:
+          region: us-south-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://us-south.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'au-syd-private-secure'
+    set:
+      global:
+        sysdig:
+          region: au-syd-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.au-syd.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao-private-secure'
+    set:
+      global:
+        sysdig:
+          region: br-sao-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.br-sao.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-private-secure'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.ca-tor.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de-private-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-de-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.eu-de.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-private-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.eu-gb.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-private-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.jp-osa.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-private-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.jp-tok.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east-private-secure'
+    set:
+      global:
+        sysdig:
+          region: us-east-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.us-east.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south-private-secure'
+    set:
+      global:
+        sysdig:
+          region: us-south-private-secure
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.us-south.sysdig-secure.cloud.ibm.com
   - it: Checking wrong region input
     set:
       global:

--- a/charts/rapid-response/tests/api_endpoint_region_test.yaml
+++ b/charts/rapid-response/tests/api_endpoint_region_test.yaml
@@ -80,7 +80,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://au-syd.sysdig-secure.cloud.ibm.com
+          value: https://au-syd.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'br-sao-monitor'
     set:
@@ -92,7 +92,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://br-sao.sysdig-secure.cloud.ibm.com
+          value: https://br-sao.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'ca-tor-monitor'
     set:
@@ -104,7 +104,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://ca-tor.sysdig-secure.cloud.ibm.com
+          value: https://ca-tor.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-de-monitor'
     set:
@@ -116,7 +116,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://eu-de.sysdig-secure.cloud.ibm.com
+          value: https://eu-de.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-gb-monitor'
     set:
@@ -128,7 +128,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://eu-gb.sysdig-secure.cloud.ibm.com
+          value: https://eu-gb.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-osa-monitor'
     set:
@@ -140,7 +140,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://jp-osa.sysdig-secure.cloud.ibm.com
+          value: https://jp-osa.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-tok-monitor'
     set:
@@ -152,7 +152,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://jp-tok.sysdig-secure.cloud.ibm.com
+          value: https://jp-tok.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-east-monitor'
     set:
@@ -164,7 +164,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://us-east.sysdig-secure.cloud.ibm.com
+          value: https://us-east.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-south-monitor'
     set:
@@ -176,7 +176,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://us-south.sysdig-secure.cloud.ibm.com
+          value: https://us-south.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'au-syd-private-monitor'
     set:
@@ -188,7 +188,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.au-syd.sysdig-secure.cloud.ibm.com
+          value: https://private.au-syd.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'br-sao-private-monitor'
     set:
@@ -200,7 +200,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.br-sao.sysdig-secure.cloud.ibm.com
+          value: https://private.br-sao.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'ca-tor-private-monitor'
     set:
@@ -212,7 +212,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.ca-tor.sysdig-secure.cloud.ibm.com
+          value: https://private.ca-tor.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-de-private-monitor'
     set:
@@ -224,7 +224,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.eu-de.sysdig-secure.cloud.ibm.com
+          value: https://private.eu-de.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-gb-private-monitor'
     set:
@@ -236,7 +236,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.eu-gb.sysdig-secure.cloud.ibm.com
+          value: https://private.eu-gb.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-osa-private-monitor'
     set:
@@ -248,7 +248,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.jp-osa.sysdig-secure.cloud.ibm.com
+          value: https://private.jp-osa.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-tok-private-monitor'
     set:
@@ -260,7 +260,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.jp-tok.sysdig-secure.cloud.ibm.com
+          value: https://private.jp-tok.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-east-private-monitor'
     set:
@@ -272,7 +272,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.us-east.sysdig-secure.cloud.ibm.com
+          value: https://private.us-east.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-south-private-monitor'
     set:
@@ -284,7 +284,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.us-south.sysdig-secure.cloud.ibm.com
+          value: https://private.us-south.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'au-syd-secure'
     set:
@@ -296,7 +296,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://au-syd.sysdig-secure.cloud.ibm.com
+          value: https://au-syd.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'br-sao-secure'
     set:
@@ -308,7 +308,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://br-sao.sysdig-secure.cloud.ibm.com
+          value: https://br-sao.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'ca-tor-secure'
     set:
@@ -320,7 +320,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://ca-tor.sysdig-secure.cloud.ibm.com
+          value: https://ca-tor.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-de-secure'
     set:
@@ -332,7 +332,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://eu-de.sysdig-secure.cloud.ibm.com
+          value: https://eu-de.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-gb-secure'
     set:
@@ -344,7 +344,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://eu-gb.sysdig-secure.cloud.ibm.com
+          value: https://eu-gb.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-osa-secure'
     set:
@@ -356,7 +356,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://jp-osa.sysdig-secure.cloud.ibm.com
+          value: https://jp-osa.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-tok-secure'
     set:
@@ -368,7 +368,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://jp-tok.sysdig-secure.cloud.ibm.com
+          value: https://jp-tok.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-east-secure'
     set:
@@ -380,7 +380,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://us-east.sysdig-secure.cloud.ibm.com
+          value: https://us-east.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-south-secure'
     set:
@@ -392,7 +392,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://us-south.sysdig-secure.cloud.ibm.com
+          value: https://us-south.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'au-syd-private-secure'
     set:
@@ -404,7 +404,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.au-syd.sysdig-secure.cloud.ibm.com
+          value: https://private.au-syd.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'br-sao-private-secure'
     set:
@@ -416,7 +416,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.br-sao.sysdig-secure.cloud.ibm.com
+          value: https://private.br-sao.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'ca-tor-private-secure'
     set:
@@ -428,7 +428,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.ca-tor.sysdig-secure.cloud.ibm.com
+          value: https://private.ca-tor.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-de-private-secure'
     set:
@@ -440,7 +440,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.eu-de.sysdig-secure.cloud.ibm.com
+          value: https://private.eu-de.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'eu-gb-private-secure'
     set:
@@ -452,7 +452,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.eu-gb.sysdig-secure.cloud.ibm.com
+          value: https://private.eu-gb.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-osa-private-secure'
     set:
@@ -464,7 +464,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.jp-osa.sysdig-secure.cloud.ibm.com
+          value: https://private.jp-osa.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'jp-tok-private-secure'
     set:
@@ -476,7 +476,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.jp-tok.sysdig-secure.cloud.ibm.com
+          value: https://private.jp-tok.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-east-private-secure'
     set:
@@ -488,7 +488,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.us-east.sysdig-secure.cloud.ibm.com
+          value: https://private.us-east.security-compliance-secure.cloud.ibm.com
 
   - it: Checking region 'us-south-private-secure'
     set:
@@ -500,7 +500,7 @@ tests:
           of: ConfigMap
       - equal:
           path: data.api_endpoint
-          value: https://private.us-south.sysdig-secure.cloud.ibm.com
+          value: https://private.us-south.security-compliance-secure.cloud.ibm.com
   - it: Checking wrong region input
     set:
       global:

--- a/charts/rapid-response/tests/api_endpoint_region_test.yaml
+++ b/charts/rapid-response/tests/api_endpoint_region_test.yaml
@@ -70,6 +70,222 @@ tests:
           path: data.api_endpoint
           value: https://app.au1.sysdig.com
 
+  - it: Checking region 'au-syd'
+    set:
+      global:
+        sysdig:
+          region: au-syd
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://au-syd.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao'
+    set:
+      global:
+        sysdig:
+          region: br-sao
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://br-sao.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor'
+    set:
+      global:
+        sysdig:
+          region: ca-tor
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://ca-tor.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de'
+    set:
+      global:
+        sysdig:
+          region: eu-de
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://eu-de.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb'
+    set:
+      global:
+        sysdig:
+          region: eu-gb
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://eu-gb.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa'
+    set:
+      global:
+        sysdig:
+          region: jp-osa
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://jp-osa.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok'
+    set:
+      global:
+        sysdig:
+          region: jp-tok
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://jp-tok.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east'
+    set:
+      global:
+        sysdig:
+          region: us-east
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://us-east.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south'
+    set:
+      global:
+        sysdig:
+          region: us-south
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://us-south.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'au-syd-private'
+    set:
+      global:
+        sysdig:
+          region: au-syd-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.au-syd.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'br-sao-private'
+    set:
+      global:
+        sysdig:
+          region: br-sao-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.br-sao.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'ca-tor-private'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.ca-tor.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-de-private'
+    set:
+      global:
+        sysdig:
+          region: eu-de-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.eu-de.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'eu-gb-private'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.eu-gb.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-osa-private'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.jp-osa.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'jp-tok-private'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.jp-tok.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-east-private'
+    set:
+      global:
+        sysdig:
+          region: us-east-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.us-east.sysdig-secure.cloud.ibm.com
+
+  - it: Checking region 'us-south-private'
+    set:
+      global:
+        sysdig:
+          region: us-south-private
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.api_endpoint
+          value: https://private.us-south.sysdig-secure.cloud.ibm.com
+
   - it: Checking wrong region input
     set:
       global:

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -14,13 +14,13 @@ dependencies:
   - name: admission-controller
     # repository: https://charts.sysdig.com
     repository: file://../admission-controller
-    version: ~0.10.0
+    version: ~0.10.1
     alias: admissionController
     condition: admissionController.enabled
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.9.2
+    version: ~1.9.3
     alias: agent
     condition: agent.enabled
   - name: common
@@ -30,7 +30,7 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.9.2
+    version: ~1.9.3
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: cluster-scanner
@@ -42,12 +42,12 @@ dependencies:
   - name: kspm-collector
     # repository: https://charts.sysdig.com
     repository: file://../kspm-collector
-    version: ~0.2.2
+    version: ~0.2.3
     alias: kspmCollector
     condition: global.kspm.deploy
   - name: rapid-response
     # repository: https://charts.sysdig.com
     repository: file://../rapid-response
-    version: ~0.5.1
+    version: ~0.5.2
     alias: rapidResponse
     condition: rapidResponse.enabled

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
   - name: cluster-scanner
     # repository: https://charts.sysdig.com
     repository: file://../cluster-scanner
-    version: ~0.1.3
+    version: ~0.2.0
     alias: clusterScanner
     condition: clusterScanner.enabled
   - name: kspm-collector

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -14,13 +14,13 @@ dependencies:
   - name: admission-controller
     # repository: https://charts.sysdig.com
     repository: file://../admission-controller
-    version: ~0.10.1
+    version: ~0.11.0
     alias: admissionController
     condition: admissionController.enabled
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.9.3
+    version: ~1.10.0
     alias: agent
     condition: agent.enabled
   - name: common
@@ -30,24 +30,24 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.9.3
+    version: ~1.10.0
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: cluster-scanner
     # repository: https://charts.sysdig.com
     repository: file://../cluster-scanner
-    version: ~0.2.0
+    version: ~0.3.0
     alias: clusterScanner
     condition: clusterScanner.enabled
   - name: kspm-collector
     # repository: https://charts.sysdig.com
     repository: file://../kspm-collector
-    version: ~0.2.3
+    version: ~0.3.0
     alias: kspmCollector
     condition: global.kspm.deploy
   - name: rapid-response
     # repository: https://charts.sysdig.com
     repository: file://../rapid-response
-    version: ~0.5.2
+    version: ~0.6.0
     alias: rapidResponse
     condition: rapidResponse.enabled

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.11.1
+version: 1.12.0
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -23,6 +23,10 @@ dependencies:
     version: ~1.9.2
     alias: agent
     condition: agent.enabled
+  - name: common
+    # repository: https://charts.sysdig.com
+    repository: file://../common
+    version: ~1.0.0
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer

--- a/charts/sysdig-deploy/templates/_helpers.tpl
+++ b/charts/sysdig-deploy/templates/_helpers.tpl
@@ -2,18 +2,8 @@
 Determine sysdig monitor endpoint based on provided region
 */}}
 {{- define "monitorUrl" -}}
-    {{- if (eq .Values.global.sysdig.region "us1") -}}
-        {{- "app.sysdigcloud.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us2") -}}
-        {{- "us2.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us3") -}}
-        {{- "app.us3.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us4") -}}
-        {{- "app.us4.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "eu1") -}}
-        {{- "eu1.app.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "au1") -}}
-        {{- "app.au1.sysdig.com" -}}
+    {{- if hasKey ((include "sysdig.regions" .) | fromYaml) .Values.global.sysdig.region }}
+        {{- include "sysdig.monitorApiEndpoint" . }}
     {{- else -}}
         {{- if (ne .Values.global.sysdig.region "custom") -}}
             {{- fail (printf "global.sysdig.region=%s provided is not recognized." .Values.global.sysdig.region ) -}}
@@ -25,18 +15,8 @@ Determine sysdig monitor endpoint based on provided region
 Determine sysdig secure endpoint based on provided region
 */}}
 {{- define "secureUrl" -}}
-    {{- if (eq .Values.global.sysdig.region "us1") -}}
-        {{- "secure.sysdig.com" -}}
-    {{- else if (eq .Values.global.sysdig.region "us2") -}}
-        {{- "us2.app.sysdig.com/secure" -}}
-    {{- else if (eq .Values.global.sysdig.region "us3") -}}
-        {{- "app.us3.sysdig.com/secure" -}}
-    {{- else if (eq .Values.global.sysdig.region "us4") -}}
-        {{- "app.us4.sysdig.com/secure" -}}
-    {{- else if (eq .Values.global.sysdig.region "eu1") -}}
-        {{- "eu1.app.sysdig.com/secure" -}}
-    {{- else if (eq .Values.global.sysdig.region "au1") -}}
-        {{- "app.au1.sysdig.com/secure" -}}
+    {{- if hasKey ((include "sysdig.regions" .) | fromYaml) .Values.global.sysdig.region }}
+        {{- include "sysdig.secureUi" . }}
     {{- else -}}
         {{- if (ne .Values.global.sysdig.region "custom") -}}
             {{- fail (printf "global.sysdig.region=%s provided is not recognized." .Values.global.sysdig.region ) -}}

--- a/charts/sysdig-deploy/tests/notes_test.yaml
+++ b/charts/sysdig-deploy/tests/notes_test.yaml
@@ -1,4 +1,4 @@
-suite: Test NOTES.txt content
+suite: Test links in the notes section for regions
 templates:
   - templates/NOTES.txt
 tests:
@@ -63,6 +63,204 @@ tests:
           pattern: https://app.au1.sysdig.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://app.au1.sysdig.com/secure/#/data-sources/agents
+
+  - it: Checking region 'au-syd'
+    set:
+      global:
+        sysdig:
+          region: au-syd
+    asserts:
+      - matchRegexRaw:
+          pattern: https://au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'br-sao'
+    set:
+      global:
+        sysdig:
+          region: br-sao
+    asserts:
+      - matchRegexRaw:
+          pattern: https://br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'ca-tor'
+    set:
+      global:
+        sysdig:
+          region: ca-tor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-de'
+    set:
+      global:
+        sysdig:
+          region: eu-de
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-gb'
+    set:
+      global:
+        sysdig:
+          region: eu-gb
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-osa'
+    set:
+      global:
+        sysdig:
+          region: jp-osa
+    asserts:
+      - matchRegexRaw:
+          pattern: https://jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-tok'
+    set:
+      global:
+        sysdig:
+          region: jp-tok
+    asserts:
+      - matchRegexRaw:
+          pattern: https://jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-east'
+    set:
+      global:
+        sysdig:
+          region: us-east
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-south'
+    set:
+      global:
+        sysdig:
+          region: us-south
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'au-syd-private'
+    set:
+      global:
+        sysdig:
+          region: au-syd-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'br-sao-private'
+    set:
+      global:
+        sysdig:
+          region: br-sao-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'ca-tor-private'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-de-private'
+    set:
+      global:
+        sysdig:
+          region: eu-de-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-gb-private'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-osa-private'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-tok-private'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-east-private'
+    set:
+      global:
+        sysdig:
+          region: us-east-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-south-private'
+    set:
+      global:
+        sysdig:
+          region: us-south-private
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking incorrect region 'ap3' should fail
     set:

--- a/charts/sysdig-deploy/tests/notes_test.yaml
+++ b/charts/sysdig-deploy/tests/notes_test.yaml
@@ -73,7 +73,7 @@ tests:
       - matchRegexRaw:
           pattern: https://au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://au-syd.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'br-sao-monitor'
     set:
@@ -84,7 +84,7 @@ tests:
       - matchRegexRaw:
           pattern: https://br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://br-sao.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'ca-tor-monitor'
     set:
@@ -95,7 +95,7 @@ tests:
       - matchRegexRaw:
           pattern: https://ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://ca-tor.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-de-monitor'
     set:
@@ -106,7 +106,7 @@ tests:
       - matchRegexRaw:
           pattern: https://eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://eu-de.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-gb-monitor'
     set:
@@ -117,7 +117,7 @@ tests:
       - matchRegexRaw:
           pattern: https://eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://eu-gb.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-osa-monitor'
     set:
@@ -128,7 +128,7 @@ tests:
       - matchRegexRaw:
           pattern: https://jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://jp-osa.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-tok-monitor'
     set:
@@ -139,7 +139,7 @@ tests:
       - matchRegexRaw:
           pattern: https://jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://jp-tok.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-east-monitor'
     set:
@@ -150,7 +150,7 @@ tests:
       - matchRegexRaw:
           pattern: https://us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://us-east.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-south-monitor'
     set:
@@ -161,7 +161,7 @@ tests:
       - matchRegexRaw:
           pattern: https://us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://us-south.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'au-syd-private-monitor'
     set:
@@ -172,7 +172,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.au-syd.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'br-sao-private-monitor'
     set:
@@ -183,7 +183,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.br-sao.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'ca-tor-private-monitor'
     set:
@@ -194,7 +194,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.ca-tor.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-de-private-monitor'
     set:
@@ -205,7 +205,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.eu-de.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-gb-private-monitor'
     set:
@@ -216,7 +216,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.eu-gb.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-osa-private-monitor'
     set:
@@ -227,7 +227,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.jp-osa.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-tok-private-monitor'
     set:
@@ -238,7 +238,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.jp-tok.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-east-private-monitor'
     set:
@@ -249,7 +249,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.us-east.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-south-private-monitor'
     set:
@@ -260,7 +260,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.us-south.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'au-syd-secure'
     set:
@@ -271,7 +271,7 @@ tests:
       - matchRegexRaw:
           pattern: https://au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://au-syd.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'br-sao-secure'
     set:
@@ -282,7 +282,7 @@ tests:
       - matchRegexRaw:
           pattern: https://br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://br-sao.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'ca-tor-secure'
     set:
@@ -293,7 +293,7 @@ tests:
       - matchRegexRaw:
           pattern: https://ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://ca-tor.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-de-secure'
     set:
@@ -304,7 +304,7 @@ tests:
       - matchRegexRaw:
           pattern: https://eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://eu-de.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-gb-secure'
     set:
@@ -315,7 +315,7 @@ tests:
       - matchRegexRaw:
           pattern: https://eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://eu-gb.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-osa-secure'
     set:
@@ -326,7 +326,7 @@ tests:
       - matchRegexRaw:
           pattern: https://jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://jp-osa.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-tok-secure'
     set:
@@ -337,7 +337,7 @@ tests:
       - matchRegexRaw:
           pattern: https://jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://jp-tok.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-east-secure'
     set:
@@ -348,7 +348,7 @@ tests:
       - matchRegexRaw:
           pattern: https://us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://us-east.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-south-secure'
     set:
@@ -359,7 +359,7 @@ tests:
       - matchRegexRaw:
           pattern: https://us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://us-south.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'au-syd-private-secure'
     set:
@@ -370,7 +370,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.au-syd.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'br-sao-private-secure'
     set:
@@ -381,7 +381,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.br-sao.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'ca-tor-private-secure'
     set:
@@ -392,7 +392,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.ca-tor.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-de-private-secure'
     set:
@@ -403,7 +403,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.eu-de.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'eu-gb-private-secure'
     set:
@@ -414,7 +414,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.eu-gb.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-osa-private-secure'
     set:
@@ -425,7 +425,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.jp-osa.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'jp-tok-private-secure'
     set:
@@ -436,7 +436,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.jp-tok.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-east-private-secure'
     set:
@@ -447,7 +447,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.us-east.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking region 'us-south-private-secure'
     set:
@@ -458,7 +458,7 @@ tests:
       - matchRegexRaw:
           pattern: https://private.us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
-          pattern: https://private.us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+          pattern: https://private.us-south.security-compliance-secure.cloud.ibm.com/#/data-sources/agents
 
   - it: Checking incorrect region 'ap3' should fail
     set:

--- a/charts/sysdig-deploy/tests/notes_test.yaml
+++ b/charts/sysdig-deploy/tests/notes_test.yaml
@@ -64,198 +64,396 @@ tests:
       - matchRegexRaw:
           pattern: https://app.au1.sysdig.com/secure/#/data-sources/agents
 
-  - it: Checking region 'au-syd'
+  - it: Checking region 'au-syd-monitor'
     set:
       global:
         sysdig:
-          region: au-syd
+          region: au-syd-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'br-sao'
+  - it: Checking region 'br-sao-monitor'
     set:
       global:
         sysdig:
-          region: br-sao
+          region: br-sao-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'ca-tor'
+  - it: Checking region 'ca-tor-monitor'
     set:
       global:
         sysdig:
-          region: ca-tor
+          region: ca-tor-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'eu-de'
+  - it: Checking region 'eu-de-monitor'
     set:
       global:
         sysdig:
-          region: eu-de
+          region: eu-de-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'eu-gb'
+  - it: Checking region 'eu-gb-monitor'
     set:
       global:
         sysdig:
-          region: eu-gb
+          region: eu-gb-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'jp-osa'
+  - it: Checking region 'jp-osa-monitor'
     set:
       global:
         sysdig:
-          region: jp-osa
+          region: jp-osa-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'jp-tok'
+  - it: Checking region 'jp-tok-monitor'
     set:
       global:
         sysdig:
-          region: jp-tok
+          region: jp-tok-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'us-east'
+  - it: Checking region 'us-east-monitor'
     set:
       global:
         sysdig:
-          region: us-east
+          region: us-east-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'us-south'
+  - it: Checking region 'us-south-monitor'
     set:
       global:
         sysdig:
-          region: us-south
+          region: us-south-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'au-syd-private'
+  - it: Checking region 'au-syd-private-monitor'
     set:
       global:
         sysdig:
-          region: au-syd-private
+          region: au-syd-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'br-sao-private'
+  - it: Checking region 'br-sao-private-monitor'
     set:
       global:
         sysdig:
-          region: br-sao-private
+          region: br-sao-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'ca-tor-private'
+  - it: Checking region 'ca-tor-private-monitor'
     set:
       global:
         sysdig:
-          region: ca-tor-private
+          region: ca-tor-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'eu-de-private'
+  - it: Checking region 'eu-de-private-monitor'
     set:
       global:
         sysdig:
-          region: eu-de-private
+          region: eu-de-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'eu-gb-private'
+  - it: Checking region 'eu-gb-private-monitor'
     set:
       global:
         sysdig:
-          region: eu-gb-private
+          region: eu-gb-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'jp-osa-private'
+  - it: Checking region 'jp-osa-private-monitor'
     set:
       global:
         sysdig:
-          region: jp-osa-private
+          region: jp-osa-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'jp-tok-private'
+  - it: Checking region 'jp-tok-private-monitor'
     set:
       global:
         sysdig:
-          region: jp-tok-private
+          region: jp-tok-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'us-east-private'
+  - it: Checking region 'us-east-private-monitor'
     set:
       global:
         sysdig:
-          region: us-east-private
+          region: us-east-private-monitor
     asserts:
       - matchRegexRaw:
           pattern: https://private.us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
       - matchRegexRaw:
           pattern: https://private.us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
 
-  - it: Checking region 'us-south-private'
+  - it: Checking region 'us-south-private-monitor'
     set:
       global:
         sysdig:
-          region: us-south-private
+          region: us-south-private-monitor
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'au-syd-secure'
+    set:
+      global:
+        sysdig:
+          region: au-syd-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'br-sao-secure'
+    set:
+      global:
+        sysdig:
+          region: br-sao-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'ca-tor-secure'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-de-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-de-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-gb-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-osa-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-tok-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-east-secure'
+    set:
+      global:
+        sysdig:
+          region: us-east-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-south-secure'
+    set:
+      global:
+        sysdig:
+          region: us-south-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://us-south.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'au-syd-private-secure'
+    set:
+      global:
+        sysdig:
+          region: au-syd-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.au-syd.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.au-syd.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'br-sao-private-secure'
+    set:
+      global:
+        sysdig:
+          region: br-sao-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.br-sao.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.br-sao.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'ca-tor-private-secure'
+    set:
+      global:
+        sysdig:
+          region: ca-tor-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.ca-tor.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.ca-tor.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-de-private-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-de-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.eu-de.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.eu-de.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'eu-gb-private-secure'
+    set:
+      global:
+        sysdig:
+          region: eu-gb-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.eu-gb.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.eu-gb.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-osa-private-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-osa-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.jp-osa.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.jp-osa.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'jp-tok-private-secure'
+    set:
+      global:
+        sysdig:
+          region: jp-tok-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.jp-tok.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.jp-tok.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-east-private-secure'
+    set:
+      global:
+        sysdig:
+          region: us-east-private-secure
+    asserts:
+      - matchRegexRaw:
+          pattern: https://private.us-east.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10
+      - matchRegexRaw:
+          pattern: https://private.us-east.sysdig-secure.cloud.ibm.com/#/data-sources/agents
+
+  - it: Checking region 'us-south-private-secure'
+    set:
+      global:
+        sysdig:
+          region: us-south-private-secure
     asserts:
       - matchRegexRaw:
           pattern: https://private.us-south.monitoring.cloud.ibm.com/#/dashboard-template/view.sysdig.agents\?last=10


### PR DESCRIPTION
## What this PR does / why we need it:
* Refactor Collector and API endpoint determinations from the individual child charts of sysdig-deploy and move them to a new library chart called 'common'. All charts can now list that library chart as a dependency and share the common logic to resolve the various Collector and API endpoints from a given region code.
* Added IBM regions

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix