### PR TITLE
doc(sysdig-deploy): Update Sysdig Deploy README to match new docs.sysdig.com content

### DIFF
--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.7.6
+version: 1.7.7
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -1,6 +1,6 @@
 # Sysdig Deploy
 
-Use the sysdig-deploy Helm chart to install Sysdig Secure and/or Sysdig Monitor in a Kubernetes environment.
+Use the `sysdig-deploy` Helm chart to install Sysdig Secure and/or Sysdig Monitor in a Kubernetes environment.
 
 ## Introduction
 

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -1,17 +1,15 @@
-# Sysdig
+# Sysdig Deploy
 
-[Sysdig](https://sysdig.com/) is a unified platform for container and microservices monitoring, troubleshooting,
-security and forensics. Sysdig platform has been built on top of [Sysdig tool](https://sysdig.com/opensource/sysdig/)
-and [Sysdig Inspect](https://sysdig.com/blog/sysdig-inspect/) open-source technologies.
+Use the sysdig-deploy Helm chart to install Sysdig Secure and/or Sysdig Monitor in a Kubernetes environment.
 
 ## Introduction
 
 This chart deploys various Sysdig components into your Kubernetes cluster.
 
 Currently included components:
-- [Sysdig agent](https://github.com/sysdiglabs/charts/tree/master/charts/agent)
-- [Sysdig NodeAnalyzer](https://github.com/sysdiglabs/charts/tree/master/charts/node-analyzer)
+- [Sysdig Agent](https://github.com/sysdiglabs/charts/tree/master/charts/agent)
 - [Sysdig KSPM Collector](https://github.com/sysdiglabs/charts/tree/master/charts/kspm-collector)
+- [Sysdig Host Scanner](https://github.com/sysdiglabs/charts/tree/master/charts/node-analyzer#host-scanner)
 - [Sysdig Rapid Response](https://github.com/sysdiglabs/charts/tree/master/charts/rapid-response)
 - [Sysdig Admission Controller](https://github.com/sysdiglabs/charts/tree/master/charts/admission-controller)
 
@@ -21,6 +19,12 @@ Currently included components:
 - Helm v3.6+
 
 ## Installation
+
+
+> **_NOTE:_** Below are the legacy instructions for installing the `sysdig-deploy` chart.
+> For more detailed installation instructions go here:
+> * [Sysdig Monitor only](https://docs.sysdig.com/en/install-kubernetes-monitor)
+> * [Sysdig Secure, or Sysdig Secure and Sysdig Monitor](https://docs.sysdig.com/en/install-kubernetes-secure)
 
 
 1. Add the Sysdig Helm repo:


### PR DESCRIPTION
## What this PR does / why we need it:
The docs.sysdig.com page has been redone and is to become the single point of truth on all installation topics.
This change makes some minor changes to fall in line with the upstream changes, as well as point readers to the
main documentation site.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.
