### PR TITLE
fix(admission-controller,agent,sysdig-deploy): fix incompatibility errors on older helm versions

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.12.0
+version: 0.12.1
 appVersion: 3.9.26
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-      --create-namespace -n sysdig-admission-controller --version=0.12.0  \
+      --create-namespace -n sysdig-admission-controller --version=0.12.1  \
       --set clusterName=CLUSTER_NAME \
       --set sysdig.secureAPIToken=SECURE_API_TOKEN
 ```
@@ -55,7 +55,7 @@ This chart deploys the Sysdig Admission Controller on a [Kubernetes](http://kube
 To install the chart with the release name `admission-controller`:
 
 ```console
-$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.12.0
+$ helm upgrade --install sysdig-admission-controller sysdig/admission-controller -n sysdig-admission-controller --version=0.12.1
 ```
 
 The command deploys the Sysdig Admission Controller on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -199,7 +199,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.12.0 \
+    --create-namespace -n sysdig-admission-controller --version=0.12.1 \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -208,7 +208,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.12.0 \
+    --create-namespace -n sysdig-admission-controller --version=0.12.1 \
     --values values.yaml
 ```
 

--- a/charts/admission-controller/templates/webhook/admissionregistration.yaml
+++ b/charts/admission-controller/templates/webhook/admissionregistration.yaml
@@ -6,7 +6,10 @@ so the template is executed just once
 {{- $certList := split "$" $certString -}}
 ---
 {{- $existingVac := (lookup "admissionregistration.k8s.io/v1" "ValidatingWebhookConfiguration" (include "admissionController.namespace" .) (include "admissionController.webhook.fullname" .))}}
-{{- if (or (not $existingVac) (and $existingVac (eq (index $existingVac.metadata.annotations "meta.helm.sh/release-name") .Release.Name ) (eq (index $existingVac.metadata.annotations "meta.helm.sh/release-namespace") .Release.Namespace ))) }}
+{{- $existingVacMetadataAnnotations := (default dict (default dict $existingVac.metadata).annotations) }}
+{{- $existingVacMetadataAnnotationsReleaseName := (default "" (index $existingVacMetadataAnnotations "meta.helm.sh/release-name")) }}
+{{- $existingVacMetadataAnnotationsReleaseNamespace := (default "" (index $existingVacMetadataAnnotations "meta.helm.sh/release-namespace")) }}
+{{- if (or (not $existingVac) (and $existingVac (eq $existingVacMetadataAnnotationsReleaseName .Release.Name ) (eq $existingVacMetadataAnnotationsReleaseNamespace .Release.Namespace ))) }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.13.1
+version: 1.13.2
 
 appVersion: 12.15.0
 

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
   Checking here the user is using Custom CA and if http_proxy.ssl = true
   If these conditions are true, then we use the agent.sslCaFileName for the http_proxy.ca_certificate
 */}}
-{{- if and (eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") (.Values.sysdig.settings) (hasKey .Values.sysdig.settings "http_proxy") (hasKey .Values.sysdig.settings.http_proxy "ssl") (eq (get .Values.sysdig.settings.http_proxy "ssl") true) }}
+{{- if and (eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") (.Values.sysdig.settings) (hasKey .Values.sysdig.settings "http_proxy") (hasKey (default dict .Values.sysdig.settings.http_proxy) "ssl") (eq (get (default (dict "ssl" false) .Values.sysdig.settings.http_proxy) "ssl") true) }}
   {{- $baseSettings := .Values.sysdig.settings -}}
   {{- $caFilePath := printf "%s%s" "/etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
   {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.13.1
+    version: ~1.13.2
     alias: agent
     condition: agent.enabled
   - name: common

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.17.3
+version: 1.17.4
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
   - name: admission-controller
     # repository: https://charts.sysdig.com
     repository: file://../admission-controller
-    version: ~0.12.0
+    version: ~0.12.1
     alias: admissionController
     condition: admissionController.enabled
   - name: agent


### PR DESCRIPTION
## What this PR does / why we need it:

Currently, the sysdig-deploy chart reports some errors when using older versions of helm (currently tested on 3.7.1).
It seems these errors are caused by a different behaviour while accessing possible null dicts.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix