### PR TITLE
ci(): Pin the version of the helm unittest plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ lint:
 	docker run --rm -e CT_VALIDATE_MAINTAINERS=false -u $(shell id -u) -v $(PWD):/charts quay.io/helmpack/chart-testing:latest sh -c "cd /charts; ct lint --all"
 
 deps-helm:
-	helm plugin install https://github.com/quintush/helm-unittest  || true
+	helm plugin install https://github.com/quintush/helm-unittest --version=0.2.11 || true
 
 test-unit-all: deps-helm test-registry-scanner
 


### PR DESCRIPTION
## What this PR does / why we need it:
The version of the helm-unittest plugin installed by in the Makefile used to just grab latest, but after a new release today it has caused issues. We are now pinning the version of the plugin to 0.2.11 as we are elsewhere in the pipelines.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.
