### PR TITLE
fix(admission-controller): Make ValidatingWebhookConfiguration part of the resource lifecycle

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: 3.9.22
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.10.0  \
+      --create-namespace -n sysdig-admission-controller --version=0.10.1  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
 ```
@@ -55,7 +55,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.10.0
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.10.1
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -184,7 +184,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.10.0 \
+    --create-namespace -n sysdig-admission-controller --version=0.10.1 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -193,7 +193,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.10.0 \
+    --create-namespace -n sysdig-admission-controller --version=0.10.1 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/templates/webhook/admissionregistration.yaml
+++ b/charts/admission-controller/templates/webhook/admissionregistration.yaml
@@ -10,6 +10,13 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "admissionController.webhook.fullname" . }}
   namespace: {{ include "admissionController.namespace" . }}
+webhooks: []
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "admissionController.webhook.fullname" . }}
+  namespace: {{ include "admissionController.namespace" . }}
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
 webhooks:


### PR DESCRIPTION
## What this PR does / why we need it:

Currently, the ValidatingWebhookConfiguration is created using a post-upgrade and post-install hook. This was made to prevent the webhook registration blocking the deployment of the AC components itself, so it is not registered until AC is correctly deployed. But, **this means the resource is not managed as part of the Helm Chart resource lifecycle, and it won't be removed on uninstall**.

More info: https://helm.sh/docs/topics/charts_hooks/#hook-resources-are-not-managed-with-corresponding-releases

Keeping the webhook registration while the services are not available might mean that the cluster is degraded because there is a configured AC endpoint but the service won't be available.

The fix is creating the  ValidatingWebhookConfiguration as a standard resource, but with an empty webhook list to prevent it from blocking AC components. The post-upgrade and post-install hooks will apply the same resource again but with the right webhooks depending on the configuration.

As the ValidatingWebhookConfiguration is now part of the lifecycle, it will be properly removed on uninstall.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
