### PR TITLE
feat(agent): Expand /var/run volume mount to include entire /var

### DIFF
--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -224,8 +224,8 @@ spec:
             {{- end }}
             - mountPath: /host/run
               name: run-vol
-            - mountPath: /host/var/run
-              name: varrun-vol
+            - mountPath: /host/var
+              name: var-vol
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -279,9 +279,9 @@ spec:
         - name: run-vol
           hostPath:
             path: /run
-        - name: varrun-vol
+        - name: var-vol
           hostPath:
-            path: /var/run
+            path: /var
         {{- if (and (or (include "agent.ebpfEnabled" .) (include "agent.gke.autopilot" .)) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -122,8 +122,8 @@ spec:
               readOnly: true
             - mountPath: /host/run
               name: run-vol
-            - mountPath: /host/var/run
-              name: varrun-vol
+            - mountPath: /host/var
+              name: var-vol
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -184,9 +184,9 @@ spec:
             type: ""
           name: run-vol
         - hostPath:
-            path: /var/run
+            path: /var
             type: ""
-          name: varrun-vol
+          name: var-vol
         {{- if .Values.extraVolumes.volumes }}
 {{ toYaml .Values.extraVolumes.volumes | indent 8 }}
         {{- end }}

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -222,8 +222,8 @@ spec:
             {{- end }}
             - mountPath: /host/run
               name: run-vol
-            - mountPath: /host/var/run
-              name: varrun-vol
+            - mountPath: /host/var
+              name: var-vol
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -281,9 +281,9 @@ spec:
         - name: run-vol
           hostPath:
             path: /run
-        - name: varrun-vol
+        - name: var-vol
           hostPath:
-            path: /var/run
+            path: /var
         {{- if (and (or .Values.ebpf.enabled .Values.gke.autopilot) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}


### PR DESCRIPTION
## What this PR does / why we need it:
Agent requires access to container fs for internal state validation and feature support. On some platforms, these directories might reside outside of /var/run in /var/<vendor-specific> directories.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
