### PR TITLE
fix(agent): trim newlines when applying nodeSelectors in delegatedAgentDeployments

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.10.1
+version: 1.10.2
 
 appVersion: 12.15.0
 

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       {{- if .Values.delegatedAgentDeployment.deployment.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.delegatedAgentDeployment.deployment.nodeSelector | nindent 8 }}
+        {{- toYaml .Values.delegatedAgentDeployment.deployment.nodeSelector | nindent 8 }}
       {{- end }}
       affinity:
       {{- if .Values.delegatedAgentDeployment.deployment.affinity }}


### PR DESCRIPTION
## What this PR does / why we need it:
Without the trim there were occasionally a newline inserted between `nodeSelector:` and the content desired to be present, which could result in the delegated agent deployment Deployment object failing to render.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers