### PR TITLE
fix(admission-controller): admission controller read does not read global.sysdig.accessKeySecret

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.14.5
+version: 0.14.6
 appVersion: 3.9.29
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -68,7 +68,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.14.5  \
+    --create-namespace -n sysdig-admission-controller --version=0.14.6  \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -80,7 +80,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-     --create-namespace -n sysdig-admission-controller --version=0.14.5  \
+     --create-namespace -n sysdig-admission-controller --version=0.14.6  \
     --values values.yaml
 
 ```

--- a/charts/admission-controller/templates/_helpers.tpl
+++ b/charts/admission-controller/templates/_helpers.tpl
@@ -298,7 +298,7 @@ the following helper function designed to take the accessKey if specified locall
 {{- end -}}
 
 {{- define "sysdig.existingAccessKeySecret" -}}
-    {{- .Values.sysdig.existingAccessKeySecret | default .Values.global.sysdig.existingAccessKeySecret | default "" -}}
+    {{- .Values.sysdig.existingAccessKeySecret | default .Values.global.sysdig.accessKeySecret | default .Values.global.sysdig.existingAccessKeySecret | default "" -}}
 {{- end -}}
 
 {{/*

--- a/charts/admission-controller/tests/global_overrides_test.yaml
+++ b/charts/admission-controller/tests/global_overrides_test.yaml
@@ -236,6 +236,45 @@ tests:
           value: some-secret
         template: webhook/deployment.yaml
 
+  - it: check value of accessKeySecret without local chart override
+    documentIndex: 0
+    set:
+      global:
+        sysdig:
+          accessKeySecret: some-secret
+      sysdig:
+        url: secure.sysdigcloud.com
+      features:
+        kspmAdmissionController: true
+        k8sAuditDetections: false
+      clusterName: test-k8s
+      version: 0.7.3
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].secret.secretName
+          value: some-secret
+        template: webhook/deployment.yaml
+
+  - it: check value of accessKeySecret with local chart override
+    documentIndex: 0
+    set:
+      global:
+        sysdig:
+          accessKeySecret: some-secret
+      sysdig:
+        url: secure.sysdigcloud.com
+        existingAccessKeySecret: override-secret
+      features:
+        kspmAdmissionController: true
+        k8sAuditDetections: false
+      clusterName: test-k8s
+      version: 0.7.3
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].secret.secretName
+          value: override-secret
+        template: webhook/deployment.yaml
+
   - it: uses the specified region
     documentIndex: 0
     set:


### PR DESCRIPTION
## What this PR does / why we need it:
https://sysdig.atlassian.net/browse/SMAGENT-5543

It seems that the admission-controller chart still uses an old version of the `global.sysdig.accessKeySecret` named `existingAccessKeySecret`.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
