### PR TITLE
chore(sysdig-deploy): add notes for Pod Security Admission

### DIFF
--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.8.28
+version: 1.8.29
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com

--- a/charts/sysdig-deploy/templates/NOTES.txt
+++ b/charts/sysdig-deploy/templates/NOTES.txt
@@ -40,3 +40,10 @@ secure or secure_light mode. Please set agent.monitor.enabled=false to ensure al
 when running the Agent in secure or secure_light modes.
     {{ end }}
 {{ end }}
+
+{{- if include "kubeVersionGreaterThan" (dict "root" . "major" 1 "minor" 24) }}
+Pod Security Admission now replaces Pod Security Policies.
+Be aware that if you enforce "baseline" or "restricted" policies in your cluster, you need to enforce "privileged" policy to this namespace:
+    kubectl label --overwrite ns <sysdig-namespace> pod-security.kubernetes.io/enforce=privileged
+Otherwise you're ok to go.
+{{ end }}

--- a/charts/sysdig-deploy/templates/_helpers.tpl
+++ b/charts/sysdig-deploy/templates/_helpers.tpl
@@ -43,3 +43,16 @@ Determine sysdig secure endpoint based on provided region
         {{- end -}}
     {{- end -}}
 {{- end -}}
+
+{{/* Returns string 'true' if the cluster's kubeVersion is greater than the parameter provided, or nothing otherwise
+     Use like: {{ include "kubeVersionGreaterThan" (dict "root" . "major" <kube_major_to_compare> "minor" <kube_minor_to_compare>) }}
+
+     Note: The use of `"root" .` in the parameter dict is necessary as the .Capabilities fields are not provided in
+           helper functions when "helm template" is used.
+*/}}
+{{- define "kubeVersionGreaterThan" }}
+{{- if (and (ge (.root.Capabilities.KubeVersion.Major | int) .major)
+            (gt (.root.Capabilities.KubeVersion.Minor | trimSuffix "+" | int) .minor)) }}
+true
+{{- end }}
+{{- end }}

--- a/charts/sysdig-deploy/tests/notes_test.yaml
+++ b/charts/sysdig-deploy/tests/notes_test.yaml
@@ -209,3 +209,21 @@ tests:
       - notMatchRegexRaw:
           pattern: |-
             A PriorityClass is recommended for GKE Autopilot environments. Please set agent.gke.createPriorityClass=true or provide the name of an existing PriorityClass by using the agent.priorityClassName parameter.
+
+  - it: Test PSA note is printed on k8s >=1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 25
+    asserts:
+      - matchRegexRaw:
+          pattern: |-
+            Pod Security Admission now replaces Pod Security Policies.
+
+  - it: Test PSA note is not printed on k8s <=1.24
+    capabilities:
+      majorVersion: 1
+      minorVersion: 24
+    asserts:
+      - notMatchRegexRaw:
+          pattern: |-
+            Pod Security Admission now replaces Pod Security Policies.


### PR DESCRIPTION
## What this PR does / why we need it:

Add a note in the `sysdig-deploy` chart regarding Pod Security Admission, to let the customer know if and what actions are needed.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix
