### PR TITLE
fix(registry-scanner): bump 2.0.10 to recover stdout logs

### DIFF
--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,8 +4,8 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.1.19
-appVersion: 0.2.9
+version: 0.1.20
+appVersion: 0.2.10
 maintainers:
   - name: airadier
     email: alvaro.iradier@sysdig.com


### PR DESCRIPTION
## What this PR does / why we need it:

bump for internal registry-scanner component, to fix logs so that the writer is `stdout` again
