### PR TITLE
feature(admission-controller,agent,kspm-collector,node-analyzer,rapid-response,sysdig-deploy): update the unittest plugin

### DIFF
--- a/.github/workflows/helm-unit-test.yaml
+++ b/.github/workflows/helm-unit-test.yaml
@@ -17,7 +17,7 @@ jobs:
           version: v3.4.0
 
       - name: Set up helm unit test plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version=0.3.0
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version=0.3.3
 
       - name: Bundle chart dependencies
         run: make deps

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ lint:
 	docker run --rm -e CT_VALIDATE_MAINTAINERS=false -u $(shell id -u) -v $(PWD):/charts quay.io/helmpack/chart-testing:latest sh -c "cd /charts; ct lint --all"
 
 deps-unittest:
-	@helm plugin install https://github.com/helm-unittest/helm-unittest --version=0.3.0 || true
+	@helm plugin install https://github.com/helm-unittest/helm-unittest --version=0.3.3 || true
 
 unittest: deps-unittest
 	find ./charts -name "Chart.yaml" | \

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.11.5
+version: 0.11.6
 appVersion: 3.9.24
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.11.5  \
+      --create-namespace -n sysdig-admission-controller --version=0.11.6  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
 ```
@@ -55,7 +55,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.11.5
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.11.6
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -181,7 +181,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.11.5 \
+    --create-namespace -n sysdig-admission-controller --version=0.11.6 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -190,7 +190,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.11.5 \
+    --create-namespace -n sysdig-admission-controller --version=0.11.6 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/tests/label_test.yaml
+++ b/charts/admission-controller/tests/label_test.yaml
@@ -99,10 +99,10 @@ tests:
       labels: "my.label/key1: "
       clusterName: test-k8s
     asserts:
-    - isNull:
+    - isEmpty:
         path: metadata.labels['my.label/key1']
       template: scanner/deployment.yaml
-    - isNull:
+    - isEmpty:
         path: metadata.labels['my.label/key1']
       template: webhook/deployment.yaml
 
@@ -161,7 +161,7 @@ tests:
       clusterName: test-k8s
     template: scanner/deployment.yaml
     asserts:
-    - isNull:
+    - isEmpty:
         path: metadata.labels['my.label/key1']
 
   - it: check application of incorrect admission controller scanner labels with yaml
@@ -221,7 +221,7 @@ tests:
       clusterName: test-k8s
     template: webhook/deployment.yaml
     asserts:
-    - isNull:
+    - isEmpty:
         path: metadata.labels['my.label/key1']
 
   - it: check application of incorrect admission controller webhook labels with yaml

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.11.0
+version: 1.11.1
 
 appVersion: 12.15.0
 

--- a/charts/agent/tests/conditional_flag_test.yaml
+++ b/charts/agent/tests/conditional_flag_test.yaml
@@ -11,9 +11,9 @@ tests:
       - equal:
           path: spec.template.metadata.annotations['autopilot.gke.io/no-connect']
           value: "true"
-      - isNull:
+      - isNullOrEmpty:
           path: spec.template.spec.affinity
-      - isNull:
+      - isEmpty:
           path: spec.template.spec.initContainers[0].env[?(@.name == "SYSDIG_BPF_PROBE")].value
       - equal:
           path: spec.template.spec.initContainers[*].volumeMounts[?(@.name == "bpf-probes")].mountPath

--- a/charts/agent/tests/k8s_coldstart_test.yaml
+++ b/charts/agent/tests/k8s_coldstart_test.yaml
@@ -14,7 +14,6 @@ tests:
               enabled: true
               enforce_leader_election: true
               namespace: NAMESPACE
-    template: templates/configmap.yaml
 
   - it: Enable leaderelection and specify custom cold start number
     set:
@@ -29,7 +28,6 @@ tests:
               enabled: true
               enforce_leader_election: true
               namespace: NAMESPACE
-    template: templates/configmap.yaml
 
   - it: Test manual setting of k8s_coldstart values
     set:

--- a/charts/agent/tests/label_test.yaml
+++ b/charts/agent/tests/label_test.yaml
@@ -52,7 +52,7 @@ tests:
       daemonset:
         labels: "my.label/key1: "
     asserts:
-    - isNull:
+    - isEmpty:
         path: metadata.labels['my.label/key1']
   - it: check application of incorrect agent labels with yaml
     set:

--- a/charts/agent/tests/notes_test.yaml
+++ b/charts/agent/tests/notes_test.yaml
@@ -479,7 +479,6 @@ tests:
       - matchRegexRaw:
           pattern: |-
             A PriorityClass is recommended for GKE Autopilot environments. Please set gke.createPriorityClass=true or provide the name of an existing PriorityClass by using the priorityClassName parameter.
-    template: templates/NOTES.txt
 
   - it: Test warning not printed for GKE Autopilot environments when PriorityClass creation specified
     set:
@@ -492,7 +491,6 @@ tests:
       - notMatchRegexRaw:
           pattern: |-
             A PriorityClass is recommended for GKE Autopilot environments. Please set gke.createPriorityClass=true or provide the name of an existing PriorityClass by using the priorityClassName parameter.
-    template: templates/NOTES.txt
 
   - it: Test warning not printed for GKE Autopilot environments when priorityClassName is specified
     set:
@@ -505,4 +503,3 @@ tests:
       - notMatchRegexRaw:
           pattern: |-
             A PriorityClass is recommended for GKE Autopilot environments. Please set gke.createPriorityClass=true or provide the name of an existing PriorityClass by using the priorityClassName parameter.
-    template: templates/NOTES.txt

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -7,21 +7,17 @@ tests:
       - equal:
           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "varrun-vol")].mountPath
           value: /host/var/run
-        template: templates/daemonset.yaml
       - equal:
           path: spec.template.spec.volumes[?(@.name == "varrun-vol")].hostPath.path
           value: /var/run
-        template: templates/daemonset.yaml
   - it: Ensure /var/lib host volume is mounted as /host/var/lib in container
     asserts:
       - equal:
           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "varlib-vol")].mountPath
           value: /host/var/lib
-        template: templates/daemonset.yaml
       - equal:
           path: spec.template.spec.volumes[?(@.name == "varlib-vol")].hostPath.path
           value: /var/lib
-        template: templates/daemonset.yaml
   - it: Ensure /var/lib host volume is not mounted as /host/var/lib in container when running on gke.autopilot
     set:
       gke:
@@ -29,10 +25,8 @@ tests:
     asserts:
       - isNull:
           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "varlib-vol")]
-        template: templates/daemonset.yaml
       - isNull:
           path: spec.template.spec.volumes[?(@.name == "varlib-vol")]
-        template: templates/daemonset.yaml
   - it: Ensure /var/lib host volume is not mounted as /host/var/lib in container when running on global.gke.autopilot
     set:
       global:
@@ -41,7 +35,5 @@ tests:
     asserts:
       - isNull:
           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "varlib-vol")]
-        template: templates/daemonset.yaml
       - isNull:
           path: spec.template.spec.volumes[?(@.name == "varlib-vol")]
-        template: templates/daemonset.yaml

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.3.3
+version: 0.3.4
 appVersion: 1.26.0
 
 keywords:

--- a/charts/kspm-collector/tests/conditional_flag_test.yaml
+++ b/charts/kspm-collector/tests/conditional_flag_test.yaml
@@ -1,7 +1,6 @@
 suite: Test conditional flags and its dependent changes
 templates:
   - serviceaccount.yaml
-  - deployment.yaml
 tests:
   - it: check global kspm deploy
     set:
@@ -13,4 +12,3 @@ tests:
       - containsDocument:
           kind: ServiceAccount
           apiVersion: v1
-        template: serviceaccount.yaml

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.11.0
+version: 1.11.1
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/tests/daemonset_update_strategy_test.yaml
+++ b/charts/node-analyzer/tests/daemonset_update_strategy_test.yaml
@@ -48,4 +48,3 @@ tests:
               maxSurge: 1
               maxUnavailable: 2
             type: RollingUpdate
-        template: templates/daemonset-node-analyzer.yaml

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.2
+version: 0.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rapid-response/tests/custom_resources.yaml
+++ b/charts/rapid-response/tests/custom_resources.yaml
@@ -25,4 +25,3 @@ tests:
                 memory: 1500Mi
           any: true
           count: 1
-        template: daemonset.yaml

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.14.0
+version: 1.14.1
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com

--- a/charts/sysdig-deploy/tests/notes_test.yaml
+++ b/charts/sysdig-deploy/tests/notes_test.yaml
@@ -465,6 +465,9 @@ tests:
       global:
         sysdig:
           region: ap3
+      # TODO: This is required to have the test pass, need more investigation on the reason why agent.enabled=false is required
+      agent:
+        enabled: false
     asserts:
       - failedTemplate:
           errorMessage: "raw: global.sysdig.region=ap3 provided is not recognized."


### PR DESCRIPTION
## What this PR does / why we need it:

- Update the unittest helm's plugin
- Fix tests

## Checklist

- [ ] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix