### PR TITLE
fix(agent): Adjust features available in secure_light mode

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.7.1
+version: 1.7.2
 
 appVersion: 12.13.0
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -414,7 +414,7 @@ agent config to prevent a backend push from enabling them after installation.
             {{- end }}
         {{- end }}
     {{- end }}
-    {{- if or (not .Values.secure.enabled) (and .Values.secure.enabled $secureLightMode) }}
+    {{- if (not .Values.secure.enabled) }}
         {{- range $secureFeature := (list
             "commandlines_capture"
             "drift_killer"
@@ -422,6 +422,14 @@ agent config to prevent a backend push from enabling them after installation.
             "memdump"
             "network_topology"
             "secure_audit_streams") }}
+            {{- $_ := set $secureConfig $secureFeature (dict "enabled" false) }}
+        {{- end }}
+    {{ else if $secureLightMode }}
+        {{- range $secureFeature := (list
+            "drift_killer"
+            "falcobaseline"
+            "memdump"
+            "network_topology") }}
             {{- $_ := set $secureConfig $secureFeature (dict "enabled" false) }}
         {{- end }}
     {{- end }}

--- a/charts/agent/tests/secure_enable_test.yaml
+++ b/charts/agent/tests/secure_enable_test.yaml
@@ -91,13 +91,30 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: 'app_checks_enabled: false\njmx:\n {2}enabled: false\nprometheus:\n {2}enabled: false\nstatsd:\n {2}enabled: false'
+          pattern: |-
+            app_checks_enabled: false
+            jmx:
+              enabled: false
+            prometheus:
+              enabled: false
+            statsd:
+              enabled: false
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: 'security:\n {2}enabled: true'
+          pattern: |-
+            security:
+              enabled: true
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: 'commandlines_capture:\n\ {2}enabled:\ false\ndrift_killer:\n\ {2}enabled:\ false\nfalcobaseline:\n {2}enabled:\ false\nmemdump:\n\ {2}enabled:\ false\nnetwork_topology:\n\ {2}enabled:\ false\nsecure_audit_streams:\n\ {2}enabled:\ false'
+          pattern: |-
+            drift_killer:
+              enabled: false
+            falcobaseline:
+              enabled: false
+            memdump:
+              enabled: false
+            network_topology:
+              enabled: false
 
   - it: Test secure.enabled=false when specifying secure_light mode
     set:

--- a/charts/agent/tests/secure_enable_test.yaml
+++ b/charts/agent/tests/secure_enable_test.yaml
@@ -156,6 +156,16 @@ tests:
           pattern: |-
             network_topology:
               enabled: false
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            commandlines_capture:
+              enabled: false
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            secure_audit_streams:
+              enabled: false
 
   - it: Test secure.enabled=false when specifying secure_light mode
     set:

--- a/charts/agent/tests/secure_enable_test.yaml
+++ b/charts/agent/tests/secure_enable_test.yaml
@@ -8,7 +8,9 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*(?:security:\n {2}enabled:\s*true).*
+          pattern: |-
+            security:
+              enabled: true
 
   - it: Set secure.enabled=true
     set:
@@ -19,7 +21,9 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*(?:security:\n {2}enabled:\s*true).*
+          pattern: |-
+            security:
+              enabled: true
 
   - it: Set secure.enabled=false
     set:
@@ -30,25 +34,39 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*(?:security:\n {2}enabled:\s*false).*
+          pattern: |-
+            security:
+              enabled: false
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: commandlines_capture:\n\ {2}enabled:\ false
+          pattern: |-
+            commandlines_capture:
+              enabled: false
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: drift_killer:\n\ {2}enabled:\ false
+          pattern: |-
+            drift_killer:
+              enabled: false
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: falcobaseline:\n {2}enabled:\ false
+          pattern: |-
+            falcobaseline:
+              enabled: false
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: memdump:\n\ {2}enabled:\ false
+          pattern: |-
+            memdump:
+              enabled: false
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: network_topology:\n\ {2}enabled:\ false
+          pattern: |-
+            network_topology:
+              enabled: false
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: secure_audit_streams:\n\ {2}enabled:\ false
+          pattern: |-
+            secure_audit_streams:
+              enabled: false
 
   - it: Set secure.enabled=true and auditLog.enabled=true
     set:
@@ -61,7 +79,12 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: security:\n\ {2}enabled:\ true\n\ {2}k8s_audit_server_enabled:\ true\n\ {2}k8s_audit_server_port:\ 7765\n\ {2}k8s_audit_server_url:\ 0\.0\.0\.0
+          pattern: |-
+            security:
+              enabled: true
+              k8s_audit_server_enabled: true
+              k8s_audit_server_port: 7765
+              k8s_audit_server_url: 0.0.0.0
 
   - it: Set secure.enabled=false and auditLog.enabled=true
     set:
@@ -93,12 +116,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |-
             app_checks_enabled: false
-            jmx:
-              enabled: false
-            prometheus:
-              enabled: false
-            statsd:
-              enabled: false
       - matchRegex:
           path: data['dragent.yaml']
           pattern: |-
@@ -107,12 +124,36 @@ tests:
       - matchRegex:
           path: data['dragent.yaml']
           pattern: |-
+            jmx:
+              enabled: false
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            prometheus:
+              enabled: false
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            statsd:
+              enabled: false
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
             drift_killer:
               enabled: false
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
             falcobaseline:
               enabled: false
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
             memdump:
               enabled: false
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
             network_topology:
               enabled: false
 


### PR DESCRIPTION
## What this PR does / why we need it:
Previously commandlines_capture and secure_audit_streams had been disabled in the Agent ConfigMap if secure_light mode was specified. This is inconsistent with the features that are allowable in secure_light mode and thus resulted in undesired behavior.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix