### PR TITLE
fix: runtimescanner gets deployed when it should not

### DIFF
--- a/charts/node-analyzer/templates/_helpers.tpl
+++ b/charts/node-analyzer/templates/_helpers.tpl
@@ -237,7 +237,8 @@ true
 {{- end -}}
 
 {{- define "nodeAnalyzer.deployRuntimeScanner" -}}
-{{- if or ((.Values.secure).vulnerabilityManagement).newEngineOnly (not (hasKey ((.Values.nodeAnalyzer).runtimeScanner) "deploy")) .Values.nodeAnalyzer.runtimeScanner.deploy }}
+{{- if and (hasKey ((.Values.nodeAnalyzer).runtimeScanner) "deploy") (not .Values.nodeAnalyzer.runtimeScanner.deploy ) }}
+{{- else if or ((.Values.secure).vulnerabilityManagement).newEngineOnly (and (hasKey ((.Values.nodeAnalyzer).runtimeScanner) "deploy") .Values.nodeAnalyzer.runtimeScanner.deploy) -}}
 true
 {{- end -}}
 {{- end -}}

--- a/charts/node-analyzer/tests/runtimescanner_test.yaml
+++ b/charts/node-analyzer/tests/runtimescanner_test.yaml
@@ -47,3 +47,62 @@ tests:
             name: docker-sock
             hostPath:
               path: /var/run/docker.sock
+
+  - it: "is disabled if explicit flag is set, should override newEngineOnly"
+    set:
+      secure.vulnerabilityManagement.newEngineOnly: true
+      nodeAnalyzer.runtimeScanner.deploy: false
+    templates:
+      - ../templates/daemonset-node-analyzer.yaml
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: "spec.template.spec.containers[0].name"
+          value: "sysdig-benchmark-runner"
+      - equal:
+          path: "spec.template.spec.containers[1].name"
+          value: "sysdig-host-scanner"
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+
+  - it: "is disabled by default, legacy will be deployed"
+    templates:
+      - ../templates/daemonset-node-analyzer.yaml
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: "spec.template.spec.containers[0].name"
+          value: "sysdig-image-analyzer"
+      - equal:
+          path: "spec.template.spec.containers[1].name"
+          value: "sysdig-host-analyzer"
+      - equal:
+          path: "spec.template.spec.containers[2].name"
+          value: "sysdig-benchmark-runner"
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 3
+
+  - it: "is enabled when newEngineOnly is set"
+    set:
+      secure.vulnerabilityManagement.newEngineOnly: true
+    templates:
+      - ../templates/daemonset-node-analyzer.yaml
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: "spec.template.spec.containers[0].name"
+          value: "sysdig-benchmark-runner"
+      - equal:
+          path: "spec.template.spec.containers[1].name"
+          value: "sysdig-runtime-scanner"
+      - equal:
+          path: "spec.template.spec.containers[2].name"
+          value: "sysdig-host-scanner"
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 3

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -268,7 +268,9 @@ nodeAnalyzer:
     env: {}
 
   runtimeScanner:
-    deploy: false
+    # Note: deploy has been commented so that it will be used as hard override to newEngineOnly flag
+    # but when not set, newEngineOnly will win. Desiderata examples in ./tests/runtimescanner_test.yaml
+    #deploy: false
     probesPort: 7002
     image:
       repository: sysdig/vuln-runtime-scanner

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -270,7 +270,7 @@ nodeAnalyzer:
   runtimeScanner:
     # Note: deploy has been commented so that it will be used as hard override to newEngineOnly flag
     # but when not set, newEngineOnly will win. Desiderata examples in ./tests/runtimescanner_test.yaml
-    #deploy: false
+    # deploy: false
     probesPort: 7002
     image:
       repository: sysdig/vuln-runtime-scanner


### PR DESCRIPTION
## What this PR does / why we need it:

as per title, similar solution we did for HostScanner
