### PR TITLE
chore(agent): add tests to better highlight the behaviour in the drift prevention feature

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.8.1
+version: 1.8.2
 
 appVersion: 12.14.0
 

--- a/charts/agent/tests/drift_prevention_test.yaml
+++ b/charts/agent/tests/drift_prevention_test.yaml
@@ -1,0 +1,94 @@
+suite: Test the drift prevention configuration
+templates:
+  - templates/configmap.yaml
+  - templates/NOTES.txt
+tests:
+  - it: Drift prevention must not be overridden by default
+    asserts:
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            drift_killer
+    template: templates/configmap.yaml
+
+  - it: Drift prevention must be false when is monitor only
+    set:
+      secure:
+        enabled: false
+      monitor:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            drift_killer:
+              enabled: false
+    template: templates/configmap.yaml
+
+  - it: Drift prevention must be false when is secure_light
+    set:
+      sysdig:
+        settings:
+          feature:
+            mode: secure_light
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            drift_killer:
+              enabled: false
+    template: templates/configmap.yaml
+
+  - it: Drift prevention must be false when is running on GKE Autopilot
+    set:
+      gke:
+        autopilot: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            drift_killer:
+              enabled: false
+    template: templates/configmap.yaml
+
+  - it: Drift prevention must be enabled when explicitally set
+    set:
+      sysdig:
+        settings:
+          drift_killer:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            drift_killer:
+              enabled: true
+    template: templates/configmap.yaml
+
+  - it: Test "drift_killer" feature message is visible when enabled and we run in GKE with autopilot enabled
+    set:
+      sysdig:
+        settings:
+          drift_killer:
+            enabled: true
+      gke:
+        autopilot: true
+    asserts:
+      - matchRegexRaw:
+          pattern: |-
+            The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
+    template: templates/NOTES.txt
+
+  - it: Test "drift_killer" feature message is not visible when run with gke.autopilot=false
+    set:
+      sysdig:
+        settings:
+          drift_killer:
+            enabled: true
+      gke:
+        autopilot: false
+    asserts:
+      - notMatchRegexRaw:
+          pattern: |-
+            The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
+    template: templates/NOTES.txt

--- a/charts/agent/tests/notes_test.yaml
+++ b/charts/agent/tests/notes_test.yaml
@@ -73,33 +73,6 @@ tests:
       - failedTemplate:
           errorMessage: "raw: global.sysdig.region=ap3 provided is not recognized."
 
-  - it: Test "drift_killer" feature message is visible when enabled and we run in GKE with autopilot enabled
-    set:
-      sysdig:
-        settings:
-          drift_killer:
-            enabled: true
-      gke:
-        autopilot: true
-    asserts:
-      - matchRegexRaw:
-          pattern: |-
-            The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
-    template: templates/NOTES.txt
-  - it: Test "drift_killer" feature is not enabled when run with gke.autopilot=false
-    set:
-      sysdig:
-        settings:
-          drift_killer:
-            enabled: true
-      gke:
-        autopilot: false
-    asserts:
-      - notMatchRegexRaw:
-          pattern: |-
-            The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
-    template: templates/NOTES.txt
-
   - it: Test warning printed for GKE Autopilot environments without PriorityClass creation or existing name specified
     set:
       gke:


### PR DESCRIPTION
## What this PR does / why we need it:

- Add tests to better indicate how the drift prevention feature should work

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix