### PR TITLE
feat(agent): Move Agent lease permissions

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.6.10
+version: 1.7.0
 
 appVersion: 12.13.0
 

--- a/charts/agent/templates/clusterrole.yaml
+++ b/charts/agent/templates/clusterrole.yaml
@@ -73,16 +73,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-    - coordination.k8s.io
-    resources:
-    - leases
-    verbs:
-    - get
-    - list
-    - create
-    - update
-    - watch
   - nonResourceURLs:
     - /metrics
     verbs:

--- a/charts/agent/templates/role.yaml
+++ b/charts/agent/templates/role.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "agent.fullname" . }}
+rules:
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+  verbs:
+    - create
+    - get
+    - list
+    - update
+    - watch
+{{- end }}

--- a/charts/agent/templates/rolebinding.yaml
+++ b/charts/agent/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "agent.fullname" .}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "agent.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/agent/tests/role_test.yaml
+++ b/charts/agent/tests/role_test.yaml
@@ -37,3 +37,15 @@ tests:
             name: RELEASE-NAME-agent
             namespace: NAMESPACE
     template: templates/rolebinding.yaml
+
+  - it: Role and RoleBinding are not created when rbac.create is set to false
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/role.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/rolebinding.yaml

--- a/charts/agent/tests/role_test.yaml
+++ b/charts/agent/tests/role_test.yaml
@@ -1,0 +1,39 @@
+suite: Agent Role Tests
+templates:
+  - templates/role.yaml
+  - templates/rolebinding.yaml
+tests:
+  - it: Role and RoleBinding created when rbac.create is set
+    set:
+      rbac:
+        create: true
+    asserts:
+      - containsDocument:
+          name: RELEASE-NAME-agent
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+        template: templates/role.yaml
+      - containsDocument:
+          name:  RELEASE-NAME-agent
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+        template: templates/rolebinding.yaml
+
+  - it: RoleBinding linked with Role and ServiceAccount
+    set:
+      rbac:
+        create: true
+    asserts:
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: RELEASE-NAME-agent
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: RELEASE-NAME-agent
+            namespace: NAMESPACE
+    template: templates/rolebinding.yaml

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,8 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.6.16
-
+version: 1.7.0
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com
@@ -21,7 +20,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.6.10
+    version: ~1.7.0
     alias: agent
     condition: agent.enabled
   - name: node-analyzer


### PR DESCRIPTION
## What this PR does / why we need it:
The lease permissions had been defined in the ClusterRole, but that was too permissive. This change creates a new Role and RoleBinding for the lease permissions so that they are scoped to the Agent's namespace.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix