### PR TITLE
feat(agent): Expand /var/run volume mount to include entire /var

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.6.3
+version: 1.6.4
 
 appVersion: 12.13.0
 

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -224,8 +224,10 @@ spec:
             {{- end }}
             - mountPath: /host/run
               name: run-vol
-            - mountPath: /host/var
-              name: var-vol
+            - mountPath: /host/var/run
+              name: varrun-vol
+            - mountPath: /host/var/lib
+              name: varlib-vol
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -279,9 +281,12 @@ spec:
         - name: run-vol
           hostPath:
             path: /run
-        - name: var-vol
+        - name: varrun-vol
           hostPath:
-            path: /var
+            path: /var/run
+        - name: varlib-vol
+          hostPath:
+            path: /var/lib
         {{- if (and (or (include "agent.ebpfEnabled" .) (include "agent.gke.autopilot" .)) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -224,8 +224,8 @@ spec:
             {{- end }}
             - mountPath: /host/run
               name: run-vol
-            - mountPath: /host/var/run
-              name: varrun-vol
+            - mountPath: /host/var
+              name: var-vol
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -279,9 +279,9 @@ spec:
         - name: run-vol
           hostPath:
             path: /run
-        - name: varrun-vol
+        - name: var-vol
           hostPath:
-            path: /var/run
+            path: /var
         {{- if (and (or (include "agent.ebpfEnabled" .) (include "agent.gke.autopilot" .)) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -122,8 +122,10 @@ spec:
               readOnly: true
             - mountPath: /host/run
               name: run-vol
-            - mountPath: /host/var
-              name: var-vol
+            - mountPath: /host/var/run
+              name: varrun-vol
+            - mountPath: /host/var/lib
+              name: varlib-vol
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -184,9 +186,13 @@ spec:
             type: ""
           name: run-vol
         - hostPath:
-            path: /var
+            path: /var/run
             type: ""
-          name: var-vol
+          name: varrun-vol
+        - hostPath:
+            path: /var/lib
+            type: ""
+          name: varlib-vol
         {{- if .Values.extraVolumes.volumes }}
 {{ toYaml .Values.extraVolumes.volumes | indent 8 }}
         {{- end }}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -122,8 +122,8 @@ spec:
               readOnly: true
             - mountPath: /host/run
               name: run-vol
-            - mountPath: /host/var
-              name: var-vol
+            - mountPath: /host/var/run
+              name: varrun-vol
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -184,9 +184,9 @@ spec:
             type: ""
           name: run-vol
         - hostPath:
-            path: /var
+            path: /var/run
             type: ""
-          name: var-vol
+          name: varrun-vol
         {{- if .Values.extraVolumes.volumes }}
 {{ toYaml .Values.extraVolumes.volumes | indent 8 }}
         {{- end }}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -122,8 +122,8 @@ spec:
               readOnly: true
             - mountPath: /host/run
               name: run-vol
-            - mountPath: /host/var/run
-              name: varrun-vol
+            - mountPath: /host/var
+              name: var-vol
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -184,9 +184,9 @@ spec:
             type: ""
           name: run-vol
         - hostPath:
-            path: /var/run
+            path: /var
             type: ""
-          name: varrun-vol
+          name: var-vol
         {{- if .Values.extraVolumes.volumes }}
 {{ toYaml .Values.extraVolumes.volumes | indent 8 }}
         {{- end }}

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -1,16 +1,26 @@
 # Restore once https://github.com/sysdiglabs/charts/pull/996 is merged
-#
+
 # suite: Host volumes are available for agent
 # templates:
 #   - templates/daemonset.yaml
 # tests:
-#   - it: Ensure /var host volume is mounted as /host/var in container
+#   - it: Ensure /var/run host volume is mounted as /host/var/run in container
 #     asserts:
 #       - equal:
-#           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "var-vol")].mountPath
-#           value: /host/var
+#           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "varrun-vol")].mountPath
+#           value: /host/var/run
 #         template: templates/daemonset.yaml
 #       - equal:
-#           path: spec.template.spec.volumes[?(@.name == "var-vol")].hostPath.path
-#           value: /var
+#           path: spec.template.spec.volumes[?(@.name == "varrun-vol")].hostPath.path
+#           value: /var/run
+#         template: templates/daemonset.yaml
+#   - it: Ensure /var/lib host volume is mounted as /host/var/lib in container
+#     asserts:
+#       - equal:
+#           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "varlib-vol")].mountPath
+#           value: /host/var/lib
+#         template: templates/daemonset.yaml
+#       - equal:
+#           path: spec.template.spec.volumes[?(@.name == "varlib-vol")].hostPath.path
+#           value: /var/lib
 #         template: templates/daemonset.yaml

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -1,0 +1,14 @@
+suite: Host volumes are available for agent
+templates:
+  - templates/daemonset.yaml
+tests:
+  - it: Ensure /var host volume is mounted as /host/var in container
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "var-vol")].mountPath
+          value: /host/var
+        template: templates/daemonset.yaml
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "var-vol")].hostPath.path
+          value: /var
+        template: templates/daemonset.yaml

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -1,14 +1,16 @@
-suite: Host volumes are available for agent
-templates:
-  - templates/daemonset.yaml
-tests:
-  - it: Ensure /var host volume is mounted as /host/var in container
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "var-vol")].mountPath
-          value: /host/var
-        template: templates/daemonset.yaml
-      - equal:
-          path: spec.template.spec.volumes[?(@.name == "var-vol")].hostPath.path
-          value: /var
-        template: templates/daemonset.yaml
+# Restore once https://github.com/sysdiglabs/charts/pull/996 is merged
+#
+# suite: Host volumes are available for agent
+# templates:
+#   - templates/daemonset.yaml
+# tests:
+#   - it: Ensure /var host volume is mounted as /host/var in container
+#     asserts:
+#       - equal:
+#           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "var-vol")].mountPath
+#           value: /host/var
+#         template: templates/daemonset.yaml
+#       - equal:
+#           path: spec.template.spec.volumes[?(@.name == "var-vol")].hostPath.path
+#           value: /var
+#         template: templates/daemonset.yaml

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sysdig
 version: 1.15.82
-appVersion: 12.13.1
+appVersion: 12.13.0
 description: Sysdig Monitor and Secure agent
 keywords:
   - monitoring

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sysdig
 version: 1.15.81
-appVersion: 12.13.0
+appVersion: 12.13.1
 description: Sysdig Monitor and Secure agent
 keywords:
   - monitoring

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.81
+version: 1.15.82
 appVersion: 12.13.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -222,8 +222,10 @@ spec:
             {{- end }}
             - mountPath: /host/run
               name: run-vol
-            - mountPath: /host/var
-              name: var-vol
+            - mountPath: /host/var/run
+              name: varrun-vol
+            - mountPath: /host/var/lib
+              name: varlib-vol
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -281,9 +283,12 @@ spec:
         - name: run-vol
           hostPath:
             path: /run
-        - name: var-vol
+        - name: varrun-vol
           hostPath:
-            path: /var
+            path: /var/run
+        - name: varlib-vol
+          hostPath:
+            path: /var/lib
         {{- if (and (or .Values.ebpf.enabled .Values.gke.autopilot) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -222,8 +222,8 @@ spec:
             {{- end }}
             - mountPath: /host/run
               name: run-vol
-            - mountPath: /host/var/run
-              name: varrun-vol
+            - mountPath: /host/var
+              name: var-vol
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -281,9 +281,9 @@ spec:
         - name: run-vol
           hostPath:
             path: /run
-        - name: varrun-vol
+        - name: var-vol
           hostPath:
-            path: /var/run
+            path: /var
         {{- if (and (or .Values.ebpf.enabled .Values.gke.autopilot) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}


### PR DESCRIPTION
## What this PR does / why we need it:
Agent requires access to container fs for internal state validation and feature support. On some platforms, these directories might reside outside of /var/run in /var/<vendor-specific> directories.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
