### PR TITLE
fix(agent,sysdig): do not mount /var/lib when GKE autopilot is enabled

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.7.0
+version: 1.7.1
 
 appVersion: 12.13.0
 

--- a/charts/agent/templates/NOTES.txt
+++ b/charts/agent/templates/NOTES.txt
@@ -6,6 +6,17 @@ Links for your deployment:
   * Sysdig Monitor: https://{{ include "monitorUrl" . }}/#/dashboard-template/view.sysdig.agents?last=10
   * Sysdig Secure: https://{{ include "secureUrl" . }}/#/data-sources/agents
 
+{{- if include "agent.gke.autopilot" . }}
+    {{- if hasKey .Values.sysdig.settings "drift_killer" }}
+        {{- if hasKey .Values.sysdig.settings.drift_killer "enabled" }}
+            {{- if .Values.sysdig.settings.drift_killer.enabled }}
+
+The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
 {{- $secureFeatProvided := false }}
 {{- if hasKey .Values.sysdig.settings "feature" }}
     {{- if hasKey .Values.sysdig.settings.feature "mode" }}

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -425,6 +425,9 @@ agent config to prevent a backend push from enabling them after installation.
             {{- $_ := set $secureConfig $secureFeature (dict "enabled" false) }}
         {{- end }}
     {{- end }}
+    {{- if include "agent.gke.autopilot" . }}
+        {{- $_ := set $secureConfig "drift_killer" (dict "enabled" false) }}
+    {{- end }}
 {{ toYaml $secureConfig }}
 {{- end }}
 

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -225,8 +225,10 @@ spec:
               name: run-vol
             - mountPath: /host/var/run
               name: varrun-vol
+            {{- if not (include "agent.gke.autopilot" .) }}
             - mountPath: /host/var/lib
               name: varlib-vol
+            {{- end }}
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -283,9 +285,11 @@ spec:
         - name: varrun-vol
           hostPath:
             path: /var/run
+        {{- if not (include "agent.gke.autopilot" .) }}
         - name: varlib-vol
           hostPath:
             path: /var/lib
+        {{- end }}
         {{- if (and (or (include "agent.ebpfEnabled" .) (include "agent.gke.autopilot" .)) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -123,8 +123,10 @@ spec:
               name: run-vol
             - mountPath: /host/var/run
               name: varrun-vol
+            {{- if not (include "agent.gke.autopilot" .) }}
             - mountPath: /host/var/lib
               name: varlib-vol
+            {{- end}}
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -188,10 +190,12 @@ spec:
             path: /var/run
             type: ""
           name: varrun-vol
+        {{- if not (include "agent.gke.autopilot" .) }}
         - hostPath:
             path: /var/lib
             type: ""
           name: varlib-vol
+        {{- end }}
         {{- if .Values.extraVolumes.volumes }}
 {{ toYaml .Values.extraVolumes.volumes | indent 8 }}
         {{- end }}

--- a/charts/agent/tests/notes_test.yaml
+++ b/charts/agent/tests/notes_test.yaml
@@ -72,3 +72,30 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "raw: global.sysdig.region=ap3 provided is not recognized."
+
+  - it: Test "drift_killer" feature message is visible when enabled and we run in GKE with autopilot enabled
+    set:
+      sysdig:
+        settings:
+          drift_killer:
+            enabled: true
+      gke:
+        autopilot: true
+    asserts:
+      - matchRegexRaw:
+          pattern: |-
+            The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
+    template: templates/NOTES.txt
+  - it: Test "drift_killer" feature is not enabled when run with gke.autopilot=false
+    set:
+      sysdig:
+        settings:
+          drift_killer:
+            enabled: true
+      gke:
+        autopilot: false
+    asserts:
+      - notMatchRegexRaw:
+          pattern: |-
+            The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
+    template: templates/NOTES.txt

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.7.1
+version: 1.7.2
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com

--- a/charts/sysdig-deploy/templates/NOTES.txt
+++ b/charts/sysdig-deploy/templates/NOTES.txt
@@ -10,6 +10,17 @@ Links for your deployment:
 Usage of global tags will override any local tags you might be using.
 {{- end }}
 
+{{- if (or .Values.agent.gke.autopilot .Values.global.gke.autopilot) }}
+    {{- if hasKey .Values.agent.sysdig.settings "drift_killer" }}
+        {{- if hasKey .Values.agent.sysdig.settings.drift_killer "enabled" }}
+            {{- if .Values.agent.sysdig.settings.drift_killer.enabled }}
+
+The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
 {{- $agentSecureFeatProvided := false }}
 {{- if hasKey .Values.agent.sysdig.settings "feature" }}
     {{- if hasKey .Values.agent.sysdig.settings.feature "mode" }}

--- a/charts/sysdig-deploy/tests/notes_test.yaml
+++ b/charts/sysdig-deploy/tests/notes_test.yaml
@@ -140,3 +140,32 @@ tests:
             secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled
             when running the Agent in secure or secure_light modes.
     template: templates/NOTES.txt
+
+  - it: Test "drift_killer" feature message is visible when enabled and we run in GKE with autopilot enabled
+    set:
+      agent:
+        sysdig:
+          settings:
+            drift_killer:
+              enabled: true
+        gke:
+          autopilot: true
+    asserts:
+      - matchRegexRaw:
+          pattern: |-
+            The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
+    template: templates/NOTES.txt
+  - it: Test "drift_killer" feature is not enabled when run with gke.autopilot=false
+    set:
+      agent:
+        sysdig:
+          settings:
+            drift_killer:
+              enabled: true
+        gke:
+          autopilot: false
+    asserts:
+      - notMatchRegexRaw:
+          pattern: |-
+            The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
+    template: templates/NOTES.txt

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.83
+version: 1.15.84
 appVersion: 12.13.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/templates/daemonset.yaml
+++ b/charts/sysdig/templates/daemonset.yaml
@@ -224,8 +224,10 @@ spec:
               name: run-vol
             - mountPath: /host/var/run
               name: varrun-vol
+            {{- if not .Values.gke.autopilot }}
             - mountPath: /host/var/lib
               name: varlib-vol
+            {{- end }}
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -286,9 +288,11 @@ spec:
         - name: varrun-vol
           hostPath:
             path: /var/run
+        {{- if not .Values.gke.autopilot }}
         - name: varlib-vol
           hostPath:
             path: /var/lib
+        {{- end }}
         {{- if (and (or .Values.ebpf.enabled .Values.gke.autopilot) .Values.slim.enabled) }}
         - name: bpf-probes
           emptyDir: {}

--- a/charts/sysdig/tests/volumes_test.yaml
+++ b/charts/sysdig/tests/volumes_test.yaml
@@ -33,15 +33,3 @@ tests:
       - isNull:
           path: spec.template.spec.volumes[?(@.name == "varlib-vol")]
         template: templates/daemonset.yaml
-  - it: Ensure /var/lib host volume is not mounted as /host/var/lib in container when running on global.gke.autopilot
-    set:
-      global:
-        gke:
-          autopilot: true
-    asserts:
-      - isNull:
-          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "varlib-vol")]
-        template: templates/daemonset.yaml
-      - isNull:
-          path: spec.template.spec.volumes[?(@.name == "varlib-vol")]
-        template: templates/daemonset.yaml


### PR DESCRIPTION
## What this PR does / why we need it:

Disable the host /var/lib folder to be shared into container for GKE cluster when autopilot feature is enabled.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix