### PR TITLE
fix(agent): don't duplicate `cointerface_enabled` field in deployment agent configmaps

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -5,7 +5,7 @@ description: Sysdig Monitor and Secure agent
 type: application
 
 # currently matching sysdig 1.14.32
-version: 1.13.5
+version: 1.13.6
 
 appVersion: 12.16.0
 

--- a/charts/agent/templates/configmap-deployment.yaml
+++ b/charts/agent/templates/configmap-deployment.yaml
@@ -8,35 +8,34 @@ metadata:
 {{ include "agent.labels" . | indent 4 }}
 data:
   dragent.yaml: |
-    new_k8s: true
 {{- include "agent.clusterName" . | trim | nindent 4 }}
 {{- include "agent.connectionSettings" . | trim | nindent 4 }}
-    feature:
-      mode: monitor_light
-    cointerface_enabled: true
-    k8s_delegated_nodes: {{ .Values.delegatedAgentDeployment.delegated_nodes | int }}
-    top_processes_in_sample: 0
-    container_engines:
-      bpm: false
-      cri: false
-      docker: false
-      libvirt_lxc: false
-      lxc: false
-      mesos: false
-      podman: false
-      rkt: false
-    app_checks_enabled: false
-    jmx:
-      enabled: false
-    prometheus:
-      enabled: false
-    statsd:
-      enabled: false
+{{- $requiredOverrides := (dict
+  "new_k8s" true
+  "feature" (dict "mode" "monitor_light")
+  "cointerface_enabled" true
+  "k8s_delegated_nodes" (.Values.delegatedAgentDeployment.delegated_nodes | int)
+  "top_processes_in_sample" 0
+  "container_engines" (dict
+    "bpm" false
+    "cri" false
+    "docker" false
+    "libvirt_lxc" false
+    "lxc" false
+    "mesos" false
+    "podman" false
+    "rkt" false
+  )
+  "app_checks_enabled" false
+  "jmx" (dict "enabled" false)
+  "prometheus" (dict "enabled" false)
+  "statsd" (dict "enabled" false)
+) }}
 {{/* Calculate the leaderElection/k8s_colstart information.
      The computed/combined results are merged with any overrides specified
      in sysdig.settings and will be rendered with that block */}}
 {{- include "agent.leaderElection" . }}
-{{ include "agent.disableCaptures" . | nindent 4 }}
+{{- include "agent.disableCaptures" . | nindent 4 }}
 {{- $_ := mergeOverwrite .Values.secure (dict "enabled" false) }}
 {{- (include "agent.secureFeatures" .) | nindent 4 }}
 {{- include "agent.logSettings" . }}
@@ -47,12 +46,13 @@ data:
   Checking here the user is using Custom CA and if http_proxy.ssl = true
   If these conditions are true, then we use the agent.sslCaFileName for the http_proxy.ca_certificate
 */}}
+{{- $baseSettings := .Values.sysdig.settings -}}
 {{- if and (eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") (.Values.sysdig.settings) (hasKey .Values.sysdig.settings "http_proxy") (hasKey .Values.sysdig.settings.http_proxy "ssl") (eq (get .Values.sysdig.settings.http_proxy "ssl") true) }}
-  {{- $baseSettings := .Values.sysdig.settings -}}
   {{- $caFilePath := printf "%s%s" "/etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
   {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}
-  {{ toYaml $mergedSettings | nindent 4 }}
-{{- else if (omit .Values.sysdig.settings "cointerface_enabled") }}
-  {{ toYaml (omit .Values.sysdig.settings "cointerface_enabled") | nindent 4 }}
+  {{- $finalSettings := mergeOverwrite $mergedSettings $requiredOverrides -}}
+  {{ toYaml $finalSettings | nindent 4 }}
 {{- end }}
+  {{- $finalSettings := mergeOverwrite $baseSettings $requiredOverrides -}}
+  {{ toYaml $finalSettings | nindent 4 }}
 {{- end }}

--- a/charts/agent/templates/configmap-deployment.yaml
+++ b/charts/agent/templates/configmap-deployment.yaml
@@ -52,7 +52,7 @@ data:
   {{- $caFilePath := printf "%s%s" "/etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
   {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}
   {{ toYaml $mergedSettings | nindent 4 }}
-{{- else if .Values.sysdig.settings }}
-  {{ toYaml .Values.sysdig.settings | nindent 4 }}
+{{- else if (omit .Values.sysdig.settings "cointerface_enabled") }}
+  {{ toYaml (omit .Values.sysdig.settings "cointerface_enabled") | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/agent/tests/custom_settings_test.yaml
+++ b/charts/agent/tests/custom_settings_test.yaml
@@ -18,6 +18,11 @@ tests:
             .*
             first:
               value: 1
+            .*
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            .*
             second: example
             .*
     template: configmap.yaml
@@ -45,6 +50,11 @@ tests:
             .*
             first:
               value: 1
+            .*
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            .*
             second: example
             .*
     template: configmap.yaml
@@ -66,6 +76,11 @@ tests:
             .*
             first:
               value: 1
+            .*
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            .*
             second: example
             .*
     template: configmap-deployment.yaml
@@ -95,6 +110,11 @@ tests:
             .*
             first:
               value: 1
+            .*
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            .*
             second: example
             .*
     template: configmap-deployment.yaml

--- a/charts/agent/tests/delegated_agent_deployment_test.yaml
+++ b/charts/agent/tests/delegated_agent_deployment_test.yaml
@@ -561,3 +561,71 @@ tests:
           path: data['dragent.yaml']
           pattern: 'cointerface_enabled: false'
         template: templates/configmap-deployment.yaml
+
+  - it: Validate cointerface_enabled keys are not duplicated
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      sysdig:
+        settings:
+          cointerface_enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: false'
+        template: templates/configmap-deployment.yaml
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: true'
+        template: templates/configmap-deployment.yaml
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: true'
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: false'
+        template: templates/configmap.yaml
+
+  - it: Validate cointerface_enabled keys are not duplicated
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      sysdig:
+        settings:
+          cointerface_enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: false'
+        template: templates/configmap-deployment.yaml
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: true'
+        template: templates/configmap-deployment.yaml
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: false'
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: true'
+        template: templates/configmap.yaml
+
+  - it: Ensure settings overrides are still provided to deployment configmap
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      sysdig:
+        settings:
+          logs:
+            console_priority: debug
+          cointerface_enabled: false
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: 'logs:\n  console_priority: debug'
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: 'cointerface_enabled: false'
+    template: templates/configmap-deployment.yaml


### PR DESCRIPTION
## What this PR does / why we need it:
The value `cointerface_enabled: true` is hardcoded into the deployment agent's configmap by design, but if the value were overridden in `sysdig.settings` the field would end up being duplicated when the deployment configmap blindly rendered out that block. This fix addresses that issue by omitting that key when rendering the set of values from the `sysdig.settings` block.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
