### PR TITLE
chore(node-analyzer): toggle volumes used by runtimeScanner and imageAnalyzer

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.14.0
+version: 1.14.1
 appVersion: 12.6.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -40,7 +40,7 @@ spec:
             name: {{ include "nodeAnalyzer.configmapName" . }}
             optional: true
         {{- end }}
-        {{- if include "nodeAnalyzer.deployRuntimeScanner" . }}
+        {{- if or (include "nodeAnalyzer.deployRuntimeScanner" .) (include "nodeAnalyzer.deployImageAnalyzer" .)}}
         # Needed for cri-o image inspection.
         # cri-o and especially OCP 4.x by default use containers/storage to handle images, and this makes sure that the
         # analyzer has access to the configuration. This file is mounted read-only.

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -40,6 +40,7 @@ spec:
             name: {{ include "nodeAnalyzer.configmapName" . }}
             optional: true
         {{- end }}
+        {{- if include "nodeAnalyzer.deployRuntimeScanner" . }}
         # Needed for cri-o image inspection.
         # cri-o and especially OCP 4.x by default use containers/storage to handle images, and this makes sure that the
         # analyzer has access to the configuration. This file is mounted read-only.
@@ -66,6 +67,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-image-analyzer
             optional: true
+        {{- end }}
         {{- if or (include "nodeAnalyzer.deployHostScanner" .) (include "nodeAnalyzer.deployBenchmarkRunner" .) (include "nodeAnalyzer.deployHostAnalyzer" .) .Values.global.kspm.deploy }}
         # Needed to run Benchmarks and Host Analyzer/Scanner. This mount is read-only.
         # Benchmarks include numerous checks that run tests against config files in the host filesystem. There are also

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.17.1
+version: 1.17.2
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -36,7 +36,7 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.14.0
+    version: ~1.14.1
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: cluster-scanner


### PR DESCRIPTION
## What this PR does / why we need it:

Don't mount volumes needed just for runtimeScanner and imageAnalyzer when their both disabled.
This is needed since GKE autopilot doesn’t allow mounting volumes not used.
Preliminary work for SMAGENT-5237 and SMAGENT-5236

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
