### PR TITLE
fix(registry-scanner): fix installation in EKS

### DIFF
--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.1.17
+version: 0.1.18
 appVersion: 0.2.7
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/templates/cronjob.yaml
+++ b/charts/registry-scanner/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if or (gt  (.Capabilities.KubeVersion.Major | atoi) 1 ) (ge (.Capabilities.KubeVersion.Minor | atoi) 21) }}
+{{- if or (gt  (.Capabilities.KubeVersion.Major | atoi) 1 ) (ge (.Capabilities.KubeVersion.Minor | trimSuffix "+" | atoi) 21) }}
 apiVersion: batch/v1
 {{- else }}
 apiVersion: batch/v1beta1


### PR DESCRIPTION
## What this PR does / why we need it:

In EKS sometimes the minor version includes a +, which means it has patches applied. This removes the trailing + for those cases, so it can detect the minor version correctly and applies the `apiVersion: batch/v1`.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
