### PR TITLE
feat(cluster-scanner): added basic tests

### DIFF
--- a/.github/workflows/helm-unit-test.yaml
+++ b/.github/workflows/helm-unit-test.yaml
@@ -64,3 +64,6 @@ jobs:
 
       - name: Test sysdig-stackdriver-bridge
         run: helm unittest --strict ./charts/sysdig-stackdriver-bridge
+
+      - name: Test cluster-scanner
+        run: helm unittest --strict ./charts/cluster-scanner

--- a/charts/cluster-scanner/templates/_helpers.tpl
+++ b/charts/cluster-scanner/templates/_helpers.tpl
@@ -61,6 +61,10 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{- define "cluster-scanner.namespace" -}}
+{{ required "speficy a release namespace" .Release.Namespace }}
+{{- end }}
+
 {{/*
 Generates configmap data for mode-specific values
 */}}

--- a/charts/cluster-scanner/templates/configmap.yaml
+++ b/charts/cluster-scanner/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "cluster-scanner.fullname" . }}
+  namespace: {{ include "cluster-scanner.namespace" . }}
   labels:
    {{- include "cluster-scanner.labels" . | nindent 4 }}
 data:

--- a/charts/cluster-scanner/templates/deployment.yaml
+++ b/charts/cluster-scanner/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cluster-scanner.fullname" . }}
+  namespace: {{ include "cluster-scanner.namespace" . }}
   labels:
    {{- include "cluster-scanner.labels" . | nindent 4 }}
 spec:

--- a/charts/cluster-scanner/templates/secret.yaml
+++ b/charts/cluster-scanner/templates/secret.yaml
@@ -2,10 +2,13 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "cluster-scanner.fullname" . }}
+  namespace: {{ include "cluster-scanner.namespace" . }}
   labels:
     {{- include "cluster-scanner.labels" . | nindent 4 }}
 type: Opaque
 data:
   sysdig_access_key: {{ required "please provide a sysdig access key" .Values.global.sysdigAccessKey | b64enc | quote }}
   js_server_password: {{ .Values.js.password | default (randAlphaNum 32) | b64enc | quote }}
+{{- if .Values.cache.redis }}
   cache_redis_password: {{ .Values.cache.redis.password | b64enc | quote }}
+{{- end }}

--- a/charts/cluster-scanner/templates/service.yaml
+++ b/charts/cluster-scanner/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cluster-scanner.fullname" . }}
+  namespace: {{ include "cluster-scanner.namespace" . }}
   labels:
     {{- include "cluster-scanner.labels" . | nindent 4 }}
 spec:

--- a/charts/cluster-scanner/templates/serviceaccount.yaml
+++ b/charts/cluster-scanner/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "cluster-scanner.serviceAccountName" . }}
+  namespace: {{ include "cluster-scanner.namespace" . }}
   labels:
     {{- include "cluster-scanner.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/cluster-scanner/tests/configmap_test.yaml
+++ b/charts/cluster-scanner/tests/configmap_test.yaml
@@ -1,0 +1,98 @@
+suite: configmap
+templates:
+  - ../templates/configmap.yaml
+values:
+  - ../values.yaml
+release:
+  name: test-release
+  namespace: test-ns
+
+tests:
+  - it: "is a configmap with the has correct name"
+    templates:
+      - ../templates/configmap.yaml
+    set:
+      global.sysdigHost: "http://test.com"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-release-cluster-scanner
+      - equal:
+          path: metadata.namespace
+          value: test-ns
+
+  - it: "has correct content"
+    templates:
+      - ../templates/configmap.yaml
+    set:
+      global.sysdigHost: "http://test.com"
+    asserts:
+      - equal:
+          path: data.sysdig_host
+          value: "http://test.com"
+      - equal:
+          path: data.root_namespace
+          value: kube-system
+      - equal:
+          path: data.eve_enabled
+          value: "false"
+      - equal:
+          path: data.eve_integration_enabled
+          value: "false"
+      - equal:
+          path: data.logging_level
+          value: "INFO"
+      - not: true
+        isEmpty:
+          path: data.js_server_user
+      - not: true
+        isEmpty:
+          path: data.js_server_url
+      - equal:
+          path: data.rsi_leaderelection_lock_name
+          value: test-release-cluster-scanner
+      - equal:
+          path: data.rsi_leaderelection_lock_namespace
+          value: test-ns
+      - equal:
+          path: data.rsi_service_name
+          value: test-release-cluster-scanner
+      - equal:
+          path: data.ise_cache_type
+          value: local
+      - equal:
+          path: data.ise_cache_prefix
+          value: sysdig-cluster-scanner
+
+  - it: "has local mode as default"
+    templates:
+      - ../templates/configmap.yaml
+    set:
+      global.sysdigHost: "http://test.com"
+    asserts:
+      - equal:
+          path: data.rsi_mode
+          value: "sitting"
+
+  - it: "can set multi mod"
+    templates:
+      - ../templates/configmap.yaml
+    set:
+      global.sysdigHost: "http://test.com"
+      global.scannerMode: "multi"
+    asserts:
+      - equal:
+          path: data.rsi_mode
+          value: "mcm"
+
+  - it: "raise error on unknown mod"
+    templates:
+      - ../templates/configmap.yaml
+    set:
+      global.sysdigHost: "http://test.com"
+      global.scannerMode: "foobar"
+    asserts:
+      - failedTemplate:
+          errorMessage: "invalid scannerMode, accepted options [local, multi]"

--- a/charts/cluster-scanner/tests/configmap_test.yaml
+++ b/charts/cluster-scanner/tests/configmap_test.yaml
@@ -9,8 +9,6 @@ release:
 
 tests:
   - it: "is a configmap with the has correct name"
-    templates:
-      - ../templates/configmap.yaml
     set:
       global.sysdigHost: "http://test.com"
     asserts:
@@ -24,8 +22,6 @@ tests:
           value: test-ns
 
   - it: "has correct content"
-    templates:
-      - ../templates/configmap.yaml
     set:
       global.sysdigHost: "http://test.com"
     asserts:
@@ -67,8 +63,6 @@ tests:
           value: sysdig-cluster-scanner
 
   - it: "has local mode as default"
-    templates:
-      - ../templates/configmap.yaml
     set:
       global.sysdigHost: "http://test.com"
     asserts:
@@ -77,8 +71,6 @@ tests:
           value: "sitting"
 
   - it: "can set multi mod"
-    templates:
-      - ../templates/configmap.yaml
     set:
       global.sysdigHost: "http://test.com"
       global.scannerMode: "multi"
@@ -88,8 +80,6 @@ tests:
           value: "mcm"
 
   - it: "raise error on unknown mod"
-    templates:
-      - ../templates/configmap.yaml
     set:
       global.sysdigHost: "http://test.com"
       global.scannerMode: "foobar"

--- a/charts/cluster-scanner/tests/deployment_test.yaml
+++ b/charts/cluster-scanner/tests/deployment_test.yaml
@@ -9,15 +9,11 @@ release:
 
 tests:
   - it: "generates a deployment resource"
-    templates:
-      - ../templates/deployment.yaml
     asserts:
       - isKind:
           of: Deployment
 
   - it: "has correct name and namespace"
-    templates:
-      - ../templates/deployment.yaml
     asserts:
       - equal:
           path: metadata.name
@@ -27,8 +23,6 @@ tests:
           value: test-ns
 
   - it: "sets replicas"
-    templates:
-      - ../templates/deployment.yaml
     set:
       replicaCount: 42
     asserts:
@@ -37,8 +31,6 @@ tests:
           value: 42
 
   - it: "has RSI and ISE containers"
-    templates:
-      - ../templates/deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].name
@@ -48,8 +40,6 @@ tests:
           value: ise
 
   - it: "has non empty default image"
-    templates:
-      - ../templates/deployment.yaml
     asserts:
       - not: true
         isEmpty:
@@ -59,8 +49,6 @@ tests:
           path: spec.template.spec.containers[1].image
 
   - it: "sets tag and repository"
-    templates:
-      - ../templates/deployment.yaml
     set:
       rsi.image.repository: test.com/repo
       rsi.image.tag: rsi
@@ -75,8 +63,6 @@ tests:
           value: test.com/repo:ise
 
   - it: "sets kubeconfig env var if set"
-    templates:
-      - ../templates/deployment.yaml
     set:
       global.scannerMode: "multi"
       multicluster.kubeconfigSecretName: "my-secret"

--- a/charts/cluster-scanner/tests/deployment_test.yaml
+++ b/charts/cluster-scanner/tests/deployment_test.yaml
@@ -1,0 +1,94 @@
+suite: deployment
+templates:
+  - ../templates/deployment.yaml
+values:
+  - ../values.yaml
+release:
+  name: test-release
+  namespace: test-ns
+
+tests:
+  - it: "generates a deployment resource"
+    templates:
+      - ../templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+
+  - it: "has correct name and namespace"
+    templates:
+      - ../templates/deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-release-cluster-scanner
+      - equal:
+          path: metadata.namespace
+          value: test-ns
+
+  - it: "sets replicas"
+    templates:
+      - ../templates/deployment.yaml
+    set:
+      replicaCount: 42
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 42
+
+  - it: "has RSI and ISE containers"
+    templates:
+      - ../templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: rsi
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: ise
+
+  - it: "has non empty default image"
+    templates:
+      - ../templates/deployment.yaml
+    asserts:
+      - not: true
+        isEmpty:
+          path: spec.template.spec.containers[0].image
+      - not: true
+        isEmpty:
+          path: spec.template.spec.containers[1].image
+
+  - it: "sets tag and repository"
+    templates:
+      - ../templates/deployment.yaml
+    set:
+      rsi.image.repository: test.com/repo
+      rsi.image.tag: rsi
+      ise.image.repository: test.com/repo
+      ise.image.tag: ise
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: test.com/repo:rsi
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: test.com/repo:ise
+
+  - it: "sets kubeconfig env var if set"
+    templates:
+      - ../templates/deployment.yaml
+    set:
+      global.scannerMode: "multi"
+      multicluster.kubeconfigSecretName: "my-secret"
+    asserts:
+      - not: true
+        isEmpty:
+          path: spec.template.spec.containers[0].env[8]
+      - isSubset:
+          path: spec.template.spec.containers[0].env[8]
+          content:
+            name: SYSDIG_KUBECONFIG_CONTENT
+            valueFrom:
+              secretKeyRef:
+                name: "my-secret"
+                key: .kubeconfig

--- a/charts/cluster-scanner/tests/secret_test.yaml
+++ b/charts/cluster-scanner/tests/secret_test.yaml
@@ -9,8 +9,6 @@ release:
 
 tests:
   - it: "has correct name and namespace"
-    templates:
-      - ../templates/secret.yaml
     set:
       global.sysdigAccessKey: "secret"
     asserts:
@@ -22,8 +20,6 @@ tests:
           value: test-ns
 
   - it: "generates a secret resource"
-    templates:
-      - ../templates/secret.yaml
     set:
       global.sysdigAccessKey: "secret"
     asserts:
@@ -31,15 +27,11 @@ tests:
           of: Secret
 
   - it: "requires access key"
-    templates:
-      - ../templates/secret.yaml
     asserts:
       - failedTemplate:
           errorMessage: "please provide a sysdig access key"
 
   - it: "has correct default content"
-    templates:
-      - ../templates/secret.yaml
     set:
       global.sysdigAccessKey: "secret"
     asserts:
@@ -49,12 +41,10 @@ tests:
       - not: true
         isEmpty:
           path: data.js_server_password
-      - isEmpty:
+      - isNull:
           path: data.cache_redis_password
 
   - it: "fills cache redis password, when set"
-    templates:
-      - ../templates/secret.yaml
     set:
       global.sysdigAccessKey: "secret"
       cache.redis.password: "secret"

--- a/charts/cluster-scanner/tests/secret_test.yaml
+++ b/charts/cluster-scanner/tests/secret_test.yaml
@@ -1,0 +1,64 @@
+suite: secret
+templates:
+  - ../templates/secret.yaml
+values:
+  - ../values.yaml
+release:
+  name: test-release
+  namespace: test-ns
+
+tests:
+  - it: "has correct name and namespace"
+    templates:
+      - ../templates/secret.yaml
+    set:
+      global.sysdigAccessKey: "secret"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-release-cluster-scanner
+      - equal:
+          path: metadata.namespace
+          value: test-ns
+
+  - it: "generates a secret resource"
+    templates:
+      - ../templates/secret.yaml
+    set:
+      global.sysdigAccessKey: "secret"
+    asserts:
+      - isKind:
+          of: Secret
+
+  - it: "requires access key"
+    templates:
+      - ../templates/secret.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "please provide a sysdig access key"
+
+  - it: "has correct default content"
+    templates:
+      - ../templates/secret.yaml
+    set:
+      global.sysdigAccessKey: "secret"
+    asserts:
+      - equal:
+          path: data.sysdig_access_key
+          value: "c2VjcmV0"
+      - not: true
+        isEmpty:
+          path: data.js_server_password
+      - isEmpty:
+          path: data.cache_redis_password
+
+  - it: "fills cache redis password, when set"
+    templates:
+      - ../templates/secret.yaml
+    set:
+      global.sysdigAccessKey: "secret"
+      cache.redis.password: "secret"
+    asserts:
+      - equal:
+          path: data.cache_redis_password
+          value: "c2VjcmV0"

--- a/charts/cluster-scanner/tests/service_test.yaml
+++ b/charts/cluster-scanner/tests/service_test.yaml
@@ -1,0 +1,36 @@
+suite: service
+templates:
+  - ../templates/service.yaml
+values:
+  - ../values.yaml
+release:
+  name: test-release
+  namespace: test-ns
+
+tests:
+  - it: "has not selector"
+    templates:
+      - ../templates/service.yaml
+    asserts:
+      - isEmpty:
+          path: spec.selector
+
+  - it: "has correct name and namespace"
+    templates:
+      - ../templates/service.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-release-cluster-scanner
+      - equal:
+          path: metadata.namespace
+          value: test-ns
+
+  - it: "generates a service resource"
+    templates:
+      - ../templates/service.yaml
+    set:
+      global.sysdigAccessKey: "secret"
+    asserts:
+      - isKind:
+          of: Service

--- a/charts/cluster-scanner/tests/service_test.yaml
+++ b/charts/cluster-scanner/tests/service_test.yaml
@@ -9,15 +9,11 @@ release:
 
 tests:
   - it: "has not selector"
-    templates:
-      - ../templates/service.yaml
     asserts:
-      - isEmpty:
+      - isNull:
           path: spec.selector
 
   - it: "has correct name and namespace"
-    templates:
-      - ../templates/service.yaml
     asserts:
       - equal:
           path: metadata.name
@@ -27,8 +23,6 @@ tests:
           value: test-ns
 
   - it: "generates a service resource"
-    templates:
-      - ../templates/service.yaml
     set:
       global.sysdigAccessKey: "secret"
     asserts:

--- a/charts/cluster-scanner/tests/serviceaccount_test.yaml
+++ b/charts/cluster-scanner/tests/serviceaccount_test.yaml
@@ -9,8 +9,6 @@ release:
 
 tests:
   - it: "has correct name and namespace"
-    templates:
-      - ../templates/serviceaccount.yaml
     asserts:
       - equal:
           path: metadata.name
@@ -20,8 +18,6 @@ tests:
           value: test-ns
 
   - it: "generates a serviceaccount resource"
-    templates:
-      - ../templates/serviceaccount.yaml
     set:
       global.sysdigAccessKey: "secret"
     asserts:

--- a/charts/cluster-scanner/tests/serviceaccount_test.yaml
+++ b/charts/cluster-scanner/tests/serviceaccount_test.yaml
@@ -1,0 +1,29 @@
+suite: serviceaccount
+templates:
+  - ../templates/serviceaccount.yaml
+values:
+  - ../values.yaml
+release:
+  name: test-release
+  namespace: test-ns
+
+tests:
+  - it: "has correct name and namespace"
+    templates:
+      - ../templates/serviceaccount.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-release-cluster-scanner
+      - equal:
+          path: metadata.namespace
+          value: test-ns
+
+  - it: "generates a serviceaccount resource"
+    templates:
+      - ../templates/serviceaccount.yaml
+    set:
+      global.sysdigAccessKey: "secret"
+    asserts:
+      - isKind:
+          of: ServiceAccount


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix
