### PR TITLE
fix(cluster-scanner): added checks to prevent execution of both runtime scanner and cluster scanner

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.8.66
+version: 1.9.1
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.9.0
+version: 1.9.1
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com
@@ -26,7 +26,7 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.8.61
+    version: ~1.9.0
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: cluster-scanner

--- a/charts/sysdig-deploy/templates/_helpers.tpl
+++ b/charts/sysdig-deploy/templates/_helpers.tpl
@@ -43,3 +43,12 @@ Determine sysdig secure endpoint based on provided region
         {{- end -}}
     {{- end -}}
 {{- end -}}
+
+{{/*
+Determine whether runtime scanner shall run by including the helper from nodeAnalyzer chart.
+
+Based on: https://github.com/helm/helm/issues/4535#issuecomment-416022809
+*/}}
+{{- define "deployRuntimeScanner" }}
+{{- include "nodeAnalyzer.deployRuntimeScanner" (dict "Chart" (dict "Name" "nodeAnalyzer") "Values" (index .Values "nodeAnalyzer") "Release" .Release "Capabilities" .Capabilities) }}
+{{- end }}

--- a/charts/sysdig-deploy/templates/cluster-scanner-runtime-scanner-check.yaml
+++ b/charts/sysdig-deploy/templates/cluster-scanner-runtime-scanner-check.yaml
@@ -1,0 +1,3 @@
+{{- if and .Values.clusterScanner.enabled .Values.nodeAnalyzer.enabled ( include "deployRuntimeScanner" . ) -}}
+{{ fail "Cannot enable both the Runtime Scanner and the Cluster Scanner at the same time" }}
+{{- end -}}

--- a/charts/sysdig-deploy/tests/scannerconstraint_test.yaml
+++ b/charts/sysdig-deploy/tests/scannerconstraint_test.yaml
@@ -1,0 +1,83 @@
+suite: Testing cluster scanner and runtime scanner should not be both enabled
+templates:
+  - templates/cluster-scanner-runtime-scanner-check.yaml
+tests:
+  - it: Should fail if cluster scanner and new engine are both enabled
+    set:
+      nodeAnalyzer:
+        enabled: true
+        secure:
+          vulnerabilityManagement:
+            newEngineOnly: true
+        nodeAnalyzer:
+          runtimeScanner:
+            deploy: true
+      clusterScanner:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Cannot enable both the Runtime Scanner and the Cluster Scanner at the same time"
+
+  - it: Should fail if cluster scanner and runtime scanner are both enabled
+    set:
+      nodeAnalyzer:
+        enabled: true
+        secure:
+          vulnerabilityManagement:
+            newEngineOnly: false
+        nodeAnalyzer:
+          runtimeScanner:
+            deploy: true
+      clusterScanner:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Cannot enable both the Runtime Scanner and the Cluster Scanner at the same time"
+
+  - it: Should not fail if node analyzer chart is disabled
+    set:
+      nodeAnalyzer:
+        enabled: false
+        secure:
+          vulnerabilityManagement:
+            newEngineOnly: true
+        nodeAnalyzer:
+          runtimeScanner:
+            deploy: true
+      clusterScanner:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not fail if runtime scanner is disabled
+    set:
+      nodeAnalyzer:
+        enabled: true
+        secure:
+          vulnerabilityManagement:
+            newEngineOnly: true
+        nodeAnalyzer:
+          runtimeScanner:
+            deploy: false
+      clusterScanner:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not fail if cluster scanner is disabled
+    set:
+      nodeAnalyzer:
+        enabled: true
+        secure:
+          vulnerabilityManagement:
+            newEngineOnly: true
+        nodeAnalyzer:
+          runtimeScanner:
+            deploy: true
+      clusterScanner:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## What this PR does / why we need it:

as per the title

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix
