### PR TITLE
feat(harbor-scanner-sysdig-secure): Adds config parameter to enable new async-mode

### DIFF
--- a/charts/harbor-scanner-sysdig-secure/Chart.yaml
+++ b/charts/harbor-scanner-sysdig-secure/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: harbor-scanner-sysdig-secure
 description: Harbor Scanner for Sysdig Secure
 type: application
-version: 0.3.6
-appVersion: 0.5.0
+version: 0.4.0
+appVersion: 0.6.0
 home: https://github.com/sysdiglabs/harbor-scanner-sysdig-secure
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 maintainers:
@@ -11,3 +11,5 @@ maintainers:
     email: nestor.salceda@sysdig.com
   - name: airadier
     email: alvaro.iradier@sysdig.com
+  - name: marcuzzuu
+    email: marco.mancuso@sysdig.com

--- a/charts/harbor-scanner-sysdig-secure/README.md
+++ b/charts/harbor-scanner-sysdig-secure/README.md
@@ -6,7 +6,7 @@ Kubernetes cluster.
 ## Installing the Chart
 
 1. Ensure you are passing the **sysdig.secure.apiToken** value. This one is
-mandatory to connect with the backend and perform scanning analysis
+   mandatory to connect with the backend and perform scanning analysis
 2. Create a namespace for the deployment:
 
 ```
@@ -58,7 +58,8 @@ Sysdig Secure chart and their default values:
 | `proxy.httpProxy`                             | URL of the proxy for HTTP connections, or empty if not using proxy (sets the http_proxy environment variable)               | ` `                                       |
 | `proxy.httpsProxy`                            | URL of the proxy for HTTPS connections, or empty if not using proxy (sets the https_proxy environment variable)             | ` `                                       |
 | `proxy.noProxy`                               | Comma-separated list of domain extensions proxy should not be used for. Include the internal IP of the kubeapi server.      | ` `                                       |
-| `inlineScanning.enabled`                      | Enable Inline Scanning feature                                                                                              | `true`                                   |
+| `inlineScanning.enabled`                      | Enable Inline Scanning feature                                                                                              | `true`                                    |
+| `asyncMode.enabled`                           | Enable Async-Mode feature                                                                                                   | `false`                                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/harbor-scanner-sysdig-secure/templates/configmap.yaml
+++ b/charts/harbor-scanner-sysdig-secure/templates/configmap.yaml
@@ -6,3 +6,4 @@ metadata:
     {{- include "harbor-scanner-sysdig-secure.labels" . | nindent 4 }}
 data:
   sysdig_secure_url: {{ .Values.sysdig.secure.url }}
+  async_mode_enabled: {{ .Values.asyncMode.enabled | quote }}

--- a/charts/harbor-scanner-sysdig-secure/templates/deployment.yaml
+++ b/charts/harbor-scanner-sysdig-secure/templates/deployment.yaml
@@ -69,6 +69,11 @@ spec:
             {{- if .Values.inlineScanning.enabled }}
             - name: INLINE_SCANNING
               value: "true"
+            - name: ASYNC_MODE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "harbor-scanner-sysdig-secure.fullname" . }}
+                  key: async_mode_enabled
             - name: NAMESPACE_NAME
               value: {{ .Release.Namespace }}
             - name: SECRET_NAME

--- a/charts/harbor-scanner-sysdig-secure/values.yaml
+++ b/charts/harbor-scanner-sysdig-secure/values.yaml
@@ -88,3 +88,6 @@ proxy:
 
 inlineScanning:
   enabled: true
+
+asyncMode:
+  enabled: "false"


### PR DESCRIPTION
## What this PR does / why we need it:

- Bumps chart version to `0.4.0`
- Bumps component version to `0.6.0`

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
