### PR TITLE
fix(cloud-connector): falco rules error on appending exceptions

### DIFF
--- a/charts/cloud-connector/CHANGELOG.md
+++ b/charts/cloud-connector/CHANGELOG.md
@@ -11,6 +11,10 @@ exclusively to fix incorrect entries and not to add new ones.
 
 
 ## Change Log
+# v0.8.3
+* fix: add aws-cloudtrail-s3-sns-sqs ingestor type for CIEM
+* fix: falco rules error on appending exceptions
+
 # v0.8.2
 ### Documentation
 * **cloud-connector** [6ad0ef92](https://github.com/sysdiglabs/charts/commit/6ad0ef926ebf7600ba7730c43219036eb1d0b57c): DOC-3215- Update Cloud connector Readme for clarity and correctness ([#1172](https://github.com/sysdiglabs/charts/issues/1172))

--- a/charts/cloud-connector/Chart.yaml
+++ b/charts/cloud-connector/Chart.yaml
@@ -3,8 +3,8 @@ name: cloud-connector
 description: Sysdig Cloud Connector
 
 type: application
-version: 0.8.2
-appVersion: 0.16.43
+version: 0.8.3
+appVersion: 0.16.46
 home: https://sysdiglabs.github.io/cloud-connector
 
 maintainers:

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -36,7 +36,7 @@ To install the chart:
 helm repo add sysdig https://charts.sysdig.com
 helm repo update
 helm upgrade --install cloud-connector sysdig/cloud-connector \
-     --create-namespace -n cloud-connector --version=0.8.2  \
+     --create-namespace -n cloud-connector --version=0.8.3  \
      --set sysdig.secureAPIToken=<SECURE_API_TOKEN>
 ```
 
@@ -60,7 +60,7 @@ For example:
 
 ```bash
 helm upgrade --install cloud-connector sysdig/cloud-connector \
-     --create-namespace -n cloud-connector --version=0.8.2  \
+     --create-namespace -n cloud-connector --version=0.8.3  \
      --set sysdig.secureAPIToken=<SECURE_API_TOKEN>
 ```
 
@@ -72,7 +72,7 @@ For example:
 
 ```bash
 helm upgrade --install cloud-connector sysdig/cloud-connector \
-     --create-namespace -n cloud-connector --version=0.8.2  \
+     --create-namespace -n cloud-connector --version=0.8.3  \
     --values values.yaml
 ```
 


### PR DESCRIPTION
## What this PR does / why we need it:
* fix Secure For Cloud GCP on falco rules error when appending exceptions
* fix: adds aws-cloudtrail-s3-sns-sqs ingestor type for CIEM

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
