### PR TITLE
feat(agent,rapid-response): set metadata.namespace on all namespaced items

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.11.1
+version: 1.12.0
 
 appVersion: 12.15.0
 

--- a/charts/agent/templates/role.yaml
+++ b/charts/agent/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "agent.fullname" . }}
+  namespace: {{ include "agent.namespace" . }}
 rules:
 - apiGroups:
     - coordination.k8s.io

--- a/charts/agent/templates/rolebinding.yaml
+++ b/charts/agent/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "agent.fullname" .}}
+  namespace: {{ include "agent.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rapid-response/templates/configmap.yaml
+++ b/charts/rapid-response/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "rapidResponse.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "rapidResponse.labels" . | indent 4 }}
 data:

--- a/charts/rapid-response/templates/daemonset.yaml
+++ b/charts/rapid-response/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "rapidResponse.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "rapidResponse.labels" . | indent 4 }}
 {{ include "rapidResponse.daemonSetLabels" . | indent 4 }}

--- a/charts/rapid-response/templates/secrets.yaml
+++ b/charts/rapid-response/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "rapidResponse.fullname" . }}-access-key
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "rapidResponse.labels" . | indent 4 }}
 type: Opaque
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "rapidResponse.fullname" . }}-passphrase
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "rapidResponse.labels" . | indent 4 }}
 type: Opaque
@@ -27,6 +29,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "rapidResponse.fullname" . }}-additionalca
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "rapidResponse.labels" . | indent 4 }}
 type: Opaque

--- a/charts/rapid-response/templates/serviceaccount.yaml
+++ b/charts/rapid-response/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "rapidResponse.serviceAccountName" .}}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "rapidResponse.labels" . | indent 4 }}
 {{- end }}

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.14.3
+version: 1.15.0
 maintainers:
   - name: aroberts87
     email: adam.roberts@sysdig.com
@@ -20,7 +20,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.11.1
+    version: ~1.12.0
     alias: agent
     condition: agent.enabled
   - name: common
@@ -48,6 +48,6 @@ dependencies:
   - name: rapid-response
     # repository: https://charts.sysdig.com
     repository: file://../rapid-response
-    version: ~0.6.3
+    version: ~0.7.0
     alias: rapidResponse
     condition: rapidResponse.enabled


### PR DESCRIPTION
## What this PR does / why we need it:
There were a handful of places in the charts related to `sysdig-deploy` where the `metadata.namespace` field was not being explicitly set. This is works out fine as Helm will set those fields itself during the `helm install` process, but does not do so during a call to `helm template`. This has been found to cause issues with come CI platforms that  generate manifest files via `helm template` and then apply them later with `kubectl apply -f ...`. What has been observed is that these select CI platforms will patch the manifests of namespaced items that do not have `metadata.namespace` set, and will do so with an unexpected value. When the subsequent `kubectl apply -f ...` command is run that supplies the desired namespace, the command fails because the namespace field is already set on these items and is different from what is being requested. This change ensures that all namespaced items have the values of `metadata.namespace` explicitly set to prevent the above issue.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

Check Contribution guidelines in README.md for more insight.
