### PR TITLE
feat(agent,sysdig-deploy): Add possibility to set proxy settings for dragent.yaml file from global proxy settings

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.9.2
+version: 1.10.0
 
 appVersion: 12.15.0
 

--- a/charts/agent/templates/configmap-deployment.yaml
+++ b/charts/agent/templates/configmap-deployment.yaml
@@ -43,6 +43,18 @@ data:
 {{- if .Values.global.sysdig.tags }}
     tags: {{ include "agent.tags" . }}
 {{- end }}
+{{- if and (or (.Values.proxy.httpProxy | default .Values.global.proxy.httpProxy) (.Values.proxy.httpsProxy | default .Values.global.proxy.httpsProxy)) (not .Values.sysdig.settings.http_proxy) }}
+    proxy:
+      {{- if contains "https" (.Values.proxy.httpProxy | default .Values.global.proxy.httpProxy) }}
+      proxy_host: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "https://" | splitList ":" | first }}
+      proxy_port: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "https://" | splitList ":" | last }}
+      ssl: true
+      {{- else }}
+      proxy_host: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "http://" | splitList ":" | first }}
+      proxy_port: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "http://" | splitList ":" | last }}
+      ssl: false
+      {{- end }}
+{{- end }}
 {{/* add in the remaining items from sysdig.settings */}}
 {{- if .Values.sysdig.settings }}
 {{- toYaml .Values.sysdig.settings | nindent 4 }}

--- a/charts/agent/templates/configmap-deployment.yaml
+++ b/charts/agent/templates/configmap-deployment.yaml
@@ -44,7 +44,7 @@ data:
     tags: {{ include "agent.tags" . }}
 {{- end }}
 {{- if and (or (.Values.proxy.httpProxy | default .Values.global.proxy.httpProxy) (.Values.proxy.httpsProxy | default .Values.global.proxy.httpsProxy)) (not .Values.sysdig.settings.http_proxy) }}
-    proxy:
+    http_proxy:
       {{- if contains "https" (.Values.proxy.httpProxy | default .Values.global.proxy.httpProxy) }}
       proxy_host: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "https://" | splitList ":" | first }}
       proxy_port: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "https://" | splitList ":" | last }}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -26,6 +26,18 @@ data:
 {{- if .Values.global.sysdig.tags }}
     tags: {{ include "agent.tags" . }}
 {{- end }}
+{{- if or (.Values.proxy.httpProxy | default .Values.global.proxy.httpProxy) (.Values.proxy.httpsProxy | default .Values.global.proxy.httpsProxy) }}
+    proxy:
+      {{- if contains "https" (.Values.proxy.httpProxy | default .Values.global.proxy.httpProxy) }}
+      proxy_host: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "https://" | splitList ":" | first }}
+      proxy_port: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "https://" | splitList ":" | last }}
+      ssl: true
+      {{- else }}
+      proxy_host: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "http://" | splitList ":" | first }}
+      proxy_port: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "http://" | splitList ":" | last }}
+      ssl: false
+      {{- end }}
+{{- end }}
 {{/* add in the remaining items from sysdig.settings */}}
 {{- if .Values.sysdig.settings }}
   {{- toYaml .Values.sysdig.settings | trim | nindent 4 }}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -26,7 +26,7 @@ data:
 {{- if .Values.global.sysdig.tags }}
     tags: {{ include "agent.tags" . }}
 {{- end }}
-{{- if or (.Values.proxy.httpProxy | default .Values.global.proxy.httpProxy) (.Values.proxy.httpsProxy | default .Values.global.proxy.httpsProxy) }}
+{{- if and (or (.Values.proxy.httpProxy | default .Values.global.proxy.httpProxy) (.Values.proxy.httpsProxy | default .Values.global.proxy.httpsProxy)) (not .Values.sysdig.settings.http_proxy) }}
     proxy:
       {{- if contains "https" (.Values.proxy.httpProxy | default .Values.global.proxy.httpProxy) }}
       proxy_host: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "https://" | splitList ":" | first }}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
     tags: {{ include "agent.tags" . }}
 {{- end }}
 {{- if and (or (.Values.proxy.httpProxy | default .Values.global.proxy.httpProxy) (.Values.proxy.httpsProxy | default .Values.global.proxy.httpsProxy)) (not .Values.sysdig.settings.http_proxy) }}
-    proxy:
+    http_proxy:
       {{- if contains "https" (.Values.proxy.httpProxy | default .Values.global.proxy.httpProxy) }}
       proxy_host: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "https://" | splitList ":" | first }}
       proxy_port: {{ .Values.proxy.httpProxy | default .Values.global.proxy.httpProxy | trimPrefix "https://" | splitList ":" | last }}

--- a/charts/agent/tests/delegated_agent_deployment_test.yaml
+++ b/charts/agent/tests/delegated_agent_deployment_test.yaml
@@ -308,6 +308,48 @@ tests:
       - templates/daemonset.yaml
       - templates/deployment.yaml
 
+  - it: Test dragent proxy settings
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      proxy:
+        httpProxy: https://192.168.10.2:3128
+        httpsProxy: https://192.168.10.2:3128
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.2"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 3128"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: true"
+    templates:
+      - templates/configmap-deployment.yaml
+      - templates/configmap.yaml
+
+  - it: Test dragent proxy settings without SSL
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      proxy:
+        httpProxy: http://192.168.10.2:3128
+        httpsProxy: http://192.168.10.2:3128
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.2"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 3128"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: false"
+    templates:
+      - templates/configmap-deployment.yaml
+      - templates/configmap.yaml
+
   - it: Check Deployment and Daemonset labels
     set:
       delegatedAgentDeployment:

--- a/charts/agent/tests/delegated_agent_deployment_test.yaml
+++ b/charts/agent/tests/delegated_agent_deployment_test.yaml
@@ -350,6 +350,123 @@ tests:
       - templates/configmap-deployment.yaml
       - templates/configmap.yaml
 
+  - it: Test dragent global proxy settings
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      global:
+        proxy:
+          httpProxy: https://192.168.10.2:3128
+          httpsProxy: https://192.168.10.2:3128
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.2"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 3128"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: true"
+    templates:
+      - templates/configmap-deployment.yaml
+      - templates/configmap.yaml
+
+  - it: Test dragent global proxy settings without SSL
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      global:
+        proxy:
+          httpProxy: http://192.168.10.2:3128
+          httpsProxy: http://192.168.10.2:3128
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.2"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 3128"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: false"
+    templates:
+      - templates/configmap-deployment.yaml
+      - templates/configmap.yaml
+
+  - it: Test dragent proxy settings from sysdig.settings options and not from global settings
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      global:
+        proxy:
+          httpProxy: http://192.168.10.102:8080
+          httpsProxy: http://192.168.10.1022:8080
+      sysdig:
+        settings:
+          http_proxy:
+            proxy_host: 192.168.10.2
+            proxy_port: 3128
+            ssl: true
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.2"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 3128"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: true"
+      - notMatchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.102"
+      - notMatchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 8080"
+      - notMatchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: false"
+    templates:
+      - templates/configmap-deployment.yaml
+      - templates/configmap.yaml
+
+  - it: Test dragent proxy settings from sysdig.settings options and not from local settings
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      proxy:
+        httpProxy: http://192.168.10.102:8080
+        httpsProxy: http://192.168.10.1022:8080
+      sysdig:
+        settings:
+          http_proxy:
+            proxy_host: 192.168.10.2
+            proxy_port: 3128
+            ssl: true
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.2"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 3128"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: true"
+      - notMatchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.102"
+      - notMatchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 8080"
+      - notMatchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: false"
+    templates:
+      - templates/configmap-deployment.yaml
+      - templates/configmap.yaml
+
   - it: Check Deployment and Daemonset labels
     set:
       delegatedAgentDeployment:

--- a/charts/agent/tests/proxy_settings_test.yaml
+++ b/charts/agent/tests/proxy_settings_test.yaml
@@ -1,0 +1,86 @@
+suite: Test proxy settings
+templates:
+  - templates/configmap.yaml
+  - templates/daemonset.yaml
+tests:
+  - it: Test container proxy settings
+    set:
+      proxy:
+        httpProxy: 192.168.10.2
+        httpsProxy: 192.168.10.3
+        noProxy: 192.168.10.4
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: http_proxy
+            value: 192.168.10.2
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: https_proxy
+            value: 192.168.10.3
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: no_proxy
+            value: 192.168.10.4
+    templates:
+      - templates/daemonset.yaml
+
+  - it: Test dragent proxy settings
+    set:
+      proxy:
+        httpProxy: https://192.168.10.2:3128
+        httpsProxy: https://192.168.10.2:3128
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.2"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 3128"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: true"
+    templates:
+      - templates/configmap.yaml
+
+  - it: Test dragent proxy settings without SSL
+    set:
+      proxy:
+        httpProxy: http://192.168.10.2:3128
+        httpsProxy: http://192.168.10.2:3128
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.2"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 3128"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: false"
+    templates:
+      - templates/configmap.yaml
+
+  - it: Test dragent proxy settings from sysdig.settings options
+    set:
+      sysdig:
+        settings:
+          http_proxy:
+            proxy_host: 192.168.10.2
+            proxy_port: 3128
+            ssl: false
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.2"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 3128"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: false"
+    templates:
+      - templates/configmap.yaml

--- a/charts/agent/tests/proxy_settings_test.yaml
+++ b/charts/agent/tests/proxy_settings_test.yaml
@@ -64,8 +64,51 @@ tests:
     templates:
       - templates/configmap.yaml
 
+  - it: Test dragent global proxy settings
+    set:
+      global:
+        proxy:
+          httpProxy: https://192.168.10.102:8080
+          httpsProxy: https://192.168.10.1022:8080
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.102"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 8080"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: true"
+    templates:
+      - templates/configmap.yaml
+
+  - it: Test dragent global proxy settings without SSL
+    set:
+      global:
+        proxy:
+          httpProxy: http://192.168.10.102:8080
+          httpsProxy: http://192.168.10.1022:8080
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.102"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 8080"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: false"
+    templates:
+      - templates/configmap.yaml
+
+
   - it: Test dragent proxy settings from sysdig.settings options
     set:
+      global:
+        proxy:
+          httpProxy: http://192.168.10.102:8080
+          httpsProxy: http://192.168.10.1022:8080
       sysdig:
         settings:
           http_proxy:

--- a/charts/agent/tests/proxy_settings_test.yaml
+++ b/charts/agent/tests/proxy_settings_test.yaml
@@ -103,7 +103,7 @@ tests:
       - templates/configmap.yaml
 
 
-  - it: Test dragent proxy settings from sysdig.settings options
+  - it: Test dragent proxy settings from sysdig.settings options and not from global settings
     set:
       global:
         proxy:
@@ -114,7 +114,7 @@ tests:
           http_proxy:
             proxy_host: 192.168.10.2
             proxy_port: 3128
-            ssl: false
+            ssl: true
     asserts:
       - matchRegex:
           path: data["dragent.yaml"]
@@ -123,6 +123,48 @@ tests:
           path: data["dragent.yaml"]
           pattern: "proxy_port: 3128"
       - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: true"
+      - notMatchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.102"
+      - notMatchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 8080"
+      - notMatchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: false"
+    templates:
+      - templates/configmap.yaml
+
+  - it: Test dragent proxy settings from sysdig.settings options and not from local settings
+    set:
+      proxy:
+        httpProxy: http://192.168.10.102:8080
+        httpsProxy: http://192.168.10.1022:8080
+      sysdig:
+        settings:
+          http_proxy:
+            proxy_host: 192.168.10.2
+            proxy_port: 3128
+            ssl: true
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.2"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 3128"
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: "ssl: true"
+      - notMatchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_host: 192.168.10.102"
+      - notMatchRegex:
+          path: data["dragent.yaml"]
+          pattern: "proxy_port: 8080"
+      - notMatchRegex:
           path: data["dragent.yaml"]
           pattern: "ssl: false"
     templates:

--- a/charts/agent/tests/proxy_settings_test.yaml
+++ b/charts/agent/tests/proxy_settings_test.yaml
@@ -102,7 +102,6 @@ tests:
     templates:
       - templates/configmap.yaml
 
-
   - it: Test dragent proxy settings from sysdig.settings options and not from global settings
     set:
       global:

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -205,12 +205,17 @@ sysdig:
     {}
     ### Example: Agent tags
     # tags: linux:ubuntu,dept:dev,local:nyc
-    ### Example: Proxy configuration (see https://docs.sysdig.com/en/enable-http-proxy-for-agents.html)
     # ssl: false
+    ### In general proxy.httpProxy, proxy.httpsProxy or global.proxy.httpProxy, global.proxy.httpsProxy settings would add required proxy settings to dragent.yaml file of the agent as well. For more advanced configuration following proxy settings should be used.
+    ### Example: Advanced Proxy configuration (see https://docs.sysdig.com/en/enable-http-proxy-for-agents.html)
     # http_proxy:
     #   proxy_host: squid.yourdomain.com
     #   proxy_port: 3128
-    #   ssl: false
+    #   proxy_user: sysdig_customer
+    #   proxy_password: 12345
+    #   ssl: true
+    #   ssl_verify_certificate: true
+    #   ca_certificate: /usr/proxy/proxy_cert.crt
 
 secure:
   # true here enables Sysdig Secure: container run-time security & forensics

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.9.2
+    version: ~1.10.0
     alias: agent
     condition: agent.enabled
   - name: node-analyzer

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.11.0
+version: 1.12.0
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com


### PR DESCRIPTION
## What this PR does / why we need it:
Adding logic to handle proxy settings of dragent.yaml file from global proxy settings without using additional options in sysdig.settings.http_proxy in values file.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
