### PR TITLE
fix(sysdig-deploy): redo deployRuntimeScanner check to remove helm version constraint

### DIFF
--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.12.1
+version: 1.12.2
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.11.0
+version: 1.11.1
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.12.2
+version: 1.12.3
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com

--- a/charts/sysdig-deploy/templates/_helpers.tpl
+++ b/charts/sysdig-deploy/templates/_helpers.tpl
@@ -58,10 +58,13 @@ true
 {{- end }}
 
 {{/*
-Determine whether runtime scanner shall run by including the helper from nodeAnalyzer chart.
-
-Based on: https://github.com/helm/helm/issues/4535#issuecomment-416022809
+Determine whether runtime scanner shall run
 */}}
 {{- define "deployRuntimeScanner" }}
-{{- include "nodeAnalyzer.deployRuntimeScanner" (dict "Chart" (dict "Name" "nodeAnalyzer") "Values" (index .Values "nodeAnalyzer") "Release" .Release "Capabilities" .Capabilities) }}
-{{- end }}
+{{- if (hasKey (.Values.nodeAnalyzer.nodeAnalyzer) "runtimeScanner") }}
+    {{- if and (hasKey .Values.nodeAnalyzer.nodeAnalyzer.runtimeScanner "deploy") (not .Values.nodeAnalyzer.nodeAnalyzer.runtimeScanner.deploy ) }}
+    {{- else if or .Values.nodeAnalyzer.secure.vulnerabilityManagement.newEngineOnly (and (hasKey .Values.nodeAnalyzer.nodeAnalyzer.runtimeScanner "deploy") .Values.nodeAnalyzer.nodeAnalyzer.runtimeScanner.deploy) -}}
+true
+    {{- end -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
## What this PR does / why we need it:
The `deployRuntimeScanner` template function on `sysdig-deploy` was leveraging some nuances of Helm
(https://github.com/helm/helm/issues/4535#issuecomment-416022809) that do not reliably work for us with Helm versions <3.10. The issue comes from the import of a template function from the node-analyzer chart when the user specifies `nodeAnalyzer.enabled=false` and `clusterScanner.enabled=true` when using `sysdig-deploy`. This change duplicates the `deployRuntimeScanner` template logic from the `node-analyzer` chart into the `sysdig-deploy` chart to work around the issue and remove the Helm version requirement.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers