### PR TITLE
chore(registry-scanner): orchestrator job label

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -3,3 +3,6 @@
 
 docs:
   make docs
+
+unit-test-rs:
+    make unit-test-rs

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,9 @@ unittest: deps-unittest
 		xargs -L1 dirname | \
 		xargs -I% sh -c \
 			"helm dependency build % ; helm unittest --strict %"
+
+unit-test-rs: deps-unittest
+	find ./charts/registry-scanner -name "Chart.yaml" | \
+		xargs -L1 dirname | \
+		xargs -I% sh -c \
+			"helm dependency build % ; helm unittest --strict %"

--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -11,6 +11,11 @@ exclusively to fix incorrect entries and not to add new ones.
 
 ## Change Log
 
+# v1.0.7
+* chore: adds label for orchestrator job
+* **registry-scanner**  bumped inner component to v0.2.34
+  - chore: add limits to waitgroups
+  - logs: clarify skip message and parallelization
 # v1.0.6
 * **registry-scanner**  bumped inner component to v0.2.33
   - chore: add limits to waitgroups

--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -13,9 +13,8 @@ exclusively to fix incorrect entries and not to add new ones.
 
 # v1.0.7
 * chore: adds label for orchestrator job
-* **registry-scanner**  bumped inner component to v0.2.34
-  - chore: add limits to waitgroups
-  - logs: clarify skip message and parallelization
+* **registry-scanner**  bumped inner component to v0.2.35
+  - add labels for worker job
 # v1.0.6
 * **registry-scanner**  bumped inner component to v0.2.33
   - chore: add limits to waitgroups

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,8 +4,8 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 1.0.6
-appVersion: 0.2.33
+version: 1.0.7
+appVersion: 0.2.35
 maintainers:
   - name: airadier
     email: alvaro.iradier@sysdig.com

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,8 +4,8 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 1.0.6
-appVersion: 0.2.33
+version: 1.0.7
+appVersion: 0.2.34
 maintainers:
   - name: airadier
     email: alvaro.iradier@sysdig.com

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -52,7 +52,7 @@ Deploy the registry scanner specify each parameter using the `--set key=value[,k
 
 ```bash
 $ helm upgrade --install registry-scanner \
-    --version=1.0.6 \
+    --version=1.0.7 \
     --set config.secureBaseURL=<SYSDIG_SECURE_URL> \
     --set config.secureAPIToken=<SYSDIG_SECURE_API_TOKEN> \
     --set config.registryURL=<REGISTRY_URL> \
@@ -64,7 +64,7 @@ $ helm upgrade --install registry-scanner \
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install registry-scanner -f values.yaml --version=1.0.6 sysdig/registry-scanner
+$ helm install registry-scanner -f values.yaml --version=1.0.7 sysdig/registry-scanner
 ```
 
 
@@ -173,7 +173,7 @@ Use the following command to deploy in an on-prem:
 
 ```bash
 $ helm upgrade --install registry-scanner \
-    --version=1.0.6 \
+    --version=1.0.7 \
     --set config.secureBaseURL=<SYSDIG_SECURE_URL> \
     --set config.secureAPIToken=<SYSDIG_SECURE_API_TOKEN> \
     --set config.secureSkipTLS=true \

--- a/charts/registry-scanner/templates/_helpers.tpl
+++ b/charts/registry-scanner/templates/_helpers.tpl
@@ -35,6 +35,7 @@ Common labels
 */}}
 {{- define "registry-scanner.labels" -}}
 helm.sh/chart: {{ include "registry-scanner.chart" . }}
+product-type: registry-scanner-orchestrator
 {{ include "registry-scanner.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/charts/registry-scanner/templates/_helpers.tpl
+++ b/charts/registry-scanner/templates/_helpers.tpl
@@ -35,7 +35,6 @@ Common labels
 */}}
 {{- define "registry-scanner.labels" -}}
 helm.sh/chart: {{ include "registry-scanner.chart" . }}
-product-type: registry-scanner-orchestrator
 {{ include "registry-scanner.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
@@ -47,8 +46,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "registry-scanner.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "registry-scanner.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "registry-scanner.name" . }}
+app.kubernetes.io/component: {{ include "registry-scanner.name" . }}-orchestrator
 {{- end }}
 
 {{/*

--- a/charts/registry-scanner/tests/cronjob_test.yaml
+++ b/charts/registry-scanner/tests/cronjob_test.yaml
@@ -64,3 +64,12 @@ tests:
       - equal:
           path: apiVersion
           value: batch/v1
+
+  - it: sets default labels
+    asserts:
+      - equal:
+          path: metadata.labels['product-type']
+          value: registry-scanner-orchestrator
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels['product-type']
+          value: registry-scanner-orchestrator

--- a/charts/registry-scanner/tests/cronjob_test.yaml
+++ b/charts/registry-scanner/tests/cronjob_test.yaml
@@ -68,8 +68,8 @@ tests:
   - it: sets default labels
     asserts:
       - equal:
-          path: metadata.labels['product-type']
+          path: metadata.labels['app.kubernetes.io/component']
           value: registry-scanner-orchestrator
       - equal:
-          path: spec.jobTemplate.spec.template.metadata.labels['product-type']
+          path: spec.jobTemplate.spec.template.metadata.labels['app.kubernetes.io/component']
           value: registry-scanner-orchestrator

--- a/charts/registry-scanner/tests/job_test.yaml
+++ b/charts/registry-scanner/tests/job_test.yaml
@@ -32,3 +32,14 @@ tests:
           content:
             name: FOO
             value: bar
+  - it: sets default labels
+    set:
+      scanOnStart:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels['product-type']
+          value: registry-scanner-orchestrator
+      - equal:
+          path: spec.template.metadata.labels['product-type']
+          value: registry-scanner-orchestrator

--- a/charts/registry-scanner/tests/job_test.yaml
+++ b/charts/registry-scanner/tests/job_test.yaml
@@ -38,8 +38,8 @@ tests:
         enabled: true
     asserts:
       - equal:
-          path: metadata.labels['product-type']
+          path: metadata.labels['app.kubernetes.io/component']
           value: registry-scanner-orchestrator
       - equal:
-          path: spec.template.metadata.labels['product-type']
+          path: spec.template.metadata.labels['app.kubernetes.io/component']
           value: registry-scanner-orchestrator


### PR DESCRIPTION
adds labels to orchestrator job `app.kubernetes.io/component:registry-scanner-orchestrator`
inner work jobs labels have been added pragmatically too in bumped registry-scanner version  `app.kubernetes.io/component:registry-scanner-worker`