### PR TITLE
fix(sysdig-deploy): nil pointer evaluating interface {}.autopilot

### DIFF
--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.7.3
+version: 1.7.4
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com

--- a/charts/sysdig-deploy/templates/NOTES.txt
+++ b/charts/sysdig-deploy/templates/NOTES.txt
@@ -11,27 +11,27 @@ Usage of global tags will override any local tags you might be using.
 {{- end }}
 
 {{- if .Values.agent.enabled }}
-{{- if (or .Values.agent.gke.autopilot .Values.global.gke.autopilot) }}
-    {{- if hasKey .Values.agent.sysdig.settings "drift_killer" }}
-        {{- if hasKey .Values.agent.sysdig.settings.drift_killer "enabled" }}
-            {{- if .Values.agent.sysdig.settings.drift_killer.enabled }}
+    {{- if (or .Values.agent.gke.autopilot .Values.global.gke.autopilot) }}
+        {{- if hasKey .Values.agent.sysdig.settings "drift_killer" }}
+            {{- if hasKey .Values.agent.sysdig.settings.drift_killer "enabled" }}
+                {{- if .Values.agent.sysdig.settings.drift_killer.enabled }}
 
 The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
+                {{- end }}
             {{- end }}
         {{- end }}
     {{- end }}
-{{- end }}
 
-{{- $agentSecureFeatProvided := false }}
-{{- if hasKey .Values.agent.sysdig.settings "feature" }}
-    {{- if hasKey .Values.agent.sysdig.settings.feature "mode" }}
-        {{- $secureLight := (eq .Values.agent.sysdig.settings.feature.mode "secure_light") }}
-        {{- $agentSecureFeatProvided = (or $secureLight (eq .Values.agent.sysdig.settings.feature.mode "secure")) }}
+    {{- $agentSecureFeatProvided := false }}
+    {{- if hasKey .Values.agent.sysdig.settings "feature" }}
+        {{- if hasKey .Values.agent.sysdig.settings.feature "mode" }}
+            {{- $secureLight := (eq .Values.agent.sysdig.settings.feature.mode "secure_light") }}
+            {{- $agentSecureFeatProvided = (or $secureLight (eq .Values.agent.sysdig.settings.feature.mode "secure")) }}
+        {{- end }}
     {{- end }}
-{{- end }}
-{{ if and .Values.agent.monitor.enabled $agentSecureFeatProvided }}
+    {{ if and .Values.agent.monitor.enabled $agentSecureFeatProvided }}
 The agent.monitor.enabled parameter is true while using agent.sysdig.settings.feature.mode to put the Agent into either
 secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled
 when running the Agent in secure or secure_light modes.
-{{ end }}
+    {{ end }}
 {{ end }}

--- a/charts/sysdig-deploy/templates/NOTES.txt
+++ b/charts/sysdig-deploy/templates/NOTES.txt
@@ -10,6 +10,7 @@ Links for your deployment:
 Usage of global tags will override any local tags you might be using.
 {{- end }}
 
+{{- if .Values.agent.enabled }}
 {{- if (or .Values.agent.gke.autopilot .Values.global.gke.autopilot) }}
     {{- if hasKey .Values.agent.sysdig.settings "drift_killer" }}
         {{- if hasKey .Values.agent.sysdig.settings.drift_killer "enabled" }}
@@ -32,4 +33,5 @@ The "drift_killer" feature in agent is not supported when running on GKE Autopil
 The agent.monitor.enabled parameter is true while using agent.sysdig.settings.feature.mode to put the Agent into either
 secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled
 when running the Agent in secure or secure_light modes.
+{{ end }}
 {{ end }}

--- a/charts/sysdig-deploy/tests/notes_test.yaml
+++ b/charts/sysdig-deploy/tests/notes_test.yaml
@@ -73,6 +73,14 @@ tests:
       - failedTemplate:
           errorMessage: "raw: global.sysdig.region=ap3 provided is not recognized."
 
+  - it: Notes should not fail if the agent is not enabled.
+    set:
+      agent:
+        enabled: false
+    asserts:
+      - notFailedTemplate:
+          errorMessage: "nil pointer evaluating interface {}.autopilot"
+
   - it: Test agent.monitor.enabled when specifying Agent secure_light mode
     set:
       agent:
@@ -88,7 +96,6 @@ tests:
             The agent.monitor.enabled parameter is true while using agent.sysdig.settings.feature.mode to put the Agent into either
             secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled
             when running the Agent in secure or secure_light modes.
-    template: templates/NOTES.txt
 
   - it: Test agent.monitor.enabled=false when specifying Agent secure_light mode
     set:
@@ -105,7 +112,6 @@ tests:
             The agent.monitor.enabled parameter is true while using agent.sysdig.settings.feature.mode to put the Agent into either
             secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled
             when running the Agent in secure or secure_light modes.
-    template: templates/NOTES.txt
 
   - it: Test agent.monitor.enabled when specifying Agent secure mode
     set:
@@ -122,7 +128,6 @@ tests:
             The agent.monitor.enabled parameter is true while using agent.sysdig.settings.feature.mode to put the Agent into either
             secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled
             when running the Agent in secure or secure_light modes.
-    template: templates/NOTES.txt
 
   - it: Test agent.monitor.enabled=false when specifying Agent secure mode
     set:
@@ -139,7 +144,6 @@ tests:
             The agent.monitor.enabled parameter is true while using agent.sysdig.settings.feature.mode to put the Agent into either
             secure or secure_light mode. Please set agent.monitor.enabled=false to ensure all Sysdig Monitor components are disabled
             when running the Agent in secure or secure_light modes.
-    template: templates/NOTES.txt
 
   - it: Test "drift_killer" feature message is visible when enabled and we run in GKE with autopilot enabled
     set:
@@ -154,7 +158,6 @@ tests:
       - matchRegexRaw:
           pattern: |-
             The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
-    template: templates/NOTES.txt
   - it: Test "drift_killer" feature is not enabled when run with gke.autopilot=false
     set:
       agent:
@@ -168,4 +171,3 @@ tests:
       - notMatchRegexRaw:
           pattern: |-
             The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
-    template: templates/NOTES.txt


### PR DESCRIPTION
## What this PR does / why we need it:

When trying to deploy for example just the admission controller via `sysdig-deploy` with `agent.enabled` set to false, it fails with the following error message:
```
helm upgrade --install sysdig -f eks.yaml sysdig/sysdig-deploy
Error: UPGRADE FAILED: template: sysdig-deploy/templates/NOTES.txt:13:18: executing "sysdig-deploy/templates/NOTES.txt" at <.Values.agent.gke.autopilot>: nil pointer evaluating interface {}.autopilot
```

Sample config:
```
global:
  clusterConfig:
    name: "eks-test"
  sysdig:
    accessKey: "KEY"
    region: "us2"
    secureAPIToken: "TOKEN"
  kspm:
    deploy: false
  
agent:
  enabled: false

nodeAnalyzer:
  enabled: false

admissionController:
  enabled: true
  scanner:
    enabled: false
```

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
