### PR TITLE
fix(admission-controller,agent,node-analyzer,rapid-response,registry-scanner,sysdig): Improve KubeVersion Comparisons

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.7.27
+version: 0.7.28
 appVersion: 3.9.17
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.7.27  \
+      --create-namespace -n sysdig-admission-controller --version=0.7.28  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.url=SECURE_URL \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
@@ -56,7 +56,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.27
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.7.28
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -182,7 +182,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.27 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.28 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,sysdig.url=SECURE_URL,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -191,7 +191,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.7.27 \
+    --create-namespace -n sysdig-admission-controller --version=0.7.28 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/templates/_helpers.tpl
+++ b/charts/admission-controller/templates/_helpers.tpl
@@ -349,7 +349,7 @@ an error if not.
 {{- end -}}
 
 {{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
-     Use like: {{ include "admissionController.kubeVersionLessThan" (dict "root" . "major" "<kube_major_to_compare>" "minor" "<kube_minor_to_compare>") }}
+     Use like: {{ include "admissionController.kubeVersionLessThan" (dict "root" . "major" <kube_major_to_compare> "minor" <kube_minor_to_compare>) }}
 
      Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
            helper functions when "helm template" is used.

--- a/charts/admission-controller/templates/_helpers.tpl
+++ b/charts/admission-controller/templates/_helpers.tpl
@@ -347,3 +347,16 @@ an error if not.
 {{- $errorMsg := "The Sysdig Secure API Token was not provided with either the sysdig.secureAPIToken or sysdig.secureAPITokenSecret values." -}}
     {{- required $errorMsg (or (include "sysdig.secureAPIToken" .) (include "sysdig.secureAPITokenSecret" .)) -}}
 {{- end -}}
+
+{{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
+     Use like: {{ include "admissionController.kubeVersionLessThan" (dict "root" . "major" "<kube_major_to_compare>" "minor" "<kube_minor_to_compare>") }}
+
+     Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
+           helper functions when "helm template" is used.
+*/}}
+{{- define "admissionController.kubeVersionLessThan" }}
+{{- if (and (le (.root.Capabilities.KubeVersion.Major | int) .major)
+            (lt (.root.Capabilities.KubeVersion.Minor | trimSuffix "+" | int) .minor)) }}
+true
+{{- end }}
+{{- end }}

--- a/charts/admission-controller/templates/scanner/psp.yaml
+++ b/charts/admission-controller/templates/scanner/psp.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.scanner.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
+{{- if and .Values.scanner.psp.create (include "admissionController.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/admission-controller/templates/scanner/role.yaml
+++ b/charts/admission-controller/templates/scanner/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.scanner.psp.create  }}
+{{- if and .Values.scanner.psp.create (include "admissionController.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/admission-controller/templates/scanner/rolebinding.yaml
+++ b/charts/admission-controller/templates/scanner/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.scanner.psp.create  }}
+{{- if and .Values.scanner.psp.create (include "admissionController.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/admission-controller/tests/psp_test.yaml
+++ b/charts/admission-controller/tests/psp_test.yaml
@@ -1,0 +1,35 @@
+suite: PSP create test
+templates:
+  - templates/scanner/psp.yaml
+  - templates/scanner/role.yaml
+  - templates/scanner/rolebinding.yaml
+tests:
+  - it: Ensure PSP is created on k8s <1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 24
+    set:
+      scanner:
+        psp:
+          create: true
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1beta1
+          kind: PodSecurityPolicy
+        template: templates/scanner/psp.yaml
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+        template: templates/scanner/role.yaml
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+        template: templates/scanner/rolebinding.yaml
+
+  - it: Ensure PSP is not created on k8s >=1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 25
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/admission-controller/tests/psp_test.yaml
+++ b/charts/admission-controller/tests/psp_test.yaml
@@ -33,3 +33,33 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: Ensure PSP is created on k8s <1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "24+"
+    set:
+      scanner:
+        psp:
+          create: true
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1beta1
+          kind: PodSecurityPolicy
+        template: templates/scanner/psp.yaml
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+        template: templates/scanner/role.yaml
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+        template: templates/scanner/rolebinding.yaml
+
+  - it: Ensure PSP is not created on k8s >=1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "25+"
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.6.8
+version: 1.6.9
 
 appVersion: 12.13.0
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -515,7 +515,7 @@ sysdig_capture_enabled: false
 {{- end }}
 
 {{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
-     Use like: {{ include "agent.kubeVersionLessThan" (dict "root" . "major" "<kube_major_to_compare>" "minor" "<kube_minor_to_compare>") }}
+     Use like: {{ include "agent.kubeVersionLessThan" (dict "root" . "major" <kube_major_to_compare> "minor" <kube_minor_to_compare>) }}
 
      Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
            helper functions when "helm template" is used.

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -513,3 +513,16 @@ k8s_cluster_name: {{ $clusterName }}
 sysdig_capture_enabled: false
     {{- end }}
 {{- end }}
+
+{{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
+     Use like: {{ include "agent.kubeVersionLessThan" (dict "root" . "major" "<kube_major_to_compare>" "minor" "<kube_minor_to_compare>") }}
+
+     Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
+           helper functions when "helm template" is used.
+*/}}
+{{- define "agent.kubeVersionLessThan" }}
+{{- if (and (le (.root.Capabilities.KubeVersion.Major | int) .major)
+            (lt (.root.Capabilities.KubeVersion.Minor | trimSuffix "+" | int) .minor)) }}
+true
+{{- end }}
+{{- end }}

--- a/charts/agent/templates/clusterrole.yaml
+++ b/charts/agent/templates/clusterrole.yaml
@@ -111,7 +111,7 @@ rules:
     - get
     - list
     - watch
-{{- if and .Values.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
+{{- if and .Values.psp.create (include "agent.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
   - apiGroups:
       - "policy"
     resources:

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -53,8 +53,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              {{- if and (eq (int .Capabilities.KubeVersion.Major) 1)
-                (lt (int .Capabilities.KubeVersion.Minor) 14) }}
+              {{- if (include "agent.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 14)) }}
               - key: beta.kubernetes.io/arch
                 operator: In
                 values: {{- toYaml .Values.daemonset.arch | nindent 18 }}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -36,8 +36,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              {{- if and (eq (int .Capabilities.KubeVersion.Major) 1)
-                (lt (int .Capabilities.KubeVersion.Minor) 14) }}
+              {{- if (include "agent.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 14)) }}
               - key: beta.kubernetes.io/arch
                 operator: In
                 values: {{- toYaml .Values.delegatedAgentDeployment.deployment.arch | nindent 18 }}

--- a/charts/agent/templates/psp.yaml
+++ b/charts/agent/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
+{{- if and .Values.psp.create (include "agent.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/agent/tests/clusterrole_test.yaml
+++ b/charts/agent/tests/clusterrole_test.yaml
@@ -1,0 +1,37 @@
+suite: Agent Cluster Role Tests
+templates:
+  - templates/clusterrole.yaml
+tests:
+  - it: Test PSP information included in k8s <1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 24
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - "policy"
+            resources:
+              - "podsecuritypolicies"
+            resourceNames:
+              - RELEASE-NAME-agent
+            verbs:
+              - "use"
+
+  - it: Test PSP information not included in k8s >=1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 25
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - "policy"
+            resources:
+              - "podsecuritypolicies"
+            resourceNames:
+              - RELEASE-NAME-agent
+            verbs:
+              - "use"

--- a/charts/agent/tests/clusterrole_test.yaml
+++ b/charts/agent/tests/clusterrole_test.yaml
@@ -35,3 +35,37 @@ tests:
               - RELEASE-NAME-agent
             verbs:
               - "use"
+
+  - it: Test PSP information included in k8s <1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "24+"
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - "policy"
+            resources:
+              - "podsecuritypolicies"
+            resourceNames:
+              - RELEASE-NAME-agent
+            verbs:
+              - "use"
+
+  - it: Test PSP information not included in k8s >=1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "25+"
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - "policy"
+            resources:
+              - "podsecuritypolicies"
+            resourceNames:
+              - RELEASE-NAME-agent
+            verbs:
+              - "use"

--- a/charts/agent/tests/psp_test.yaml
+++ b/charts/agent/tests/psp_test.yaml
@@ -18,6 +18,32 @@ tests:
     capabilities:
       majorVersion: 1
       minorVersion: 25
+    set:
+      psp:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Ensure PSP is created on k8s <1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "24+"
+    set:
+      psp:
+        create: true
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1beta1
+          kind: PodSecurityPolicy
+
+  - it: Ensure PSP is not created on k8s >=1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "25+"
+    set:
+      psp:
+        create: true
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/agent/tests/psp_test.yaml
+++ b/charts/agent/tests/psp_test.yaml
@@ -1,0 +1,23 @@
+suite: PSP create test
+templates:
+  - templates/psp.yaml
+tests:
+  - it: Ensure PSP is created on k8s <1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 24
+    set:
+      psp:
+        create: true
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1beta1
+          kind: PodSecurityPolicy
+
+  - it: Ensure PSP is not created on k8s >=1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 25
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.8.48
+version: 1.8.49
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/_helpers.tpl
+++ b/charts/node-analyzer/templates/_helpers.tpl
@@ -278,7 +278,7 @@ Returns the namespace for installing components
 {{- end -}}
 
 {{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
-     Use like: {{ include "nodeAnalyzer.kubeVersionLessThan" (dict "root" . "major" "<kube_major_to_compare>" "minor" "<kube_minor_to_compare>") }}
+     Use like: {{ include "nodeAnalyzer.kubeVersionLessThan" (dict "root" . "major" <kube_major_to_compare> "minor" <kube_minor_to_compare>) }}
 
      Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
            helper functions when "helm template" is used.

--- a/charts/node-analyzer/templates/_helpers.tpl
+++ b/charts/node-analyzer/templates/_helpers.tpl
@@ -276,3 +276,16 @@ Returns the namespace for installing components
 {{- define "nodeAnalyzer.namespace" -}}
     {{- coalesce .Values.namespace .Values.global.clusterConfig.namespace .Release.Namespace -}}
 {{- end -}}
+
+{{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
+     Use like: {{ include "nodeAnalyzer.kubeVersionLessThan" (dict "root" . "major" "<kube_major_to_compare>" "minor" "<kube_minor_to_compare>") }}
+
+     Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
+           helper functions when "helm template" is used.
+*/}}
+{{- define "nodeAnalyzer.kubeVersionLessThan" }}
+{{- if (and (le (.root.Capabilities.KubeVersion.Major | int) .major)
+            (lt (.root.Capabilities.KubeVersion.Minor | trimSuffix "+" | int) .minor)) }}
+true
+{{- end }}
+{{- end }}

--- a/charts/node-analyzer/templates/clusterrole-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/clusterrole-node-analyzer.yaml
@@ -111,7 +111,7 @@ rules:
     - create
     - delete
 {{- end }}
-{{- if and .Values.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
+{{- if and .Values.psp.create (include "nodeAnalyzer.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
 - apiGroups:
     - "policy"
   resources:

--- a/charts/node-analyzer/templates/psp.yaml
+++ b/charts/node-analyzer/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if not (include "nodeAnalyzer.gke.autopilot" .) }}
-{{- if and .Values.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
+{{- if and .Values.psp.create (include "nodeAnalyzer.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/node-analyzer/tests/clusterrole_test.yaml
+++ b/charts/node-analyzer/tests/clusterrole_test.yaml
@@ -35,3 +35,37 @@ tests:
               - RELEASE-NAME-node-analyzer
             verbs:
               - "use"
+
+  - it: Test PSP information included in k8s <1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "24+"
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - "policy"
+            resources:
+              - "podsecuritypolicies"
+            resourceNames:
+              - RELEASE-NAME-node-analyzer
+            verbs:
+              - "use"
+
+  - it: Test PSP information not included in k8s >=1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "25+"
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - "policy"
+            resources:
+              - "podsecuritypolicies"
+            resourceNames:
+              - RELEASE-NAME-node-analyzer
+            verbs:
+              - "use"

--- a/charts/node-analyzer/tests/clusterrole_test.yaml
+++ b/charts/node-analyzer/tests/clusterrole_test.yaml
@@ -1,0 +1,37 @@
+suite: Node Analyzer Cluster Role Tests
+templates:
+  - templates/clusterrole-node-analyzer.yaml
+tests:
+  - it: Test PSP information included in k8s <1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 24
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - "policy"
+            resources:
+              - "podsecuritypolicies"
+            resourceNames:
+              - RELEASE-NAME-node-analyzer
+            verbs:
+              - "use"
+
+  - it: Test PSP information not included in k8s >=1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 25
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - "policy"
+            resources:
+              - "podsecuritypolicies"
+            resourceNames:
+              - RELEASE-NAME-node-analyzer
+            verbs:
+              - "use"

--- a/charts/node-analyzer/tests/psp_test.yaml
+++ b/charts/node-analyzer/tests/psp_test.yaml
@@ -1,0 +1,23 @@
+suite: PSP create test
+templates:
+  - templates/psp.yaml
+tests:
+  - it: Ensure PSP is created on k8s <1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 24
+    set:
+      psp:
+        create: true
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1beta1
+          kind: PodSecurityPolicy
+
+  - it: Ensure PSP is not created on k8s >=1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 25
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/node-analyzer/tests/psp_test.yaml
+++ b/charts/node-analyzer/tests/psp_test.yaml
@@ -21,3 +21,23 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: Ensure PSP is created on k8s <1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "24+"
+    set:
+      psp:
+        create: true
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1beta1
+          kind: PodSecurityPolicy
+
+  - it: Ensure PSP is not created on k8s >=1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "25+"
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.9
+version: 0.4.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rapid-response/templates/_helpers.tpl
+++ b/charts/rapid-response/templates/_helpers.tpl
@@ -206,3 +206,16 @@ Create the name of the Rapid Response collector specific service account to use
     {{ default "default" .Values.rapidResponse.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
+     Use like: {{ include "rapidResponse.kubeVersionLessThan" (dict "root" . "major" "<kube_major_to_compare>" "minor" "<kube_minor_to_compare>") }}
+
+     Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
+           helper functions when "helm template" is used.
+*/}}
+{{- define "rapidResponse.kubeVersionLessThan" }}
+{{- if (and (le (.root.Capabilities.KubeVersion.Major | int) .major)
+            (lt (.root.Capabilities.KubeVersion.Minor | trimSuffix "+" | int) .minor)) }}
+true
+{{- end }}
+{{- end }}

--- a/charts/rapid-response/templates/_helpers.tpl
+++ b/charts/rapid-response/templates/_helpers.tpl
@@ -208,7 +208,7 @@ Create the name of the Rapid Response collector specific service account to use
 {{- end -}}
 
 {{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
-     Use like: {{ include "rapidResponse.kubeVersionLessThan" (dict "root" . "major" "<kube_major_to_compare>" "minor" "<kube_minor_to_compare>") }}
+     Use like: {{ include "rapidResponse.kubeVersionLessThan" (dict "root" . "major" <kube_major_to_compare> "minor" <kube_minor_to_compare>) }}
 
      Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
            helper functions when "helm template" is used.

--- a/charts/rapid-response/templates/daemonset.yaml
+++ b/charts/rapid-response/templates/daemonset.yaml
@@ -41,8 +41,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              {{- if and (eq (int .Capabilities.KubeVersion.Major) 1)
-                  (lt (int .Capabilities.KubeVersion.Minor) 14) }}
+              {{- if (include "rapidResponse.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
               - key: beta.kubernetes.io/arch
                 operator: In
                 values: {{- toYaml .Values.rapidResponse.arch | nindent 18 }}

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 0.1.37
+version: 0.1.38
 appVersion: 0.2.27
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/templates/_helpers.tpl
+++ b/charts/registry-scanner/templates/_helpers.tpl
@@ -117,7 +117,7 @@ Allow overriding registry and repository for air-gapped environments
 {{- end -}}
 
 {{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
-     Use like: {{ include "registry-scanner.kubeVersionLessThan" (dict "root" . "major" "<kube_major_to_compare>" "minor" "<kube_minor_to_compare>") }}
+     Use like: {{ include "registry-scanner.kubeVersionLessThan" (dict "root" . "major" <kube_major_to_compare> "minor" <kube_minor_to_compare>) }}
 
      Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
            helper functions when "helm template" is used.

--- a/charts/registry-scanner/templates/_helpers.tpl
+++ b/charts/registry-scanner/templates/_helpers.tpl
@@ -115,3 +115,16 @@ Allow overriding registry and repository for air-gapped environments
 {{- define "registry-scanner.pullSecretList" -}}
 {{ trimSuffix "," (include "registry-scanner.rawPullSecretList" .) }}
 {{- end -}}
+
+{{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
+     Use like: {{ include "registry-scanner.kubeVersionLessThan" (dict "root" . "major" "<kube_major_to_compare>" "minor" "<kube_minor_to_compare>") }}
+
+     Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
+           helper functions when "helm template" is used.
+*/}}
+{{- define "registry-scanner.kubeVersionLessThan" }}
+{{- if (and (le (.root.Capabilities.KubeVersion.Major | int) .major)
+            (lt (.root.Capabilities.KubeVersion.Minor | trimSuffix "+" | int) .minor)) }}
+true
+{{- end }}
+{{- end }}

--- a/charts/registry-scanner/templates/cronjob.yaml
+++ b/charts/registry-scanner/templates/cronjob.yaml
@@ -1,7 +1,7 @@
-{{- if or (gt  (.Capabilities.KubeVersion.Major | atoi) 1 ) (ge (.Capabilities.KubeVersion.Minor | trimSuffix "+" | atoi) 21) }}
-apiVersion: batch/v1
-{{- else }}
+{{- if (include "registry-scanner.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 21)) }}
 apiVersion: batch/v1beta1
+{{- else }}
+apiVersion: batch/v1
 {{- end }}
 kind: CronJob
 metadata:

--- a/charts/registry-scanner/tests/cronjob_test.yaml
+++ b/charts/registry-scanner/tests/cronjob_test.yaml
@@ -28,3 +28,21 @@ tests:
     - equal:
         path: spec.jobTemplate.spec.backoffLimit
         value: 0
+
+  - it: Check apiVersion for Kube <1.21
+    capabilities:
+      majorVersion: 1
+      minorVersion: 20
+    asserts:
+      - equal:
+          path: apiVersion
+          value: batch/v1beta1
+
+  - it: Check apiVersion for Kube >=1.21
+    capabilities:
+      majorVersion: 1
+      minorVersion: 21
+    asserts:
+      - equal:
+          path: apiVersion
+          value: batch/v1

--- a/charts/registry-scanner/tests/cronjob_test.yaml
+++ b/charts/registry-scanner/tests/cronjob_test.yaml
@@ -46,3 +46,21 @@ tests:
       - equal:
           path: apiVersion
           value: batch/v1
+
+  - it: Check apiVersion for Kube <1.21 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "20+"
+    asserts:
+      - equal:
+          path: apiVersion
+          value: batch/v1beta1
+
+  - it: Check apiVersion for Kube >=1.21 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "21+"
+    asserts:
+      - equal:
+          path: apiVersion
+          value: batch/v1

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.82
+version: 1.15.83
 appVersion: 12.13.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/_helpers.tpl
+++ b/charts/sysdig/templates/_helpers.tpl
@@ -297,7 +297,7 @@ true
 {{- end -}}
 
 {{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
-     Use like: {{ include "sysdig.kubeVersionLessThan" (dict "root" . "major" "<kube_major_to_compare>" "minor" "<kube_minor_to_compare>") }}
+     Use like: {{ include "sysdig.kubeVersionLessThan" (dict "root" . "major" <kube_major_to_compare> "minor" <kube_minor_to_compare>) }}
 
      Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
            helper functions when "helm template" is used.

--- a/charts/sysdig/templates/_helpers.tpl
+++ b/charts/sysdig/templates/_helpers.tpl
@@ -295,3 +295,16 @@ true
 true
 {{- end -}}
 {{- end -}}
+
+{{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
+     Use like: {{ include "sysdig.kubeVersionLessThan" (dict "root" . "major" "<kube_major_to_compare>" "minor" "<kube_minor_to_compare>") }}
+
+     Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
+           helper functions when "helm template" is used.
+*/}}
+{{- define "sysdig.kubeVersionLessThan" }}
+{{- if (and (le (.root.Capabilities.KubeVersion.Major | int) .major)
+            (lt (.root.Capabilities.KubeVersion.Minor | trimSuffix "+" | int) .minor)) }}
+true
+{{- end }}
+{{- end }}

--- a/charts/sysdig/templates/psp-node-analyzer.yaml
+++ b/charts/sysdig/templates/psp-node-analyzer.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
+{{- if and .Values.psp.create (include "sysdig.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/sysdig/templates/psp.yaml
+++ b/charts/sysdig/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.psp.create (lt (int .Capabilities.KubeVersion.Minor) 25) }}
+{{- if and .Values.psp.create (include "sysdig.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/sysdig/tests/psp_test.yaml
+++ b/charts/sysdig/tests/psp_test.yaml
@@ -1,0 +1,24 @@
+suite: PSP create tests
+templates:
+  - templates/psp.yaml
+  - templates/psp-node-analyzer.yaml
+tests:
+  - it: Ensure PSPs are created on k8s <1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 24
+    set:
+      psp:
+        create: true
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1beta1
+          kind: PodSecurityPolicy
+
+  - it: Ensure PSP is not created on k8s >=1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 25
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/sysdig/tests/psp_test.yaml
+++ b/charts/sysdig/tests/psp_test.yaml
@@ -22,3 +22,23 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: Ensure PSPs are created on k8s <1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "24+"
+    set:
+      psp:
+        create: true
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1beta1
+          kind: PodSecurityPolicy
+
+  - it: Ensure PSP is not created on k8s >=1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "25+"
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## What this PR does / why we need it:
In various places across many charts we do compatibility checks against exact Kubernetes versions. To do so, the charts had been casting the raw value of `.Capabilities.KubeVersion.Minor` to an int like the following:

```
(lt (int .Capabilities.KubeVersion.Minor) 25)
```

The bug here is that certain Kubernetes flavors (EKS, microk8s, etc.) will sometimes put a `+` at the end of the minor version. That `+` was causing the cast to an int to silently fail and return a zero, which was causing failure by attempting to deploy constructs that are not supported on incorrect cluster versions.

This change guards against the `+` suffix as well as abstracts away the version check logic into another helper function that can be more easily adjusted if necessary.


## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix