### PR TITLE
ci(sysdig-deploy): add new integration tests for `sysdig-deploy` chart CI runs

### DIFF
--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.23.2
+version: 1.23.3
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com

--- a/charts/sysdig-deploy/ci/test-default-saas-values.yaml.template
+++ b/charts/sysdig-deploy/ci/test-default-saas-values.yaml.template
@@ -1,0 +1,36 @@
+global:
+  clusterConfig:
+    name: "test-cluster"
+    namespace: ""
+  sysdig:
+    accessKey: ${SECURE_AGENT_TOKEN}
+    secureAPIToken: ${SECURE_API_TOKEN}
+  kspm:
+    deploy: true
+agent:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 200Mi
+kspmCollector:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 200Mi
+nodeAnalyzer:
+  secure:
+    vulnerabilityManagement:
+      newEngineOnly: true
+  nodeAnalyzer:
+    benchmarkRunner:
+      deploy: false
+    imageAnalyzer:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 200Mi
+    hostAnalyzer:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 200Mi

--- a/charts/sysdig-deploy/ci/test-enable-all-subcharts-values.yaml.template
+++ b/charts/sysdig-deploy/ci/test-enable-all-subcharts-values.yaml.template
@@ -1,0 +1,65 @@
+global:
+  clusterConfig:
+    name: "test-cluster"
+    namespace: ""
+  sysdig:
+    accessKey: ${SECURE_AGENT_TOKEN}
+    secureAPIToken: ${SECURE_API_TOKEN}
+  kspm:
+    deploy: true
+admissionController:
+  enabled: true
+  webhook:
+    resources:
+      requests:
+        cpu: 25m
+        memory: 200Mi
+agent:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 200Mi
+clusterScanner:
+  enabled: true
+  imageSbomExtractor:
+    resources:
+      requests:
+        cpu: 25m
+        memory: 200Mi
+  runtimeStatusIntegrator:
+    resources:
+      requests:
+        cpu: 25m
+        memory: 200Mi
+kspmCollector:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 200Mi
+nodeAnalyzer:
+  nodeAnalyzer:
+    benchmarkRunner:
+      deploy: false
+    imageAnalyzer:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 200Mi
+    hostAnalyzer:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 200Mi
+    kspmAnalyzer:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 200Mi
+rapidResponse:
+  enabled: true
+  rapidResponse:
+    passphrase: "abcd"
+    resources:
+      requests:
+        cpu: 25m
+        memory: 200Mi


### PR DESCRIPTION
## What this PR does / why we need it:
Add new integration tests to the `sysdig-deploy` chart to better test the various combinations of deployment options


## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
