### PR TITLE
feat(admission-controller,agent,cloud-bench,cloud-connector,cloud-scanning,harbor-scanner-sysdig-secure,kspm-collector,node-analyzer,rapid-response,registry-scanner,sysdig,sysdig-deploy,sysdig-mcm-navmenu,sysdig-stackdriver-bridge): use a PGP private key to sign charts on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,12 +106,27 @@ jobs:
           git config user.name "$GITHUB_USERNAME"
           git config user.email "$GITHUB_USER_EMAIL"
 
+      - name: Import GPG key
+        run: |
+          GPG_DIR=".helm-gpg"
+          mkdir "$GPG_DIR"
+          KEYRING_FILE="$GPG_DIR/keyring.gpg"
+          echo "${GPG_PRIVATE_KEY}" | gpg --dearmor --output "${KEYRING_FILE}"
+          PASSPHRASE_FILE="$GPG_DIR/passphrase"
+          echo "${GPG_PASSPHRASE}" > "${PASSPHRASE_FILE}"
+          echo "CR_PASSPHRASE_FILE=$PASSPHRASE_FILE" >> "$GITHUB_ENV"
+          echo "CR_KEYRING=$KEYRING_FILE" >> "$GITHUB_ENV"
+        env:
+          GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
+          GPG_PRIVATE_KEY: "${{ secrets.GPG_PRIVATE_KEY }}"
+
       - name: Run Chart Releaser
         uses: helm/chart-releaser-action@v1.5.0
         with:
           config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}"
+          CR_KEY: "${{ secrets.GPG_KEY_NAME }}"
 
       - name: Copy README.md files to gh-pages
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,8 +139,14 @@ jobs:
           pushd ${tmp_folder}
           git add -A "charts/**/README.md"
           git add -A "charts/**/values.yaml"
-          git pull && git commit -m "github_actions_ci: Update README.md and values files" && git push
+          echo "${GPG_PUBLIC_KEY}" > public.gpg
+          git add public.gpg
+          if ! git diff-index --quiet HEAD; then
+            git pull && git commit -m "github_actions_ci: Update public key" && git push
+          fi
           popd
+        env:
+          GPG_PUBLIC_KEY: "${{ secrets.GPG_PUBLIC_KEY }}"
 
   commit-changelogs:
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,7 +128,7 @@ jobs:
           CR_TOKEN: "${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}"
           CR_KEY: "${{ secrets.GPG_KEY_NAME }}"
 
-      - name: Copy README.md files to gh-pages
+      - name: Copy README.md files and GPG public key to gh-pages
         run: |
           existing_worktree=$(git worktree list --porcelain | grep -B 2 "branch refs/heads/gh-pages" | head -n 1 | cut -d ' ' -f 2)
           if [[ $existing_worktree != "" ]]; then git worktree remove -f $existing_worktree; fi

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.8.6
+version: 0.9.0
 appVersion: 3.9.22
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.8.6  \
+      --create-namespace -n sysdig-admission-controller --version=0.9.0  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
 ```
@@ -55,7 +55,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.8.6
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.9.0
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -183,7 +183,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.8.6 \
+    --create-namespace -n sysdig-admission-controller --version=0.9.0 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -192,7 +192,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.8.6 \
+    --create-namespace -n sysdig-admission-controller --version=0.9.0 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -196,6 +196,20 @@ $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller
     --values values.yaml
 ```
 
+### Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+#### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+#### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 ## Examples
 - [Default `values.yaml`](https://github.com/sysdiglabs/charts/blob/master/charts/admission-controller/values.yaml)
 - Find some [examples of these values](https://github.com/sysdiglabs/charts/tree/master/charts/admission-controller/ci)

--- a/charts/admission-controller/README.tpl
+++ b/charts/admission-controller/README.tpl
@@ -97,6 +97,20 @@ $ helm upgrade --install sysdig-{{ .Release.Name }} {{ .Repository.Name }}/{{ .C
     --values values.yaml
 ```
 
+### Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+#### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+#### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 ## Examples
 - [Default `values.yaml`](https://github.com/sysdiglabs/charts/blob/master/charts/admission-controller/values.yaml)
 - Find some [examples of these values](https://github.com/sysdiglabs/charts/tree/master/charts/admission-controller/ci)

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.8.8
+version: 1.9.0
 
 appVersion: 12.14.1
 

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -22,6 +22,19 @@ To deploy the Sysdig Agent, follow the installation instructions given on the Sy
 - [Install Sysdig Agent for a Sysdig On-Premises Deployment](https://docs.sysdig.com/en/docs/installation/on-premises/)
 - [Install Sysdig Agent in an Airgapped Environment](https://docs.sysdig.com/en/docs/installation/on-premises/airgapped-installation/)
 
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
 
 ## Configuration
 

--- a/charts/cloud-bench/Chart.yaml
+++ b/charts/cloud-bench/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-bench
 description: Sysdig Cloud Bench
 
 type: application
-version: 0.2.3
+version: 0.3.0
 appVersion: 0.1.0
 home: https://sysdig.com
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/cloud-bench/README.md
+++ b/charts/cloud-bench/README.md
@@ -16,6 +16,20 @@ $ helm repo add sysdig https://charts.sysdig.com
 $ helm install --create-namespace -n cloud-bench cloud-bench -f values.yaml sysdig/cloud-bench
 ```
 
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 ## Configuration
 
 The following table lists the configurable parameters of the Sysdig Cloud Bench

--- a/charts/cloud-connector/Chart.yaml
+++ b/charts/cloud-connector/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-connector
 description: Sysdig Cloud Connector
 
 type: application
-version: 0.7.25
+version: 0.8.0
 appVersion: 0.16.42
 home: https://sysdiglabs.github.io/cloud-connector
 

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install cloud-connector sysdig/cloud-connector \
-      --create-namespace -n cloud-connector --version=0.7.25  \
+      --create-namespace -n cloud-connector --version=0.8.0  \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
 ```
 
@@ -48,7 +48,7 @@ to enable threat-detection and image scanning capabilities for the main three pr
 To install the chart with the release name `cloud-connector`:
 
 ```console
-$ helm upgrade --install cloud-connector sysdig/cloud-connector -n cloud-connector --version=0.7.25
+$ helm upgrade --install cloud-connector sysdig/cloud-connector -n cloud-connector --version=0.8.0
 ```
 
 The command deploys the Sysdig Cloud Connector on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -120,7 +120,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install cloud-connector sysdig/cloud-connector \
-    --create-namespace -n cloud-connector --version=0.7.25 \
+    --create-namespace -n cloud-connector --version=0.8.0 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE
 ```
 
@@ -129,7 +129,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install cloud-connector sysdig/cloud-connector \
-    --create-namespace -n cloud-connector --version=0.7.25 \
+    --create-namespace -n cloud-connector --version=0.8.0 \
     --values values.yaml
 ```
 

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -66,6 +66,20 @@ $ helm uninstall cloud-connector -n cloud-connector
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+### Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+#### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+#### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 ## Configuration
 
 The following table lists the configurable parameters of the `cloud-connector` chart and their default values.

--- a/charts/cloud-connector/README.tpl
+++ b/charts/cloud-connector/README.tpl
@@ -65,6 +65,20 @@ $ helm uninstall {{ .Release.Name }} -n {{ .Release.Namespace }}
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+### Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+#### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+#### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 {{ if .Chart.Values -}}
 
 ## Configuration

--- a/charts/cloud-scanning/Chart.yaml
+++ b/charts/cloud-scanning/Chart.yaml
@@ -3,7 +3,7 @@ name: cloud-scanning
 description: Sysdig Cloud Scanning
 
 type: application
-version: 0.3.3
+version: 0.4.0
 appVersion: 0.11.3
 home: https://sysdiglabs.github.io/cloud-connector
 

--- a/charts/cloud-scanning/README.md
+++ b/charts/cloud-scanning/README.md
@@ -15,6 +15,20 @@ $ helm repo add sysdig https://charts.sysdig.com
 $ helm install --create-namespace -n cloud-scanning cloud-scanning -f values.yaml sysdig/cloud-scanning
 ```
 
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 ## Configuration
 
 The following table lists the configurable parameters of the Sysdig Cloud Scanning

--- a/charts/harbor-scanner-sysdig-secure/Chart.yaml
+++ b/charts/harbor-scanner-sysdig-secure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: harbor-scanner-sysdig-secure
 description: Harbor Scanner for Sysdig Secure
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: 0.6.0
 home: https://github.com/sysdiglabs/harbor-scanner-sysdig-secure
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/harbor-scanner-sysdig-secure/README.md
+++ b/charts/harbor-scanner-sysdig-secure/README.md
@@ -25,6 +25,20 @@ $ helm repo add sysdig https://charts.sysdig.com
 $ helm install -n sharbor-scanner-sysdig-secure harbor-scanner-sysdig-secure -f values.yaml sysdig/harbor-scanner-sysdig-secure
 ```
 
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 ## Configuration
 
 The following table lists the configurable parameters of the Harbor Scanner

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.1.52
+version: 0.2.0
 appVersion: 1.25.0
 keywords:
   - monitoring

--- a/charts/kspm-collector/README.md
+++ b/charts/kspm-collector/README.md
@@ -18,6 +18,20 @@ Deploy the kspm collector
 $ helm install --create-namespace -n kspm-collector kspm-collector -f values.yaml sysdig/kspm-collector
 ```
 
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 ## Configuration
 
 The following table lists the configurable parameters of the Sysdig KSPM Collector chart and their default values:

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.8.65
+version: 1.9.0
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/README.md
+++ b/charts/node-analyzer/README.md
@@ -72,6 +72,20 @@ $ helm delete --namespace nodeanalyzer node-analyzer
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 ## Configuration
 
 The following table lists the configurable parameters of the Sysdig Node Analyzer chart and their default values.

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.12
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rapid-response/README.md
+++ b/charts/rapid-response/README.md
@@ -20,6 +20,20 @@ Deploy Rapid Response
 $ helm install --create-namespace -n rapid-response rapid-response -f values.yaml sysdig/rapid-response
 ```
 
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 ## Configuration
 
 The following table lists the configurable parameters of the Sysdig Rapid Response chart and their default values:

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 1.0.15
+version: 1.1.0
 appVersion: 0.2.41
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -52,7 +52,7 @@ Deploy the registry scanner specify each parameter using the `--set key=value[,k
 
 ```bash
 $ helm upgrade --install registry-scanner \
-    --version=1.0.15 \
+    --version=1.1.0 \
     --set config.secureBaseURL=<SYSDIG_SECURE_URL> \
     --set config.secureAPIToken=<SYSDIG_SECURE_API_TOKEN> \
     --set config.registryURL=<REGISTRY_URL> \
@@ -64,7 +64,7 @@ $ helm upgrade --install registry-scanner \
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install registry-scanner -f values.yaml --version=1.0.15 sysdig/registry-scanner
+$ helm install registry-scanner -f values.yaml --version=1.1.0 sysdig/registry-scanner
 ```
 
 
@@ -175,7 +175,7 @@ Use the following command to deploy in an on-prem:
 
 ```bash
 $ helm upgrade --install registry-scanner \
-    --version=1.0.15 \
+    --version=1.1.0 \
     --set config.secureBaseURL=<SYSDIG_SECURE_URL> \
     --set config.secureAPIToken=<SYSDIG_SECURE_API_TOKEN> \
     --set config.secureSkipTLS=true \

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -86,6 +86,20 @@ $ helm uninstall registry-scanner
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 ## Configuration
 
 The following table lists the configurable parameters of the Sysdig Registry Scanner chart and their default values:

--- a/charts/registry-scanner/README.tpl
+++ b/charts/registry-scanner/README.tpl
@@ -86,6 +86,20 @@ $ helm uninstall {{ .Chart.Name }}
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 {{- if .Chart.Values }}
 
 ## Configuration

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.8.29
+version: 1.9.0
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com
@@ -14,30 +14,30 @@ dependencies:
   - name: admission-controller
     # repository: https://charts.sysdig.com
     repository: file://../admission-controller
-    version: ~0.8.6
+    version: ~0.9.0
     alias: admissionController
     condition: admissionController.enabled
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.8.8
+    version: ~1.9.0
     alias: agent
     condition: agent.enabled
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.8.65
+    version: ~1.9.0
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: kspm-collector
     # repository: https://charts.sysdig.com
     repository: file://../kspm-collector
-    version: ~0.1.52
+    version: ~0.2.0
     alias: kspmCollector
     condition: global.kspm.deploy
   - name: rapid-response
     # repository: https://charts.sysdig.com
     repository: file://../rapid-response
-    version: ~0.4.12
+    version: ~0.5.0
     alias: rapidResponse
     condition: rapidResponse.enabled

--- a/charts/sysdig-deploy/README.md
+++ b/charts/sysdig-deploy/README.md
@@ -106,7 +106,19 @@ Currently included components:
        helm install -n sysdig-agent sysdig sysdig/sysdig-deploy -f values.sysdig.yaml
        ```
 
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
 
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
 
 ## Migrating from `sysdig` chart
 

--- a/charts/sysdig-mcm-navmenu/Chart.yaml
+++ b/charts/sysdig-mcm-navmenu/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sysdig IBM MCM Nav Menu integration
 name: sysdig-mcm-navmenu
-version: 1.0.4
+version: 1.2.0
 appVersion: 1.0.0
 home: https://www.sysdig.com/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png

--- a/charts/sysdig-mcm-navmenu/README.md
+++ b/charts/sysdig-mcm-navmenu/README.md
@@ -6,3 +6,17 @@ These helm charts deploy a couple of services and an Ingress with the labels and
 * "Sysdig Monitor" entry is created inside "Monitor health"
 
 The ingress entry does not seem to work for ExternalService (unable to resolve service), so a nginx pod is deployed with a couple of redirect rules to redirect the user to Secure or Monitor SaaS URLs.
+
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.

--- a/charts/sysdig-stackdriver-bridge/Chart.yaml
+++ b/charts/sysdig-stackdriver-bridge/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig-stackdriver-bridge
-version: 1.1.4
+version: 1.2.0
 appVersion: 0.0.7
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig-stackdriver-bridge/README.md
+++ b/charts/sysdig-stackdriver-bridge/README.md
@@ -41,6 +41,20 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+### Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+#### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+#### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 ## Configuration
 
 The following table lists the configurable parameters of the Sysdig Stackdriver Bridge chart and their default values.

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.15.93
+version: 1.16.0
 appVersion: 12.14.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/charts/sysdig/README.md
+++ b/charts/sysdig/README.md
@@ -76,6 +76,20 @@ $ helm delete --namespace sysdig-agent sysdig-agent
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
 ## Configuration
 
 The following table lists the configurable parameters of the Sysdig chart and their default values.

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,2 +1,3 @@
 release-notes-file: RELEASE-NOTES.md
 skip-existing: true
+sign: true


### PR DESCRIPTION
## What this PR does / why we need it:

 - use a PGP private key to sign charts on release

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix