### PR TITLE
fix(agent): Do not infer `max_parallel_cold_start` value

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.8.3
+version: 1.8.4
 
 appVersion: 12.14.1
 

--- a/charts/agent/templates/configmap-deployment.yaml
+++ b/charts/agent/templates/configmap-deployment.yaml
@@ -32,6 +32,9 @@ data:
       enabled: false
     statsd:
       enabled: false
+{{/* Calculate the leaderElection/k8s_colstart information.
+     The computed/combined results are merged with any overrides specified
+     in sysdig.settings and will be rendered with that block */}}
 {{- include "agent.leaderElection" . }}
 {{ include "agent.disableCaptures" . | nindent 4 }}
 {{- $_ := mergeOverwrite .Values.secure (dict "enabled" false) }}

--- a/charts/agent/templates/configmap-deployment.yaml
+++ b/charts/agent/templates/configmap-deployment.yaml
@@ -32,7 +32,7 @@ data:
       enabled: false
     statsd:
       enabled: false
-{{- include "agent.k8sColdStart" . | nindent 4 }}
+{{- include "agent.leaderElection" . }}
 {{ include "agent.disableCaptures" . | nindent 4 }}
 {{- $_ := mergeOverwrite .Values.secure (dict "enabled" false) }}
 {{- (include "agent.secureFeatures" .) | nindent 4 }}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
 {{- end }}
 {{- include "agent.connectionSettings" . | trim | nindent 4 }}
 {{- include "agent.planSettings" . | trim | nindent 4 }}
-{{- include "agent.k8sColdStart" . | nindent 4 }}
+{{- include "agent.leaderElection" . }}
 {{- include "agent.disableCaptures" . | nindent 4 }}
 {{- include "agent.logSettings" . }}
 {{- if .Values.global.sysdig.tags }}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -17,6 +17,9 @@ data:
 {{- end }}
 {{- include "agent.connectionSettings" . | trim | nindent 4 }}
 {{- include "agent.planSettings" . | trim | nindent 4 }}
+{{/* Calculate the leaderElection/k8s_colstart information.
+     The computed/combined results are merged with any overrides specified
+     in sysdig.settings and will be rendered with that block */}}
 {{- include "agent.leaderElection" . }}
 {{- include "agent.disableCaptures" . | nindent 4 }}
 {{- include "agent.logSettings" . }}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -443,5 +443,5 @@ spec:
   updateStrategy:
     type: {{ .Values.daemonset.updateStrategy.type }}
     rollingUpdate:
-      maxUnavailable: {{ include "agent.parallelStarts" . }}
+      maxUnavailable: {{ include "agent.maxUnavailable" . }}
 {{- end }}

--- a/charts/agent/tests/delegated_agent_deployment_test.yaml
+++ b/charts/agent/tests/delegated_agent_deployment_test.yaml
@@ -414,7 +414,6 @@ tests:
             k8s_coldstart:
               enabled: true
               enforce_leader_election: true
-              max_parallel_cold_start: 1
               namespace: NAMESPACE
     template: templates/configmap-deployment.yaml
 
@@ -424,6 +423,10 @@ tests:
         enabled: true
       leaderelection:
         enable: true
+      sysdig:
+        settings:
+          k8s_coldstart:
+            max_parallel_cold_start: 10
       resourceProfile: large
     asserts:
       - matchRegex:
@@ -432,7 +435,7 @@ tests:
             k8s_coldstart:
               enabled: true
               enforce_leader_election: true
-              max_parallel_cold_start: 1
+              max_parallel_cold_start: 10
               namespace: NAMESPACE
     template: templates/configmap-deployment.yaml
 

--- a/charts/agent/tests/k8s_coldstart_test.yaml
+++ b/charts/agent/tests/k8s_coldstart_test.yaml
@@ -13,7 +13,6 @@ tests:
             k8s_coldstart:
               enabled: true
               enforce_leader_election: true
-              max_parallel_cold_start: 1
               namespace: NAMESPACE
     template: templates/configmap.yaml
 
@@ -29,7 +28,6 @@ tests:
             k8s_coldstart:
               enabled: true
               enforce_leader_election: true
-              max_parallel_cold_start: 10
               namespace: NAMESPACE
     template: templates/configmap.yaml
 


### PR DESCRIPTION
## What this PR does / why we need it:
PR #1069 fixed a typo in the `max_parallel_cold_start` key. That fix resulted in the inferred values being generated actually being used for the first time. Looking through the commit history in the charts it looks like the typo had been in place since the beginning, but now that the values are being consumed by the agent they are resulting in undesirable behavior.

The fix here is to no longer infer or generate a number for the `max_parallel_cold_start` key, but instead just rely on the Agent's default unless the user specifies something else.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
