### PR TITLE
fix(agent): Fix invalid comparison type

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.6.0
+version: 1.6.1
 
 appVersion: 12.12.1
 

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
     cointerface_enabled: false
 {{- end }}
 {{- include "agent.connectionSettings" . | trim | nindent 4 }}
-{{- (include "agent.secureFeatures" (dict "root" . "force_secure_disabled" nil)) | nindent 4 }}
+{{- (include "agent.secureFeatures" (dict "root" . "force_secure_disabled" false)) | nindent 4 }}
 {{- include "agent.k8sColdStart" . | nindent 4 -}}
 {{ include "agent.disableCaptures" . | nindent 4 }}
 {{- include "agent.logSettings" . }}


### PR DESCRIPTION
## What this PR does / why we need it:
On older versions of helm the eq operation is not supported between nil and boolean values.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
