### PR TITLE
fix(agent):Fix dragent.yaml indentation for security block

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.6.7
+version: 1.6.8
 
 appVersion: 12.13.0
 

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -284,7 +284,7 @@ The Sysdig agent uses a file called `dragent.yaml` to store the configuration.
 
 Using the Helm chart, the default configuration settings can be updated using `sysdig.settings` either
 via `--set sysdig.settings.key = value` or in the values YAML file. For example, to eanble Prometheus metrics scraping,
-you need this in your `values.yaml` file::
+you need this in your `values.yaml` file:
 
 ```yaml
 sysdig:
@@ -297,6 +297,19 @@ sysdig:
 
 ```bash
 $ helm install --namespace sysdig-agent sysdig-agent -f values.yaml sysdig/agent
+```
+
+### Agent Modes
+When directly specifying the agent mode by `sysdig.settitngs.feature.mode`, the values of `monitor.enabled` and
+`secure.enabled` must match the provided type. For example, setting `sysdig.settings.feature.mode=secure` would require
+the following:
+```yaml
+monitor:
+  enabled: false
+sysdig:
+  settings:
+    feature:
+      mode: secure
 ```
 
 ## Upgrading Sysdig agent configuration

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -377,7 +377,7 @@ For monitor.enabled=false, disable all Monitor specific extras (like app checks,
             "statsd") }}
             {{- $_ := set $monitorBlock $monitorFeature (dict "enabled" false) }}
         {{- end }}
-        {{- toYaml $monitorBlock }}
+{{ toYaml $monitorBlock }}
     {{- end -}}
 {{- end -}}
 
@@ -428,7 +428,7 @@ agent config to prevent a backend push from enabling them after installation.
             {{- $_ := set $secureConfig $secureFeature (dict "enabled" false) }}
         {{- end }}
     {{- end }}
-    {{- toYaml $secureConfig }}
+{{ toYaml $secureConfig }}
 {{- end }}
 
 {{ define "agent.k8sColdStart" }}


### PR DESCRIPTION
## What this PR does / why we need it:
When manually specifying secure mode the security block was being improperly indented.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts

Check Contribution guidelines in README.md for more insight.
