### PR TITLE
ci(): migrate all github actions to self-hosted runners

### DIFF
--- a/.github/workflows/approve-test-run.yaml
+++ b/.github/workflows/approve-test-run.yaml
@@ -9,7 +9,7 @@ jobs:
   approve-test-run:
     permissions:
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     if: ${{ github.event.issue.pull_request }}
     steps:
       - name: Slash Command Dispatch

--- a/.github/workflows/greeting.yaml
+++ b/.github/workflows/greeting.yaml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       pull-requests: write
     name: Greeting comment upon PR from fork
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != 'sysdiglabs/charts'
 
     steps:

--- a/.github/workflows/helm-unit-test.yaml
+++ b/.github/workflows/helm-unit-test.yaml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   Unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/k8s-apis-deprecation.yml
+++ b/.github/workflows/k8s-apis-deprecation.yml
@@ -13,7 +13,7 @@ on: workflow_dispatch
 jobs:
 
   charts:
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     # Parallel builds
     strategy:
       # Don't stop the pipeline in case one of parallel jobs fails

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     steps:
       - uses: actions/labeler@v4.0.3
         with:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint-test-branch:
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-large
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
@@ -77,7 +77,7 @@ jobs:
 
 
   lint-test-fork:
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-large
     permissions:
       checks: write
     if: github.event_name == 'repository_dispatch' &&

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -8,7 +8,7 @@ jobs:
   pr-lint:
     permissions:
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     steps:
       - uses: morrisoncole/pr-lint-action@v1.7.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   charts-to-release:
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     outputs:
       modified-charts-files: ${{ steps.updated-charts.outputs.all_modified_files }}
     steps:
@@ -29,7 +29,7 @@ jobs:
   generate-changelog:
     needs: charts-to-release
     if: needs.charts-to-release.outputs.modified-charts-files
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     container: quay.io/sysdig/git-chglog:0.15.1-3-g6e4e27d
     steps:
       - name: Checkout
@@ -88,7 +88,7 @@ jobs:
   release-charts:
     needs:
       - generate-changelog
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -160,7 +160,7 @@ jobs:
     needs:
       - charts-to-release
       - release-charts
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     steps:
     - uses: actions/stale@v8
       with:

--- a/.github/workflows/update-operator.yaml
+++ b/.github/workflows/update-operator.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   dispatch:
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     steps:
       - name: filter release tag
         id: filter_tag

--- a/.github/workflows/update-sysdig-deploy-chart.yaml
+++ b/.github/workflows/update-sysdig-deploy-chart.yaml
@@ -6,7 +6,7 @@ on:
       - master
 jobs:
   update-sysdig-deploy-version:
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     steps:
       - name: Git checkout
         uses: actions/checkout@v3

--- a/.github/workflows/update-tanzu.yaml
+++ b/.github/workflows/update-tanzu.yaml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   publish-chart:
-    runs-on: ubuntu-latest
+    runs-on: tools-runner-small
     steps:
     - name: Get name from tag
       id: tag_name


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix