### PR TITLE
fix(admission-controller): Use namespaceSelector to prevent webhook deadlock

### DIFF
--- a/charts/admission-controller/templates/_helpers.tpl
+++ b/charts/admission-controller/templates/_helpers.tpl
@@ -143,7 +143,7 @@ matchExpressions:
   - key: kubernetes.io/metadata.name
     operator: NotIn
     values:
-      - {{ .Release.Namespace }}
+      - {{ .admissionController.namespace }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/admission-controller/templates/_helpers.tpl
+++ b/charts/admission-controller/templates/_helpers.tpl
@@ -132,6 +132,20 @@ Sysdig NATS service URL
 {{- end -}}
 {{- end -}}
 
+{{/*
+Define excluded namespaces for admissionController webhook
+*/}}
+{{- define "admissionController.webhook.namespaceSelector" -}}
+{{- if .Values.webhook.namespaceSelector }}
+{{ toYaml .Values.webhook.namespaceSelector }}
+{{- else }}
+matchExpressions:
+  - key: kubernetes.io/metadata.name
+    operator: NotIn
+    values:
+      - {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Common labels

--- a/charts/admission-controller/templates/webhook/admissionregistration.yaml
+++ b/charts/admission-controller/templates/webhook/admissionregistration.yaml
@@ -19,6 +19,8 @@ metadata:
 webhooks:
 {{- if .Values.features.kspmAdmissionController}}
 - name: vac.secure.sysdig.com
+  namespaceSelector:
+{{- include "admissionController.webhook.namespaceSelector" . | indent 4 }}
   rules:
   - apiGroups:
     - ""
@@ -49,6 +51,8 @@ webhooks:
 {{- end }}
 {{- if or .Values.scanner.enabled .Values.webhook.acConfig }}
 - name: scanning.secure.sysdig.com
+  namespaceSelector:
+{{- include "admissionController.webhook.namespaceSelector" . | indent 4 }}
   matchPolicy: Equivalent
   rules:
   - apiGroups:
@@ -84,6 +88,8 @@ webhooks:
 {{- end }}
 {{- if .Values.features.k8sAuditDetections }}
 - name: audit.secure.sysdig.com
+  namespaceSelector:
+{{- include "admissionController.webhook.namespaceSelector" . | indent 4 }}
   matchPolicy: Equivalent
   rules:
   {{- with .Values.features.k8sAuditDetectionsRules }}

--- a/charts/admission-controller/templates/webhook/admissionregistration.yaml
+++ b/charts/admission-controller/templates/webhook/admissionregistration.yaml
@@ -5,19 +5,6 @@ so the template is executed just once
 {{- $certString := include "admissionController.webhook.gen-certs" . -}}
 {{- $certList := split "$" $certString -}}
 ---
-{{- $existingVac := (lookup "admissionregistration.k8s.io/v1" "ValidatingWebhookConfiguration" (include "admissionController.namespace" .) (include "admissionController.webhook.fullname" .))}}
-{{- $existingVacMetadataAnnotations := (default dict (default dict $existingVac.metadata).annotations) }}
-{{- $existingVacMetadataAnnotationsReleaseName := (default "" (index $existingVacMetadataAnnotations "meta.helm.sh/release-name")) }}
-{{- $existingVacMetadataAnnotationsReleaseNamespace := (default "" (index $existingVacMetadataAnnotations "meta.helm.sh/release-namespace")) }}
-{{- if (or (not $existingVac) (and $existingVac (eq $existingVacMetadataAnnotationsReleaseName .Release.Name ) (eq $existingVacMetadataAnnotationsReleaseNamespace .Release.Namespace ))) }}
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: {{ include "admissionController.webhook.fullname" . }}
-  namespace: {{ include "admissionController.namespace" . }}
-webhooks: []
-{{- end}}
----
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:


### PR DESCRIPTION
## What this PR does / why we need it:
As mentioned in #1310 the helm-chart for admission-controller produces multiple values for the ValidatingWebhookConfiguration. I was explained that this is because the resource is added with a post-install, and in order to have to resource a part of the lifecycle of the helm-installation the resource needs to be created on install.
By excluding the admission-controller from the webhook validation the issue with deadlocks on installation should be resolved.

I can't see where and how the post-install configuration is done. Can anyone help with this?

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
