### PR TITLE
fix(kspm-collector,node-analyzer): properly handle affinity beta annotations

### DIFF
--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.25.0
 
 keywords:

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.2.2
+version: 0.2.3
 appVersion: 1.25.0
 
 keywords:

--- a/charts/kspm-collector/templates/deployment.yaml
+++ b/charts/kspm-collector/templates/deployment.yaml
@@ -33,19 +33,21 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values: {{- toYaml .Values.arch | nindent 18 }}
-              - key: kubernetes.io/os
-                operator: In
-                values: {{- toYaml .Values.os | nindent 18 }}
-            - matchExpressions:
+              {{- if (include "kspmCollector.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 14)) }}
               - key: beta.kubernetes.io/arch
                 operator: In
                 values: {{- toYaml .Values.arch | nindent 18 }}
               - key: beta.kubernetes.io/os
                 operator: In
                 values: {{- toYaml .Values.os | nindent 18 }}
+              {{- else }}
+              - key: kubernetes.io/arch
+                operator: In
+                values: {{- toYaml .Values.arch | nindent 18 }}
+              - key: kubernetes.io/os
+                operator: In
+                values: {{- toYaml .Values.os | nindent 18 }}
+              {{- end }}
       {{- end }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}

--- a/charts/kspm-collector/tests/deployment_affinity_test.yaml
+++ b/charts/kspm-collector/tests/deployment_affinity_test.yaml
@@ -1,0 +1,71 @@
+suite: Test specifying affinity settings to the KSPM Collector Deployment
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: Test the default affinity annotations (<1.14)
+    capabilities:
+      majorVersion: '1'
+      minorVersion: '13'
+    asserts:
+      - equal:
+          path: spec.template.spec['affinity']
+          value:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: beta.kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
+                        - arm64
+                    - key: beta.kubernetes.io/os
+                      operator: In
+                      values:
+                        - linux
+
+  - it: Test the default affinity annotations (>=1.14)
+    capabilities:
+      majorVersion: '1'
+      minorVersion: '14'
+    asserts:
+      - equal:
+          path: spec.template.spec['affinity']
+          value:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
+                        - arm64
+                    - key: kubernetes.io/os
+                      operator: In
+                      values:
+                        - linux
+
+  - it: Test adding custom affinity settings
+    set:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - IA64
+    asserts:
+      - equal:
+          path: spec.template.spec['affinity']
+          value:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - IA64

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.9.2
+version: 1.9.3
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.10.1
+version: 1.10.2
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -806,8 +806,35 @@ spec:
       {{- with .Values.nodeAnalyzer.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeAnalyzer.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
+      affinity:
+      {{- if .Values.nodeAnalyzer.affinity }}
+{{ toYaml .Values.nodeAnalyzer.affinity | indent 8 }}
+      {{- else }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+              {{- if (include "nodeAnalyzer.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 14)) }}
+                - key: beta.kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                - key: beta.kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+              {{- else }}
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+              {{- end }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/node-analyzer/tests/daemonset_affinity_test.yaml
+++ b/charts/node-analyzer/tests/daemonset_affinity_test.yaml
@@ -1,0 +1,72 @@
+suite: Test specifying affinity settings on the Node Analyzer DaemonSet
+templates:
+  - templates/daemonset-node-analyzer.yaml
+tests:
+  - it: Test the default affinity annotations (<1.14)
+    capabilities:
+      majorVersion: '1'
+      minorVersion: '13'
+    asserts:
+      - equal:
+          path: spec.template.spec['affinity']
+          value:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: beta.kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
+                        - arm64
+                    - key: beta.kubernetes.io/os
+                      operator: In
+                      values:
+                        - linux
+
+  - it: Test the default affinity annotations (>=1.14)
+    capabilities:
+      majorVersion: '1'
+      minorVersion: '14'
+    asserts:
+      - equal:
+          path: spec.template.spec['affinity']
+          value:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
+                        - arm64
+                    - key: kubernetes.io/os
+                      operator: In
+                      values:
+                        - linux
+
+  - it: Test adding custom affinity settings
+    set:
+      nodeAnalyzer:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - IA64
+    asserts:
+      - equal:
+          path: spec.template.spec['affinity']
+          value:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - IA64

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -132,30 +132,7 @@ nodeAnalyzer:
 
   # Allow the DaemonSet to schedule using affinity rules
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                  - amd64
-                  - arm64
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                  - linux
-          - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                  - amd64
-                  - arm64
-              - key: beta.kubernetes.io/os
-                operator: In
-                values:
-                  - linux
+  affinity: {}
 
   # Allow passing extra volumes to the Node Analyzer to mount docker socket, cri-o socket, etc.
   extraVolumes:


### PR DESCRIPTION
## What this PR does / why we need it:
Address the issue in both the kspm-collector and node-analyzer charts where the deployment/daemonset were using both the deprecated use of both `beta.kubernetes.io/arch` and `beta.kubernetes.io/os` on clusters that cause warnings to be emitted.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix