### PR TITLE
fix(agent): fix Chart.yaml field

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.13.3
+version: 1.13.4
 
 appVersion: 12.16.0
 
@@ -36,4 +36,4 @@ dependencies:
   - name: common
     # repository: https://charts.sysdig.com
     repository: file://../common
-version: 1.13.3~1.1.1
+    version: ~1.1.0


### PR DESCRIPTION
## What this PR does / why we need it:
The agent release pipeline had not been updated to handle two `version` keys in the agent chart's `Chart.yaml` file and accidentally mangled the version field of the `common` chart dependency.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
