### PR TITLE
feat(admission-controller): Add labels to VAC webhook to adopt existing one

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.11.3
+version: 0.11.4
 appVersion: 3.9.24
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.11.3  \
+      --create-namespace -n sysdig-admission-controller --version=0.11.4  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
 ```
@@ -55,7 +55,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.11.3
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.11.4
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -184,7 +184,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.11.3 \
+    --create-namespace -n sysdig-admission-controller --version=0.11.4 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -193,7 +193,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.11.3 \
+    --create-namespace -n sysdig-admission-controller --version=0.11.4 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/templates/webhook/admissionregistration.yaml
+++ b/charts/admission-controller/templates/webhook/admissionregistration.yaml
@@ -5,12 +5,15 @@ so the template is executed just once
 {{- $certString := include "admissionController.webhook.gen-certs" . -}}
 {{- $certList := split "$" $certString -}}
 ---
+{{- $existingVac := (lookup "admissionregistration.k8s.io/v1" "ValidatingWebhookConfiguration" (include "admissionController.namespace" .) (include "admissionController.webhook.fullname" .))}}
+{{- if (or (not $existingVac) (and $existingVac (eq (index $existingVac.metadata.annotations "meta.helm.sh/release-name") .Release.Name ) (eq (index $existingVac.metadata.annotations "meta.helm.sh/release-namespace") .Release.Namespace ))) }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "admissionController.webhook.fullname" . }}
   namespace: {{ include "admissionController.namespace" . }}
 webhooks: []
+{{- end}}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -19,6 +22,10 @@ metadata:
   namespace: {{ include "admissionController.namespace" . }}
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
 webhooks:
 {{- if .Values.scanner.enabled }}
 - name: scanning.secure.sysdig.com


### PR DESCRIPTION
## What this PR does / why we need it:

A recent change in the chart prevents the AC from installing if it was an upgrade from a previous version. The reason is that the old chart didn't treat the VAC registration as part of the lifecycle, and now we are doing.

To fix this, now we skip creating the resource as part of the lifecycle in case it already exists but doesn't contain the right annotations to be adopted. In the post-install hook we set the right annotations, so next upgrade or install, it will be adopted as part of the lifecycle and managed correct.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
