### PR TITLE
fix(agent): fix occasional k8s_coldstart block duplication and key name

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.7.3
+version: 1.7.4
 
 appVersion: 12.14.0
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -450,13 +450,13 @@ agent config to prevent a backend push from enabling them after installation.
     {{- end }}
     {{- if not .Values.sysdig.settings.k8s_coldstart }}
         {{- if not .Values.delegatedAgentDeployment.enabled }}
-            {{- $_ := set $k8sColdStartBlock "max_parallel_cold_starts" (include "agent.parallelStarts" . | int ) }}
+            {{- $_ := set $k8sColdStartBlock "max_parallel_cold_start" (include "agent.parallelStarts" . | int ) }}
         {{- else }}
-            {{- $_ := set $k8sColdStartBlock "max_parallel_cold_starts" 1 }}
+            {{- $_ := set $k8sColdStartBlock "max_parallel_cold_start" 1 }}
         {{- end }}
     {{- end }}
     {{- $completeBlock := dict "k8s_coldstart" $k8sColdStartBlock }}
-    {{- toYaml $completeBlock }}
+    {{- $_ := merge .Values.sysdig.settings $completeBlock }}
 {{- end }}
 
 {{ define "agent.connectionSettings" }}

--- a/charts/agent/tests/delegated_agent_deployment_test.yaml
+++ b/charts/agent/tests/delegated_agent_deployment_test.yaml
@@ -414,7 +414,7 @@ tests:
             k8s_coldstart:
               enabled: true
               enforce_leader_election: true
-              max_parallel_cold_starts: 1
+              max_parallel_cold_start: 1
               namespace: NAMESPACE
     template: templates/configmap-deployment.yaml
 
@@ -432,7 +432,7 @@ tests:
             k8s_coldstart:
               enabled: true
               enforce_leader_election: true
-              max_parallel_cold_starts: 1
+              max_parallel_cold_start: 1
               namespace: NAMESPACE
     template: templates/configmap-deployment.yaml
 

--- a/charts/agent/tests/k8s_coldstart_test.yaml
+++ b/charts/agent/tests/k8s_coldstart_test.yaml
@@ -13,7 +13,7 @@ tests:
             k8s_coldstart:
               enabled: true
               enforce_leader_election: true
-              max_parallel_cold_starts: 1
+              max_parallel_cold_start: 1
               namespace: NAMESPACE
     template: templates/configmap.yaml
 
@@ -29,6 +29,57 @@ tests:
             k8s_coldstart:
               enabled: true
               enforce_leader_election: true
-              max_parallel_cold_starts: 10
+              max_parallel_cold_start: 10
               namespace: NAMESPACE
     template: templates/configmap.yaml
+
+  - it: Test manual setting of k8s_coldstart values
+    set:
+      sysdig:
+        settings:
+          k8s_coldstart:
+            max_parallel_cold_start: 1
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            k8s_coldstart:
+              max_parallel_cold_start: 1
+
+  - it: Test manual setting of k8s_coldstart values with leaderelection set
+    set:
+      leaderelection:
+        enable: true
+      sysdig:
+        settings:
+          k8s_coldstart:
+            max_parallel_cold_start: 2
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            k8s_coldstart:
+              enabled: true
+              enforce_leader_election: true
+              max_parallel_cold_start: 2
+              namespace: NAMESPACE
+
+  - it: Test manual setting of k8s_coldstart values with leaderelection and delegatedAgentDeployment set
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      leaderelection:
+        enable: true
+      sysdig:
+        settings:
+          k8s_coldstart:
+            max_parallel_cold_start: 2
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            k8s_coldstart:
+              enabled: true
+              enforce_leader_election: true
+              max_parallel_cold_start: 2
+              namespace: NAMESPACE


### PR DESCRIPTION
## What this PR does / why we need it:
* In certain conditions when the `k8s_coldstart` parameter is manually provided
  to the agent via the `sysdig.settings` field, the top level `k8s_coldstart`
  key would be written out twice, but only one field would have the intended
  content. This fix makes the processing of the `k8s_coldstart` field consistent
  across the various conditions when it is provided and specified to ensure
  duplication no longer occurs.

* Address issues where the `max_parallel_cold_start` parameter had typos

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
