### PR TITLE
feature(agent,common,sysdig-deploy,sysdig): Update mantainer and set the sysdig chart deprecated.

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.12.0
+version: 1.12.1
 
 appVersion: 12.15.0
 
@@ -22,10 +22,16 @@ sources:
   - https://app.sysdigcloud.com/#/settings/user
   - https://github.com/draios/sysdig
 maintainers:
+  - name: AlbertoBarba
+    email: alberto.barba@sysdig.com
   - name: aroberts87
     email: adam.roberts@sysdig.com
-  - name: lilx1ao
-    email: zhongcheng.xiao@sysdig.com
+  - name: francesco-furlan
+    email: francesco.furlan@sysdig.com
+  - name: iurly
+    email: gerlando.falauto@sysdig.com
+  - name: mavimo
+    email: marcovito.moscaritolo@sysdig.com
 dependencies:
   - name: common
     # repository: https://charts.sysdig.com

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -16,8 +16,16 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 maintainers:
+  - name: AlbertoBarba
+    email: alberto.barba@sysdig.com
   - name: aroberts87
     email: adam.roberts@sysdig.com
+  - name: francesco-furlan
+    email: francesco.furlan@sysdig.com
+  - name: iurly
+    email: gerlando.falauto@sysdig.com
+  - name: mavimo
+    email: marcovito.moscaritolo@sysdig.com

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,12 +2,18 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.15.2
+version: 1.15.3
 maintainers:
+  - name: AlbertoBarba
+    email: alberto.barba@sysdig.com
   - name: aroberts87
     email: adam.roberts@sysdig.com
-  - name: lilx1ao
-    email: zhongcheng.xiao@sysdig.com
+  - name: francesco-furlan
+    email: francesco.furlan@sysdig.com
+  - name: iurly
+    email: gerlando.falauto@sysdig.com
+  - name: mavimo
+    email: marcovito.moscaritolo@sysdig.com
 home: https://www.sysdig.com/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 dependencies:

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.16.3
+version: 1.16.4
 appVersion: 12.15.0
 description: Sysdig Monitor and Secure agent
 keywords:
@@ -15,14 +15,4 @@ icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 sources:
   - https://app.sysdigcloud.com/#/settings/user
   - https://github.com/draios/sysdig
-maintainers:
-  - name: lachie83
-    email: lachlan@deis.com
-  - name: bencer
-    email: jorge.salamero@sysdig.com
-  - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
-  - name: airadier
-    email: alvaro.iradier@sysdig.com
-  - name: carillan81
-    email: carlos.arilla@sysdig.com
+deprecated: true


### PR DESCRIPTION
## What this PR does / why we need it:
 - update mantainers
 - set the sysdig chart deprecated.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix
