### PR TITLE
fix(agent): remove inline multiple checks that are not supported by helm 3.7

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.6.6
+version: 1.6.7
 
 appVersion: 12.13.0
 


### PR DESCRIPTION
## What this PR does / why we need it:

Helm 3.7 to not support multiple condition  inline (where there are dependencies in the tree) like:
```
{{- if and (hasKey .Values.first "second") (hasKey .Values.first.second "third") }}
     ....
{{- end }}
```
we need to split in different (nested) condition like:
```
{{- if hasKey .Values.first "second" }}
     {{- if hasKey .Values.first.second "third" }}
         ...
     {{- end }}
{{- end }}
```

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix
