### PR TITLE
feat(agent): add drift_control to secure exclude lists when appropriate

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.8.4
+version: 1.8.5
 
 appVersion: 12.14.1
 

--- a/charts/agent/templates/NOTES.txt
+++ b/charts/agent/templates/NOTES.txt
@@ -16,6 +16,16 @@ The "drift_killer" feature in agent is not supported when running on GKE Autopil
         {{- end }}
     {{- end }}
 {{- end }}
+{{- if include "agent.gke.autopilot" . }}
+    {{- if hasKey .Values.sysdig.settings "drift_control" }}
+        {{- if hasKey .Values.sysdig.settings.drift_control "enabled" }}
+            {{- if .Values.sysdig.settings.drift_control.enabled }}
+
+The "drift_control" feature in agent is not supported when running on GKE Autopilot.
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
 
 {{- if and (include "agent.gke.autopilot" .) (not .Values.gke.createPriorityClass) (not .Values.priorityClassName) }}
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -422,6 +422,7 @@ agent config to prevent a backend push from enabling them after installation.
     {{- if (not .Values.secure.enabled) }}
         {{- range $secureFeature := (list
             "commandlines_capture"
+            "drift_control"
             "drift_killer"
             "falcobaseline"
             "memdump"
@@ -431,6 +432,7 @@ agent config to prevent a backend push from enabling them after installation.
         {{- end }}
     {{ else if $secureLightMode }}
         {{- range $secureFeature := (list
+            "drift_control"
             "drift_killer"
             "falcobaseline"
             "memdump"
@@ -439,6 +441,7 @@ agent config to prevent a backend push from enabling them after installation.
         {{- end }}
     {{- end }}
     {{- if include "agent.gke.autopilot" . }}
+        {{- $_ := set $secureConfig "drift_control" (dict "enabled" false) }}
         {{- $_ := set $secureConfig "drift_killer" (dict "enabled" false) }}
     {{- end }}
 {{ toYaml $secureConfig }}

--- a/charts/agent/tests/delegated_agent_deployment_test.yaml
+++ b/charts/agent/tests/delegated_agent_deployment_test.yaml
@@ -354,8 +354,22 @@ tests:
     asserts:
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: "commandlines_capture:\n {2}enabled: false\ndrift_killer:\n {2}enabled: false\nfalcobaseline:\n {2}enabled: false\nmemdump:\n {2}enabled: false\nnetwork_topology:\n {2}enabled: false\nsecure_audit_streams:\n {2}enabled: false"
-        template: templates/configmap-deployment.yaml
+          pattern: |-
+            commandlines_capture:
+              enabled: false
+            drift_control:
+              enabled: false
+            drift_killer:
+              enabled: false
+            falcobaseline:
+              enabled: false
+            memdump:
+              enabled: false
+            network_topology:
+              enabled: false
+            secure_audit_streams:
+              enabled: false
+    template: templates/configmap-deployment.yaml
 
   - it: Ensure disabling secure still works for Daemonset too
     set:
@@ -366,7 +380,21 @@ tests:
     asserts:
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: "commandlines_capture:\n {2}enabled: false\ndrift_killer:\n {2}enabled: false\nfalcobaseline:\n {2}enabled: false\nmemdump:\n {2}enabled: false\nnetwork_topology:\n {2}enabled: false\nsecure_audit_streams:\n {2}enabled: false"
+          pattern: |-
+            commandlines_capture:
+              enabled: false
+            drift_control:
+              enabled: false
+            drift_killer:
+              enabled: false
+            falcobaseline:
+              enabled: false
+            memdump:
+              enabled: false
+            network_topology:
+              enabled: false
+            secure_audit_streams:
+              enabled: false
     templates:
       - templates/configmap.yaml
       - templates/configmap-deployment.yaml

--- a/charts/agent/tests/drift_prevention_test.yaml
+++ b/charts/agent/tests/drift_prevention_test.yaml
@@ -92,3 +92,93 @@ tests:
           pattern: |-
             The "drift_killer" feature in agent is not supported when running on GKE Autopilot.
     template: templates/NOTES.txt
+
+  - it: Drift control must not be overridden by default
+    asserts:
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            drift_control
+    template: templates/configmap.yaml
+
+  - it: Drift control must be false when is monitor only
+    set:
+      secure:
+        enabled: false
+      monitor:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            drift_control:
+              enabled: false
+    template: templates/configmap.yaml
+
+  - it: Drift control must be false when is secure_light
+    set:
+      sysdig:
+        settings:
+          feature:
+            mode: secure_light
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            drift_control:
+              enabled: false
+    template: templates/configmap.yaml
+
+  - it: Drift control must be false when is running on GKE Autopilot
+    set:
+      gke:
+        autopilot: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            drift_control:
+              enabled: false
+    template: templates/configmap.yaml
+
+  - it: Drift control must be enabled when explicitally set
+    set:
+      sysdig:
+        settings:
+          drift_control:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            drift_control:
+              enabled: true
+    template: templates/configmap.yaml
+
+  - it: Test "drift_control" feature message is visible when enabled and we run in GKE with autopilot enabled
+    set:
+      sysdig:
+        settings:
+          drift_control:
+            enabled: true
+      gke:
+        autopilot: true
+    asserts:
+      - matchRegexRaw:
+          pattern: |-
+            The "drift_control" feature in agent is not supported when running on GKE Autopilot.
+    template: templates/NOTES.txt
+
+  - it: Test "drift_control" feature message is not visible when run with gke.autopilot=false
+    set:
+      sysdig:
+        settings:
+          drift_control:
+            enabled: true
+      gke:
+        autopilot: false
+    asserts:
+      - notMatchRegexRaw:
+          pattern: |-
+            The "drift_control" feature in agent is not supported when running on GKE Autopilot.
+    template: templates/NOTES.txt

--- a/charts/agent/tests/gke_test.yaml
+++ b/charts/agent/tests/gke_test.yaml
@@ -1,5 +1,6 @@
 suite: Test GKE Specific config settings
 templates:
+  - templates/configmap.yaml
   - templates/daemonset.yaml
   - templates/gkeautopilotpriorityclass.yaml
 tests:
@@ -90,3 +91,17 @@ tests:
           kind: PriorityClass
           name: my-priority-class
     template: templates/gkeautopilotpriorityclass.yaml
+
+  - it: Ensure drift_control and drift_killer features are disabled
+    set:
+      gke:
+        autopilot: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            drift_control:
+              enabled: false
+            drift_killer:
+              enabled: false
+    template: templates/configmap.yaml

--- a/charts/agent/tests/secure_enable_test.yaml
+++ b/charts/agent/tests/secure_enable_test.yaml
@@ -45,6 +45,11 @@ tests:
       - matchRegex:
           path: data['dragent.yaml']
           pattern: |-
+            drift_control:
+              enabled: false
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
             drift_killer:
               enabled: false
       - matchRegex:
@@ -135,6 +140,11 @@ tests:
           path: data['dragent.yaml']
           pattern: |-
             statsd:
+              enabled: false
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            drift_control:
               enabled: false
       - matchRegex:
           path: data['dragent.yaml']


### PR DESCRIPTION
## What this PR does / why we need it:
When either `agent.secure.enabled=false` or
`agent.sysdig.settings.feature.mode=secure_light`, add the `drift_control`
feature to the list of items to explicitly disable in the Agent configuration.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
