### PR TITLE
fix(node-analyzer): prevent `custom_tags` from being set to `nil`

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.17.1
+version: 1.17.2
 appVersion: 12.8.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/configmap-host-scanner.yaml
+++ b/charts/node-analyzer/templates/configmap-host-scanner.yaml
@@ -10,7 +10,9 @@ data:
   api_endpoint: https://{{ include "nodeAnalyzer.apiEndpoint" . }}
   cluster_name: {{ required "A valid clusterName is required" (include "nodeAnalyzer.clusterName" . ) }}
   {{- if hasKey .Values.global.sysdig "tags" }}
+  {{- if .Values.global.sysdig.tags }}
   custom_tags: {{ include "agent.tags" . }}
+  {{- end }}
   {{- end }}
   {{- if hasKey .Values.nodeAnalyzer.hostScanner "scanOnStart" }}
   scan_on_start: "{{ .Values.nodeAnalyzer.hostScanner.scanOnStart }}"


### PR DESCRIPTION
## What this PR does / why we need it:
https://github.com/sysdiglabs/charts/pull/1351 introduced a bug where the `custom_tags` field would be set to `nil` if the user did not specify values for `global.sysdig.tags` when using `sysdig-deploy` to install the host scanner. The node analyzer DaemonSet uses this entry to set an environment variable on the host scanner containers(s), and a `nil` value here was causing errors like the following:
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: unknown object type "nil" in ConfigMap.data.custom_tags
```

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
