### PR TITLE
fix(sysdig-deploy): install deps on all charts before release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,6 +120,14 @@ jobs:
           GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
           GPG_PRIVATE_KEY: "${{ secrets.GPG_PRIVATE_KEY }}"
 
+      - name: Set up Helm
+        uses: azure/setup-helm@v3.5
+        with:
+          version: v3.10.3
+
+      - name: Bundle chart dependencies
+        run: make deps
+
       - name: Run Chart Releaser
         uses: helm/chart-releaser-action@v1.5.0
         with:

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.17.10
+version: 1.17.11
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com


### PR DESCRIPTION
## What this PR does / why we need it:

It seems we currently have some issues with dependencies when the release does not affect every chart causing missing subdependencies.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
