### PR TITLE
fix(kspm-collector): Add missing clusterrole for KSPM PSP

### DIFF
--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.1.44
+version: 0.1.45
 appVersion: 1.22.0
 keywords:
   - monitoring

--- a/charts/kspm-collector/templates/clusterrole.yaml
+++ b/charts/kspm-collector/templates/clusterrole.yaml
@@ -54,4 +54,14 @@ rules:
       - 'get'
       - 'list'
       - 'watch'
+{{- if and .Values.psp.create (include "kspmCollector.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
+  - apiGroups:
+      - "policy"
+    resources:
+      - "podsecuritypolicies"
+    resourceNames:
+      - "{{ template "kspmCollector.fullname" .}}"
+    verbs:
+      - "use"
+{{- end }}
 {{- end }}

--- a/charts/kspm-collector/tests/clusterrole_test.yaml
+++ b/charts/kspm-collector/tests/clusterrole_test.yaml
@@ -1,0 +1,71 @@
+suite: KSPM Collector Cluster Role Tests
+templates:
+  - templates/clusterrole.yaml
+tests:
+  - it: Test PSP information included in k8s <1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 24
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - "policy"
+            resources:
+              - "podsecuritypolicies"
+            resourceNames:
+              - release-name-kspm-collector
+            verbs:
+              - "use"
+
+  - it: Test PSP information not included in k8s >=1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 25
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - "policy"
+            resources:
+              - "podsecuritypolicies"
+            resourceNames:
+              - release-name-kspm-collector
+            verbs:
+              - "use"
+
+  - it: Test PSP information included in k8s <1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "24+"
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - "policy"
+            resources:
+              - "podsecuritypolicies"
+            resourceNames:
+              - release-name-kspm-collector
+            verbs:
+              - "use"
+
+  - it: Test PSP information not included in k8s >=1.25 with '+' character in minor version
+    capabilities:
+      majorVersion: 1
+      minorVersion: "25+"
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - "policy"
+            resources:
+              - "podsecuritypolicies"
+            resourceNames:
+              - release-name-kspm-collector
+            verbs:
+              - "use"


### PR DESCRIPTION
## What this PR does / why we need it:

On PR (https://github.com/sysdiglabs/charts/pull/1088) I forgot to push the changes to clusterrole file for allow the usage of PSP policies

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
