### PR TITLE
fix: cluster name should be optional

### DIFF
--- a/charts/cluster-scanner/templates/deployment.yaml
+++ b/charts/cluster-scanner/templates/deployment.yaml
@@ -98,7 +98,6 @@ spec:
                 name: {{ include "cluster-scanner.fullname" . }}
                 key: cluster_name
                 optional: true
-          - name: SYSDIG_KUBECONFIG_CONTENT
           - name: K8S_ROOT_NAMESPACE
             valueFrom:
               configMapKeyRef:

--- a/charts/cluster-scanner/templates/deployment.yaml
+++ b/charts/cluster-scanner/templates/deployment.yaml
@@ -97,6 +97,8 @@ spec:
               configMapKeyRef:
                 name: {{ include "cluster-scanner.fullname" . }}
                 key: cluster_name
+                optional: true
+          - name: SYSDIG_KUBECONFIG_CONTENT
           - name: K8S_ROOT_NAMESPACE
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
## What this PR does / why we need it:
in multi mode it can be empty. Application will raise an error if it needs to be a non empty string
