### PR TITLE
fix(cluster-scanner): PR comments

### DIFF
--- a/charts/cluster-scanner/.helmignore
+++ b/charts/cluster-scanner/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+# Unittests and CI
+ci/
+tests/

--- a/charts/cluster-scanner/Makefile
+++ b/charts/cluster-scanner/Makefile
@@ -1,3 +1,3 @@
 .PHONY: test
 test:
-	helm unittest -3 .
+	helm unittest .


### PR DESCRIPTION
## What this PR does / why we need it:

- `fix(cluster-scanner):` added `ci/` and `tests/` to `.helmignore`
- `fix(cluster-scanner):` removed unsupported helm unittests flag in Makefile

## Checklist

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
