### PR TITLE
feat(cluster-scanner): allow to configure http proxy

### DIFF
--- a/charts/cluster-scanner/Chart.yaml
+++ b/charts/cluster-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Cluster Scanner
 
 type: application
 
-version: 0.4.1
+version: 0.5.0
 
 appVersion: "0.1.0"
 home: https://www.sysdig.com/

--- a/charts/cluster-scanner/README.md
+++ b/charts/cluster-scanner/README.md
@@ -25,7 +25,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-      --create-namespace -n sysdig --version=0.4.1  \
+      --create-namespace -n sysdig --version=0.5.0  \
       --set global.clusterConfig.name=CLUSTER_NAME \
       --set global.sysdig.region=SYSDIG_REGION \
       --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -55,7 +55,7 @@ To install the chart with the release name `cluster-scanner`, run:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-       --create-namespace -n sysdig --version=0.4.1 \
+       --create-namespace -n sysdig --version=0.5.0 \
        --set global.clusterConfig.name=CLUSTER_NAME \
        --set global.sysdig.region=SYSDIG_REGION \
        --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -93,6 +93,7 @@ The following table lists the configurable parameters of the `cluster-scanner` c
 | global.sysdig.region                               | Region name for Sysdig. Valid options: `us1`, `us2`, `us3`, `us4`, `eu1`, `au1`. When no region is suitable (e.g. on-premise installations) set the `global.sysdig.apiHost: ""` parameter.                                                                                                                                                                                                                              | <code>"us1"</code>                            |
 | global.image.pullSecrets                           | The pull secrets for Cluster Scanner                                                                                                                                                                                                                                                                                                                                                                                    | <code>[]</code>                               |
 | global.image.pullPolicy                            | The pull policy for Cluster Scanner                                                                                                                                                                                                                                                                                                                                                                                     | <code>IfNotPresent</code>                     |
+| global.proxy                                       | Global HTTP Proxy settings.                                                                                                                                                                                                                                                                                                                                                                                             | <code>{}</code>                               |
 | global.loggingLevel                                | Set the logging level to use, useful for troubleshooting. Valid values, sorted by increasing level of verbosity are: `PANIC`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`.                                                                                                                                                                                                                                       | <code>"INFO"</code>                           |
 | global.ssl.ca.certs                                | For outbound connections (secure backend, proxy,...) A PEM-encoded x509 certificate.  This can also be a bundle with multiple certificates.                                                                                                                                                                                                                                                                             | <code>[]</code>                               |
 | global.ssl.ca.keyName                              | Filename that is used when creating the secret.  Required if cert is provided.                                                                                                                                                                                                                                                                                                                                          | <code></code>                                 |
@@ -158,7 +159,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.4.1 \
+    --create-namespace -n sysdig --version=0.5.0 \
     --set global.sysdig.region="us1"
 ```
 
@@ -167,7 +168,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.4.1 \
+    --create-namespace -n sysdig --version=0.5.0 \
     --values values.yaml
 ```
 

--- a/charts/cluster-scanner/templates/configmap.yaml
+++ b/charts/cluster-scanner/templates/configmap.yaml
@@ -25,6 +25,15 @@ data:
   rsi_leaderelection_lock_name: {{ .Values.runtimeStatusIntegrator.leaderElectionLeaseNameOverride | default (include "cluster-scanner.fullname" .) }}
   rsi_leaderelection_lock_namespace: {{ .Values.runtimeStatusIntegrator.leaderElectionLeaseNamespaceOverride | default .Release.Namespace }}
   rsi_service_name: {{ include "cluster-scanner.fullname" . }}
+  {{- if .Values.global.proxy.httpProxy }}
+  http_proxy: {{ .Values.global.proxy.httpProxy }}
+  {{- end -}}
+  {{- if .Values.global.proxy.httpsProxy }}
+  https_proxy: {{ .Values.global.proxy.httpsProxy }}
+  {{- end -}}
+  {{- if .Values.global.proxy.noProxy }}
+  no_proxy: {{ .Values.global.proxy.noProxy }}
+  {{- end -}}
 {{- include "cluster-scanner.rsiJsConfig" . | nindent 2 }}
 {{- include "cluster-scanner.iseJsConfig" . | nindent 2 }}
   ise_cache_type: {{ .Values.imageSbomExtractor.cache.type }}

--- a/charts/cluster-scanner/templates/deployment.yaml
+++ b/charts/cluster-scanner/templates/deployment.yaml
@@ -73,6 +73,24 @@ spec:
           - name: PPROF_PORT
             value: {{ .ports.pprof | default "6060" | quote }}
       {{- end }}
+          - name: HTTP_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "cluster-scanner.fullname" . }}
+                key: http_proxy
+                optional: true
+          - name: HTTPS_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "cluster-scanner.fullname" . }}
+                key: https_proxy
+                optional: true
+          - name: NO_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "cluster-scanner.fullname" . }}
+                key: no_proxy
+                optional: true
           {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
           - name: SSL_CERT_FILE
             value: /ca-certs/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
@@ -295,6 +313,24 @@ spec:
           - name: PPROF_PORT
             value: {{ .ports.pprof | default "6061" | quote }}
       {{- end }}
+          - name: HTTP_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "cluster-scanner.fullname" . }}
+                key: http_proxy
+                optional: true
+          - name: HTTPS_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "cluster-scanner.fullname" . }}
+                key: https_proxy
+                optional: true
+          - name: NO_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "cluster-scanner.fullname" . }}
+                key: no_proxy
+                optional: true
           {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
           - name: SSL_CERT_FILE
             value: /ca-certs/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}

--- a/charts/cluster-scanner/tests/configmap_test.yaml
+++ b/charts/cluster-scanner/tests/configmap_test.yaml
@@ -310,3 +310,34 @@ tests:
       - equal:
           path: data.ise_pprof_enabled
           value: "marzullo"
+
+  - it: "proxy parameters are optional"
+    set:
+      global.sysdig.apiHost: "http://test.com"
+    asserts:
+      - isNull:
+          path: data.http_proxy
+      - isNull:
+          path: data.https_proxy
+      - isNull:
+          path: data.no_proxy
+
+  - it: "has correct value for proxy parameters when provided"
+    set:
+      global:
+        sysdig:
+          apiHost: "http://test.com"
+        proxy:
+          httpProxy: "fake-http-proxy"
+          httpsProxy: "fake-https-proxy"
+          noProxy: "fake-no-proxy"
+    asserts:
+      - equal:
+          path: data.http_proxy
+          value: "fake-http-proxy"
+      - equal:
+          path: data.https_proxy
+          value: "fake-https-proxy"
+      - equal:
+          path: data.no_proxy
+          value: "fake-no-proxy"

--- a/charts/cluster-scanner/tests/deployment_test.yaml
+++ b/charts/cluster-scanner/tests/deployment_test.yaml
@@ -92,9 +92,9 @@ tests:
     asserts:
       - not: true
         isEmpty:
-          path: spec.template.spec.containers[0].env[9]
+          path: spec.template.spec.containers[0].env[?(@.name == "SYSDIG_KUBECONFIG_CONTENT")]
       - isSubset:
-          path: spec.template.spec.containers[0].env[9]
+          path: spec.template.spec.containers[0].env[?(@.name == "SYSDIG_KUBECONFIG_CONTENT")]
           content:
             name: SYSDIG_KUBECONFIG_CONTENT
             valueFrom:
@@ -111,9 +111,9 @@ tests:
     asserts:
       - not: true
         isEmpty:
-          path: spec.template.spec.containers[1].env[37]
+          path: spec.template.spec.containers[1].env[?(@.name == "ANALYZER_CACHE_REDIS_TTL")]
       - isSubset:
-          path: spec.template.spec.containers[1].env[37]
+          path: spec.template.spec.containers[1].env[?(@.name == "ANALYZER_CACHE_REDIS_TTL")]
           content:
             name: ANALYZER_CACHE_REDIS_TTL
             valueFrom:
@@ -146,7 +146,7 @@ tests:
               - myOtherDockerSecretTwo
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].env[15]
+          path: spec.template.spec.containers[0].env[?(@.name == "LOCAL_REGISTRY_SECRETS")]
           value:
             name: LOCAL_REGISTRY_SECRETS
             valueFrom:
@@ -172,7 +172,7 @@ tests:
               - myOtherDockerSecretTwo
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].env[16]
+          path: spec.template.spec.containers[0].env[?(@.name == "EVE_ENABLED")]
           value:
             name: EVE_ENABLED
             valueFrom:
@@ -328,17 +328,17 @@ tests:
     asserts:
       - not: true
         isEmpty:
-          path: spec.template.spec.containers[0].env[2]
+          path: spec.template.spec.containers[0].env[?(@.name == "PPROF_PORT")]
       - isSubset:
-          path: spec.template.spec.containers[0].env[2]
+          path: spec.template.spec.containers[0].env[?(@.name == "PPROF_PORT")]
           content:
             name: PPROF_PORT
             value: "6060"
       - not: true
         isEmpty:
-          path: spec.template.spec.containers[1].env[2]
+          path: spec.template.spec.containers[1].env[?(@.name == "PPROF_PORT")]
       - isSubset:
-          path: spec.template.spec.containers[1].env[2]
+          path: spec.template.spec.containers[1].env[?(@.name == "PPROF_PORT")]
           content:
             name: PPROF_PORT
             value: "6061"
@@ -352,17 +352,17 @@ tests:
     asserts:
       - not: true
         isEmpty:
-          path: spec.template.spec.containers[0].env[2]
+          path: spec.template.spec.containers[0].env[?(@.name == "PPROF_PORT")]
       - isSubset:
-          path: spec.template.spec.containers[0].env[2]
+          path: spec.template.spec.containers[0].env[?(@.name == "PPROF_PORT")]
           content:
             name: PPROF_PORT
             value: "1010"
       - not: true
         isEmpty:
-          path: spec.template.spec.containers[1].env[2]
+          path: spec.template.spec.containers[1].env[?(@.name == "PPROF_PORT")]
       - isSubset:
-          path: spec.template.spec.containers[1].env[2]
+          path: spec.template.spec.containers[1].env[?(@.name == "PPROF_PORT")]
           content:
             name: PPROF_PORT
             value: "666"

--- a/charts/cluster-scanner/values.yaml
+++ b/charts/cluster-scanner/values.yaml
@@ -24,6 +24,8 @@ global:
     pullSecrets: []
     # The pull policy for Cluster Scanner
     pullPolicy: IfNotPresent
+  # Global HTTP Proxy settings.
+  proxy: {}
 
   # Set the logging level to use, useful for troubleshooting. Valid values,
   # sorted by increasing level of verbosity are: `PANIC`, `FATAL`, `ERROR`,

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.18.1
+version: 1.19.0
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -42,7 +42,7 @@ dependencies:
   - name: cluster-scanner
     # repository: https://charts.sysdig.com
     repository: file://../cluster-scanner
-    version: ~0.4.1
+    version: ~0.5.0
     alias: clusterScanner
     condition: clusterScanner.enabled
   - name: kspm-collector


### PR DESCRIPTION
## What this PR does / why we need it:

Cluster scanner currently had the possibility to specify a custom CA but it was not adding the needed variables needed for HTTP/HTTPS proxy.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
