### PR TITLE
docs(registry-scanner): fix configuration table rendering

### DIFF
--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 1.1.3
+version: 1.1.4
 appVersion: 0.2.42
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -117,6 +117,7 @@ The following table lists the configurable parameters of the Sysdig Registry Sca
 | scanOnStart.jobName                              | The name of the job created for the post-install scanner job                                                                                                                                                                               | <code>"registry-scanner-start-test"</code>   |
 | scanOnStart.asPostInstallHook                    | Specify whether to launch the job as a post-install helm hook. <br/>Used for testing purpose.                                                                                                                                              | <code>false</code>                           |
 | extraEnvVars                                     | The additional environment variables to be set.                                                                                                                                                                                            | <code>[]</code>                              |
+
 ## On-Prem Deployment
 
 If you are using a Sysdig on-prem version greater than 6.2, you need to configure legacy VM engine while setting up registry scanner.

--- a/charts/registry-scanner/README.tpl
+++ b/charts/registry-scanner/README.tpl
@@ -49,8 +49,7 @@ Once installed, you can view the scan results in the [Vulnerabilities UI](https:
 The following table lists the configurable parameters of the Sysdig Registry Scanner chart and their default values:
 
 {{ .Chart.Values }}
-{{- end -}}
-
+{{- end }}
 ## On-Prem Deployment
 
 If you are using a Sysdig on-prem version greater than 6.2, you need to configure legacy VM engine while setting up registry scanner.


### PR DESCRIPTION
## What this PR does / why we need it:
The Configuration Parameters table at the bottom of the Node Analyzer chart page is all mangled on [charts.sysdig.com](https://charts.sysdig.com/charts/registry-scanner/#configuration-parameters) (while it looks fine on GitHub).

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
