### PR TITLE
ci(): update github actions versions

### DIFF
--- a/.github/workflows/approve-test-run.yaml
+++ b/.github/workflows/approve-test-run.yaml
@@ -13,11 +13,10 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v1
+        uses: peter-evans/slash-command-dispatch@v3
         with:
           token: ${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request
           commands: approve-test-run
-          named-args: true
           permission: write

--- a/.github/workflows/greeting.yaml
+++ b/.github/workflows/greeting.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Issue the greeting comment
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/helm-unit-test.yaml
+++ b/.github/workflows/helm-unit-test.yaml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3.5
         with:
           version: v3.4.0
 

--- a/.github/workflows/k8s-apis-deprecation.yml
+++ b/.github/workflows/k8s-apis-deprecation.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: "🛎️ Checkout"
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: "🔑 Expand templates for CI"
         run: |

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4.0.2
+      - uses: actions/labeler@v4.0.3
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
           git clean -df .
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2.4.0
 
       - name: Expand templates for CI
         run: |
@@ -84,7 +84,7 @@ jobs:
       contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.sha)
     steps:
       - name: Fork based /approve-test-run checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: "refs/pull/${{ github.event.client_payload.pull_request.number }}/merge"
           fetch-depth: 0
@@ -112,7 +112,7 @@ jobs:
           git clean -df .
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2.4.0
 
       - name: Expand templates for CI
         run: |
@@ -141,7 +141,7 @@ jobs:
       - name: Run chart-testing (install)
         run: ct install --upgrade --excluded-charts sysdig-stackdriver-bridge
 
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v6
         id: update-check-run
         if: ${{ always() }}
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Retrieve a list of updated charts
         id: updated-charts
-        uses: tj-actions/changed-files@v34
+        uses: tj-actions/changed-files@v35
         with:
           files: charts/*/Chart.yaml
 
@@ -78,7 +78,7 @@ jobs:
           done
 
       - name: Stash changelog files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: generated-changelogs
           path: |
@@ -96,7 +96,7 @@ jobs:
           fetch-depth: 0
 
       - name: Unstash generated changelogs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: generated-changelogs
           path: charts
@@ -107,7 +107,7 @@ jobs:
           git config user.email "$GITHUB_USER_EMAIL"
 
       - name: Run Chart Releaser
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@v1.5.0
         with:
           config: cr.yaml
         env:
@@ -140,7 +140,7 @@ jobs:
           token: ${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}
 
       - name: Unstash generated changelogs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: generated-changelogs
           path: charts

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days'

--- a/.github/workflows/update-sysdig-deploy-chart.yaml
+++ b/.github/workflows/update-sysdig-deploy-chart.yaml
@@ -12,8 +12,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Check if dependent charts were modified or not
-        uses: tj-actions/changed-files@v14.3
+        uses: tj-actions/changed-files@v35
         id: dependent_files
         with:
           files: |
@@ -22,20 +23,24 @@ jobs:
             charts/kspm-collector/*
             charts/rapid-response/*
             charts/admission-controller/*
+
       - name: Install YQ
         if: steps.dependent_files.outputs.any_changed == 'true'
-        uses: dcarbone/install-yq-action@v1.0.1
+        uses: dcarbone/install-yq-action@v1.1.0
+
       - name: run the script
         if: steps.dependent_files.outputs.any_changed == 'true'
         run: scripts/sysdig-deploy/update-sysdig-deploy.sh
+
       - name: Configure Git
         if: steps.dependent_files.outputs.any_changed == 'true'
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
       - name: Create Pull Request
         if: steps.dependent_files.outputs.any_changed == 'true'
-        uses: peter-evans/create-pull-request@v4.2.0
+        uses: peter-evans/create-pull-request@v5.0.1
         with:
           title: "chore(sysdig-deploy): Automatic version bump due to updated dependencies"
           base: master


### PR DESCRIPTION
## What this PR does / why we need it:

 - Update GH actions plugins to the last version

## Checklist

- [ ] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix
