### PR TITLE
feat(cluster-scanner): added cluster scanner in sysdig-deploy

### DIFF
--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.7.5
+version: 1.9.0
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com
@@ -29,6 +29,12 @@ dependencies:
     version: ~1.8.50
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
+  - name: cluster-scanner
+    # repository: https://charts.sysdig.com
+    repository: file://../cluster-scanner
+    version: ~0.1.0
+    alias: clusterScanner
+    condition: clusterScanner.enabled
   - name: kspm-collector
     # repository: https://charts.sysdig.com
     repository: file://../kspm-collector

--- a/charts/sysdig-deploy/templates/scannerconstraint.yaml
+++ b/charts/sysdig-deploy/templates/scannerconstraint.yaml
@@ -1,0 +1,3 @@
+{{- if and .Values.clusterScanner.enabled .Values.nodeAnalyzer.enabled ( include "nodeAnalyzer.deployRuntimeScanner" . ) -}}
+{{- fail "Cannot enable both the clusterScanner and runtimeScanner at the same time" -}}
+{{- end -}}

--- a/charts/sysdig-deploy/tests/scannerconstraint_test.yaml
+++ b/charts/sysdig-deploy/tests/scannerconstraint_test.yaml
@@ -1,0 +1,60 @@
+suite: Testing cluster scanner and node analyzer should not be both enabled
+templates:
+  - templates/scannerconstraint.yaml
+tests:
+  - it: Should fail if cluster scanner and new engine are both enabled
+    set:
+      secure:
+        vulnerabilityManagement:
+          newEngineOnly: true
+      nodeAnalyzer:
+        enabled: true
+        runtimeScanner:
+          deploy: false
+      clusterScanner:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Cannot enable both the clusterScanner and runtimeScanner at the same time"
+  - it: Should fail if cluster scanner and runtimeScanner are both enabled
+    set:
+      secure:
+        vulnerabilityManagement:
+          newEngineOnly: false
+      nodeAnalyzer:
+        enabled: true
+        runtimeScanner:
+          deploy: true
+      clusterScanner:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Cannot enable both the clusterScanner and runtimeScanner at the same time"
+  - it: Should not fail if only cluster scanner is enabled
+    set:
+      secure:
+        vulnerabilityManagement:
+          newEngineOnly: false
+      nodeAnalyzer:
+        enabled: false
+        runtimeScanner:
+          deploy: false
+      clusterScanner:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: Should not fail if only node analyzer is enabled
+    set:
+      secure:
+        vulnerabilityManagement:
+          newEngineOnly: false
+      nodeAnalyzer:
+        enabled: true
+        runtimeScanner:
+          deploy: true
+      clusterScanner:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/sysdig-deploy/values.yaml
+++ b/charts/sysdig-deploy/values.yaml
@@ -25,6 +25,9 @@ agent:
 nodeAnalyzer:
   enabled: true
 
+clusterScanner:
+  enabled: false
+
 rapidResponse:
   enabled: false
   rapidResponse:


### PR DESCRIPTION
## What this PR does / why we need it:

feat(cluster-scanner): added cluster scanner in sysdig-deploy
feat(sysdig-deploy): prevent cluster-scanner and runtime-analyzer to be running at the same time

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
