### PR TITLE
fix(agent,sysdig-deploy): Reduce Agent mode misconfiguration from fail to NOTES output

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.6.9
+version: 1.6.10
 
 appVersion: 12.13.0
 

--- a/charts/agent/templates/NOTES.txt
+++ b/charts/agent/templates/NOTES.txt
@@ -6,4 +6,17 @@ Links for your deployment:
   * Sysdig Monitor: https://{{ include "monitorUrl" . }}/#/dashboard-template/view.sysdig.agents?last=10
   * Sysdig Secure: https://{{ include "secureUrl" . }}/#/data-sources/agents
 
+{{- $secureFeatProvided := false }}
+{{- if hasKey .Values.sysdig.settings "feature" }}
+    {{- if hasKey .Values.sysdig.settings.feature "mode" }}
+        {{- $secureLight := (eq .Values.sysdig.settings.feature.mode "secure_light") }}
+        {{- $secureFeatProvided = (or $secureLight (eq .Values.sysdig.settings.feature.mode "secure")) }}
+    {{- end }}
+{{- end }}
+{{ if and .Values.monitor.enabled $secureFeatProvided }}
+The monitor.enabled parameter is true while using sysdig.settings.feature.mode to put the Agent into either
+secure or secure_light mode. Please set monitor.enabled=false to ensure all Sysdig Monitor components are disabled
+when running the Agent in secure or secure_light modes.
+{{ else }}
 No further action should be required.
+{{ end }}

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -353,9 +353,6 @@ and set the agent chart parameters accordingly
     {{- if and (not .Values.secure.enabled) $secureFeatProvided }}
         {{ fail "Set secure.enabled=true when specifying sysdig.settings.feature.mode is `secure` or `secure_light`" }}
     {{- end }}
-    {{- if and .Values.monitor.enabled $secureFeatProvided }}
-        {{ fail "Cannot set monitor.enabled=true when sysdig.settings.feature.mode is `secure` or `secure_light`" }}
-    {{- end }}
 
 {{ include "agent.monitorFeatures" . }}
 {{ include "agent.secureFeatures" . }}

--- a/charts/agent/tests/monitor_enable_test.yaml
+++ b/charts/agent/tests/monitor_enable_test.yaml
@@ -1,6 +1,7 @@
 suite: Test enabling/disabling monitor features
 templates:
   - templates/configmap.yaml
+  - templates/NOTES.txt
 tests:
   - it: Set chart defaults (monitor.enabled=true)
     asserts:
@@ -11,6 +12,7 @@ tests:
           pattern: |-
             app_checks_enabled: false
         not: true
+    template: templates/configmap.yaml
 
   - it: Set monitor.enabled=true
     set:
@@ -24,6 +26,7 @@ tests:
           pattern: |-
             app_checks_enabled: false
         not: true
+    template: templates/configmap.yaml
 
   - it: Set monitor.enabled=false
     set:
@@ -42,6 +45,7 @@ tests:
               enabled: false
             statsd:
               enabled: false
+    template: templates/configmap.yaml
 
   - it: Test monitor.enabled when specifying secure_light mode
     set:
@@ -52,8 +56,12 @@ tests:
           feature:
             mode: secure_light
     asserts:
-      - failedTemplate:
-          errorMessage: 'Cannot set monitor.enabled=true when sysdig.settings.feature.mode is `secure` or `secure_light`'
+      - matchRegexRaw:
+          pattern: |-
+            The monitor.enabled parameter is true while using sysdig.settings.feature.mode to put the Agent into either
+            secure or secure_light mode. Please set monitor.enabled=false to ensure all Sysdig Monitor components are disabled
+            when running the Agent in secure or secure_light modes.
+    template: templates/NOTES.txt
 
   - it: Test monitor.enabled when specifying secure mode
     set:
@@ -64,5 +72,9 @@ tests:
           feature:
             mode: secure
     asserts:
-      - failedTemplate:
-          errorMessage: 'Cannot set monitor.enabled=true when sysdig.settings.feature.mode is `secure` or `secure_light`'
+      - matchRegexRaw:
+          pattern: |-
+            The monitor.enabled parameter is true while using sysdig.settings.feature.mode to put the Agent into either
+            secure or secure_light mode. Please set monitor.enabled=false to ensure all Sysdig Monitor components are disabled
+            when running the Agent in secure or secure_light modes.
+    template: templates/NOTES.txt

--- a/charts/agent/tests/monitor_enable_test.yaml
+++ b/charts/agent/tests/monitor_enable_test.yaml
@@ -63,6 +63,22 @@ tests:
             when running the Agent in secure or secure_light modes.
     template: templates/NOTES.txt
 
+  - it: Test monitor.enabled=false when specifying secure_light mode
+    set:
+      monitor:
+        enabled: false
+      sysdig:
+        settings:
+          feature:
+            mode: secure_light
+    asserts:
+      - notMatchRegexRaw:
+          pattern: |-
+            The monitor.enabled parameter is true while using sysdig.settings.feature.mode to put the Agent into either
+            secure or secure_light mode. Please set monitor.enabled=false to ensure all Sysdig Monitor components are disabled
+            when running the Agent in secure or secure_light modes.
+    template: templates/NOTES.txt
+
   - it: Test monitor.enabled when specifying secure mode
     set:
       monitor:
@@ -73,6 +89,22 @@ tests:
             mode: secure
     asserts:
       - matchRegexRaw:
+          pattern: |-
+            The monitor.enabled parameter is true while using sysdig.settings.feature.mode to put the Agent into either
+            secure or secure_light mode. Please set monitor.enabled=false to ensure all Sysdig Monitor components are disabled
+            when running the Agent in secure or secure_light modes.
+    template: templates/NOTES.txt
+
+  - it: Test monitor.enabled=false when specifying secure mode
+    set:
+      monitor:
+        enabled: false
+      sysdig:
+        settings:
+          feature:
+            mode: secure
+    asserts:
+      - notMatchRegexRaw:
           pattern: |-
             The monitor.enabled parameter is true while using sysdig.settings.feature.mode to put the Agent into either
             secure or secure_light mode. Please set monitor.enabled=false to ensure all Sysdig Monitor components are disabled

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.6.15
+version: 1.6.16
 
 maintainers:
   - name: aroberts87
@@ -21,7 +21,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.6.9
+    version: ~1.6.10
     alias: agent
     condition: agent.enabled
   - name: node-analyzer

--- a/charts/sysdig-deploy/templates/NOTES.txt
+++ b/charts/sysdig-deploy/templates/NOTES.txt
@@ -9,3 +9,16 @@ Links for your deployment:
 {{- if .Values.global.sysdig.tags }}
 Usage of global tags will override any local tags you might be using.
 {{- end }}
+
+{{- $agentSecureFeatProvided := false }}
+{{- if hasKey .Values.agent.sysdig.settings "feature" }}
+    {{- if hasKey .Values.agent.sysdig.settings.feature "mode" }}
+        {{- $secureLight := (eq .Values.agent.sysdig.settings.feature.mode "secure_light") }}
+        {{- $agentSecureFeatProvided = (or $secureLight (eq .Values.agent.sysdig.settings.feature.mode "secure")) }}
+    {{- end }}
+{{- end }}
+{{ if and .Values.agent.monitor.enabled $agentSecureFeatProvided }}
+The agent.monitor.enabled parameter is true while using agent.sysdig.settings.feature.mode to put the Agent into either
+secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled
+when running the Agent in secure or secure_light modes.
+{{ end }}

--- a/charts/sysdig-deploy/tests/notes_test.yaml
+++ b/charts/sysdig-deploy/tests/notes_test.yaml
@@ -90,6 +90,23 @@ tests:
             when running the Agent in secure or secure_light modes.
     template: templates/NOTES.txt
 
+  - it: Test agent.monitor.enabled=false when specifying Agent secure_light mode
+    set:
+      agent:
+        monitor:
+          enabled: false
+        sysdig:
+          settings:
+            feature:
+              mode: secure_light
+    asserts:
+      - notMatchRegexRaw:
+          pattern: |-
+            The agent.monitor.enabled parameter is true while using agent.sysdig.settings.feature.mode to put the Agent into either
+            secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled
+            when running the Agent in secure or secure_light modes.
+    template: templates/NOTES.txt
+
   - it: Test agent.monitor.enabled when specifying Agent secure mode
     set:
       agent:
@@ -101,6 +118,23 @@ tests:
               mode: secure
     asserts:
       - matchRegexRaw:
+          pattern: |-
+            The agent.monitor.enabled parameter is true while using agent.sysdig.settings.feature.mode to put the Agent into either
+            secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled
+            when running the Agent in secure or secure_light modes.
+    template: templates/NOTES.txt
+
+  - it: Test agent.monitor.enabled=false when specifying Agent secure mode
+    set:
+      agent:
+        monitor:
+          enabled: false
+        sysdig:
+          settings:
+            feature:
+              mode: secure
+    asserts:
+      - notMatchRegexRaw:
           pattern: |-
             The agent.monitor.enabled parameter is true while using agent.sysdig.settings.feature.mode to put the Agent into either
             secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled

--- a/charts/sysdig-deploy/tests/notes_test.yaml
+++ b/charts/sysdig-deploy/tests/notes_test.yaml
@@ -1,4 +1,4 @@
-suite: Test links in the notes section for regions (us1,us2,us3,us4,eu1,au1)
+suite: Test NOTES.txt content
 templates:
   - templates/NOTES.txt
 tests:
@@ -72,3 +72,37 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "raw: global.sysdig.region=ap3 provided is not recognized."
+
+  - it: Test agent.monitor.enabled when specifying Agent secure_light mode
+    set:
+      agent:
+        monitor:
+          enabled: true
+        sysdig:
+          settings:
+            feature:
+              mode: secure_light
+    asserts:
+      - matchRegexRaw:
+          pattern: |-
+            The agent.monitor.enabled parameter is true while using agent.sysdig.settings.feature.mode to put the Agent into either
+            secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled
+            when running the Agent in secure or secure_light modes.
+    template: templates/NOTES.txt
+
+  - it: Test agent.monitor.enabled when specifying Agent secure mode
+    set:
+      agent:
+        monitor:
+          enabled: true
+        sysdig:
+          settings:
+            feature:
+              mode: secure
+    asserts:
+      - matchRegexRaw:
+          pattern: |-
+            The agent.monitor.enabled parameter is true while using agent.sysdig.settings.feature.mode to put the Agent into either
+            secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled
+            when running the Agent in secure or secure_light modes.
+    template: templates/NOTES.txt


### PR DESCRIPTION
## What this PR does / why we need it:
The introduction of the monitor.enabled flag introduced a breaking change for users explicitly putting the Agent into secure or secure_light mode by informing the user that putting the Agent into one of those two modes while running the Sysdig Monitor components is not advised. This change reduces the intentional rendering fail into a suggestion in the NOTES.txt output.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts