### PR TITLE
feat(registry-scanner): hide sensitive data from logs

### DIFF
--- a/charts/registry-scanner/CHANGELOG.md
+++ b/charts/registry-scanner/CHANGELOG.md
@@ -11,6 +11,8 @@ exclusively to fix incorrect entries and not to add new ones.
 
 ## Change Log
 
+# v1.0.8
+* feat: hide sensitive data from logs
 # v1.0.7
 * chore: adds label for orchestrator job
 * **registry-scanner**  bumped inner component to v0.2.35

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,8 +4,8 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 1.0.7
-appVersion: 0.2.35
+version: 1.0.8
+appVersion: 0.2.36
 maintainers:
   - name: airadier
     email: alvaro.iradier@sysdig.com

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -52,7 +52,7 @@ Deploy the registry scanner specify each parameter using the `--set key=value[,k
 
 ```bash
 $ helm upgrade --install registry-scanner \
-    --version=1.0.7 \
+    --version=1.0.8 \
     --set config.secureBaseURL=<SYSDIG_SECURE_URL> \
     --set config.secureAPIToken=<SYSDIG_SECURE_API_TOKEN> \
     --set config.registryURL=<REGISTRY_URL> \
@@ -64,7 +64,7 @@ $ helm upgrade --install registry-scanner \
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install registry-scanner -f values.yaml --version=1.0.7 sysdig/registry-scanner
+$ helm install registry-scanner -f values.yaml --version=1.0.8 sysdig/registry-scanner
 ```
 
 
@@ -173,7 +173,7 @@ Use the following command to deploy in an on-prem:
 
 ```bash
 $ helm upgrade --install registry-scanner \
-    --version=1.0.7 \
+    --version=1.0.8 \
     --set config.secureBaseURL=<SYSDIG_SECURE_URL> \
     --set config.secureAPIToken=<SYSDIG_SECURE_API_TOKEN> \
     --set config.secureSkipTLS=true \


### PR DESCRIPTION
## What this PR does / why we need it:

## Description
Remove sensitive data from registry-scanner worker pods logs

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
