### PR TITLE
feat(registry-scanner): user/passwords field optionals when dockerv2

### DIFF
--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 1.1.4
+version: 1.1.5
 appVersion: 0.2.42
 maintainers:
   - name: airadier

--- a/charts/registry-scanner/templates/secret.yaml
+++ b/charts/registry-scanner/templates/secret.yaml
@@ -12,6 +12,9 @@ data:
   aws_access_key_id: {{ .Values.config.aws.accessKeyId | b64enc | quote }}
   aws_secret_access_key: {{ .Values.config.aws.secretAccessKey | b64enc | quote }}
   aws_region: {{ required "A valid .Values.config.aws.region is required" .Values.config.aws.region | b64enc | quote }}
+  {{- else if eq .Values.config.registryType "dockerv2" }}
+  registryUser: {{ .Values.config.registryUser | b64enc | quote }}
+  registryPassword: {{ .Values.config.registryPassword | b64enc | quote }}
   {{- else }}
   registryUser: {{ required "A valid .Values.config.registryUser is required" .Values.config.registryUser | b64enc | quote }}
   registryPassword: {{ required "A valid .Values.config.registryPassword is required" .Values.config.registryPassword | b64enc | quote }}


### PR DESCRIPTION
## What this PR does / why we need it:

Removes the requirement for `registryUser` and `registryPassword` 

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix