### PR TITLE
feat(kspm-collector): Added PSP policies for KSPM Collector

### DIFF
--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.1.43
+version: 0.1.44
 appVersion: 1.22.0
 keywords:
   - monitoring

--- a/charts/kspm-collector/README.md
+++ b/charts/kspm-collector/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the Sysdig KSPM Collect
 | `affinity`                                | Node affinities. Overrides `arch` and `os` values                                       | `{}`                                                        |
 | `labels`                                  | KSPM collector specific labels (as a multi-line templated string map or as YAML)        | `{}`                                                        |
 | `port`                                    | KSPM collector port for health checks                                                   | `8080`                                                      |
+| `psp.create`                              | Create Pod Security Policy to allow the KSPM Collector running in clusters with PSP enabled                                                   | `true`                                                      |
 | `readinessProbe.enabled`                  | KSPM collector readinessProbe enablement                                                | `true`                                                      |
 | `livenessProbe.enabled`                   | KSPM collector livenessProbe enablement                                                 | `true`                                                      |
 | `scc.create`                              | Create OpenShift's Security Context Constraint                                          | `true`                                                      |

--- a/charts/kspm-collector/templates/_helpers.tpl
+++ b/charts/kspm-collector/templates/_helpers.tpl
@@ -187,3 +187,4 @@ KSPM Collector nodeSelector
             (lt (.root.Capabilities.KubeVersion.Minor | trimSuffix "+" | int) .minor)) }}
 true
 {{- end }}
+{{- end }}

--- a/charts/kspm-collector/templates/_helpers.tpl
+++ b/charts/kspm-collector/templates/_helpers.tpl
@@ -175,3 +175,15 @@ KSPM Collector nodeSelector
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/* Returns string 'true' if the cluster's kubeVersion is less than the parameter provided, or nothing otherwise
+     Use like: {{ include "kspmCollector.kubeVersionLessThan" (dict "root" . "major" <kube_major_to_compare> "minor" <kube_minor_to_compare>) }}
+
+     Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
+           helper functions when "helm template" is used.
+*/}}
+{{- define "kspmCollector.kubeVersionLessThan" }}
+{{- if (and (le (.root.Capabilities.KubeVersion.Major | int) .major)
+            (lt (.root.Capabilities.KubeVersion.Minor | trimSuffix "+" | int) .minor)) }}
+true
+{{- end }}

--- a/charts/kspm-collector/templates/psp.yaml
+++ b/charts/kspm-collector/templates/psp.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.psp.create (include "kspmCollector.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "kspmCollector.fullname" . }}
+  namespace: {{ include "kspmCollector.namespace" . }}
+spec:
+  allowedCapabilities: []
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - emptyDir
+  - secret
+  - configMap
+  - downwardAPI
+{{- end }}

--- a/charts/kspm-collector/tests/psp_test.yaml
+++ b/charts/kspm-collector/tests/psp_test.yaml
@@ -1,0 +1,43 @@
+suite: PSP create test
+templates:
+  - templates/psp.yaml
+tests:
+  - it: Ensure PSP is created on k8s <1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 24
+    set:
+      psp:
+        create: true
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1beta1
+          kind: PodSecurityPolicy
+
+  - it: Ensure PSP is not created on k8s >=1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 25
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Ensure PSP is created on k8s <1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "24+"
+    set:
+      psp:
+        create: true
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1beta1
+          kind: PodSecurityPolicy
+
+  - it: Ensure PSP is not created on k8s >=1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "25+"
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/kspm-collector/tests/psp_test.yaml
+++ b/charts/kspm-collector/tests/psp_test.yaml
@@ -41,3 +41,14 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: Ensure PSP is not created when disabled
+    capabilities:
+      majorVersion: 1
+      minorVersion: 24
+    set:
+      psp:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/kspm-collector/values.yaml
+++ b/charts/kspm-collector/values.yaml
@@ -58,6 +58,10 @@ scc:
   # true here enables creation of Security Context Constraints in Openshift
   create: true
 
+psp:
+  # true here enables creation of Pod Security Policy to allow the agent run with the required permissions
+  create: true
+
 serviceAccount:
   # true here enables creation of service account
   create: true


### PR DESCRIPTION
## What this PR does / why we need it:
PSP Policies are missing, this will cause KSPM Collector to not being deployed on k8s cluster with a version < 1.25 and with PSP enabled

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
