### PR TITLE
fix(agent): Allow cointerface to be enabled in daemonset agents in delegated agent deployment

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.7.4
+version: 1.7.5
 
 appVersion: 12.14.0
 

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -11,7 +11,9 @@ data:
     new_k8s: true
 {{- include "agent.clusterName" . | trim | nindent 4 }}
 {{- if .Values.delegatedAgentDeployment.enabled }}
+  {{- if not (hasKey .Values.sysdig.settings "cointerface_enabled") }}
     cointerface_enabled: false
+  {{- end }}
 {{- end }}
 {{- include "agent.connectionSettings" . | trim | nindent 4 }}
 {{- include "agent.planSettings" . | trim | nindent 4 }}

--- a/charts/agent/tests/delegated_agent_deployment_test.yaml
+++ b/charts/agent/tests/delegated_agent_deployment_test.yaml
@@ -491,3 +491,42 @@ tests:
           content:
             serviceAccountName: RELEASE-NAME-agent
         template: templates/deployment.yaml
+
+  - it: Validate override cointerface_enabled settings
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      sysdig:
+        settings:
+          cointerface_enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: true'
+        template: templates/configmap.yaml
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: false'
+        template: templates/configmap.yaml
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: false'
+        template: templates/configmap-deployment.yaml
+
+  - it: Validate cointerface disabled normally
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: false'
+        template: templates/configmap.yaml
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: true'
+        template: templates/configmap.yaml
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: false'
+        template: templates/configmap-deployment.yaml


### PR DESCRIPTION
## What this PR does / why we need it:
There exist some use cases where having cointerface enabled on both the Deployment and DaemonSet Agents would be beneficial. This change removes the hard requirement that cointerface is disabled in the DaemonSet. Cointerface will remain disabled by default in the delegated agent deployments, but should the user specify `cointerface_enabled: true` in the agent chart's `sysdig.settings` block, cointerface will remain enabled in the DaemonSet Agents.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix
