### PR TITLE
fix: adjust RELEASE-NOTES template to avoid extra new lines at the end of the file

### DIFF
--- a/.chglog/RELEASE.tpl.md
+++ b/.chglog/RELEASE.tpl.md
@@ -2,7 +2,7 @@
 {{ if .Versions -}}
 {{ range .Versions }}
 {{ range .CommitGroups -}}
-{{- if not (eq "Ignored" .Title ) -}}
+{{ if not (eq "Ignored" .Title ) -}}
 ### {{ .Title }}
 {{ range .Commits -}}
 - {{ if .Scope }}**{{ .Scope }}** {{ end }}[{{.Hash.Short}}]({{ $.Info.RepositoryURL }}/commit/{{ .Hash.Long }}): {{ .Subject }}
@@ -14,17 +14,15 @@
 {{ end -}}
 {{ end -}}
 {{ end -}}
-
-{{- if .OtherCommits -}}
+{{ if .OtherCommits -}}
 ### Others
-{{ range .OtherCommits -}}
+{{- range .OtherCommits -}}
 - [{{.Hash.Short}}]({{ $.Info.RepositoryURL  }}/commit/{{ .Hash.Long }})
 {{ end -}}
 {{ end -}}
 {{ end -}}
-
 {{- if .Versions }}
-{{ range .Versions -}}
+{{- range .Versions -}}
 {{ if .Tag.Previous -}}
 #### Full diff: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
 {{ end -}}

--- a/charts/cluster-scanner/Chart.yaml
+++ b/charts/cluster-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.1
+version: 0.1.2
 
 appVersion: "0.1.0"
 home: https://www.sysdig.com/

--- a/charts/cluster-scanner/README.md
+++ b/charts/cluster-scanner/README.md
@@ -25,7 +25,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-      --create-namespace -n sysdig --version=0.1.1  \
+      --create-namespace -n sysdig --version=0.1.2  \
       --set global.clusterConfig.name=CLUSTER_NAME \
       --set global.sysdig.region=SYSDIG_REGION \
       --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -55,7 +55,7 @@ To install the chart with the release name `cluster-scanner`, run:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-       --create-namespace -n sysdig --version=0.1.1 \
+       --create-namespace -n sysdig --version=0.1.2 \
        --set global.clusterConfig.name=CLUSTER_NAME \
        --set global.sysdig.region=SYSDIG_REGION \
        --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -146,7 +146,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.1.1 \
+    --create-namespace -n sysdig --version=0.1.2 \
     --set global.sysdig.region="us1"
 ```
 
@@ -155,7 +155,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.1.1 \
+    --create-namespace -n sysdig --version=0.1.2 \
     --values values.yaml
 ```
 

--- a/charts/cluster-scanner/RELEASE-NOTES.md
+++ b/charts/cluster-scanner/RELEASE-NOTES.md
@@ -4,4 +4,3 @@
 - **cluster-scanner** [c952eb44](https://github.com/sysdiglabs/charts/commit/c952eb44af7a45d9a09ed447eebc7cc54b5d1f21): added missing CHANGELOG.md, improved cluster scanner chart. ([#1215](https://github.com/sysdiglabs/charts/issues/1215))
 ### New Features
 - **cluster-scanner** [f9d0dc59](https://github.com/sysdiglabs/charts/commit/f9d0dc595b6c7e926021e7be4b02e0a5c9f6a46b): init chart with minimal templates and configuration ([#1056](https://github.com/sysdiglabs/charts/issues/1056))
-


### PR DESCRIPTION
## What this PR does / why we need it:

Fix the template for `RELESE-NOTES.md` files. It was creating files with an extra new line at the end of the file causing PR checks to fail.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
