### PR TITLE
chore(sysdig-deploy): bump sysdig-deploy cluster scanner 0.5.6

### DIFF
--- a/.github/workflows/update-sysdig-deploy-chart.yaml
+++ b/.github/workflows/update-sysdig-deploy-chart.yaml
@@ -18,11 +18,13 @@ jobs:
         id: dependent_files
         with:
           files: |
-            charts/node-analyzer/*
-            charts/agent/*
-            charts/kspm-collector/*
-            charts/rapid-response/*
             charts/admission-controller/*
+            charts/agent/*
+            charts/cluster-scanner/*
+            charts/common/*
+            charts/kspm-collector/*
+            charts/node-analyzer/*
+            charts/rapid-response/*
 
       - name: Install YQ
         if: steps.dependent_files.outputs.any_changed == 'true'

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
   - name: cluster-scanner
     # repository: https://charts.sysdig.com
     repository: file://../cluster-scanner
-    version: ~0.5.4
+    version: ~0.5.6
     alias: clusterScanner
     condition: clusterScanner.enabled
   - name: kspm-collector

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.22.10
+version: 1.22.11
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com

--- a/scripts/sysdig-deploy/update-sysdig-deploy.sh
+++ b/scripts/sysdig-deploy/update-sysdig-deploy.sh
@@ -2,12 +2,15 @@
 
 set -e
 
-node_analyzer_chart_path="node-analyzer"
-agent_chart_path="agent"
-kspm_collector_chart_path="kspm-collector"
-rapid_response_chart_path="rapid-response"
-admission_controller_chart_path="admission-controller"
 sysdig_deploy_path="sysdig-deploy"
+
+admission_controller_chart_path="admission-controller"
+agent_chart_path="agent"
+cluster_scanner_chart_path="cluster-scanner"
+common_chart_path="common"
+kspm_collector_chart_path="kspm-collector"
+node_analyzer_chart_path="node-analyzer"
+rapid_response_chart_path="rapid-response"
 
 minor=0
 major=0
@@ -66,7 +69,7 @@ check_update_needed () {
     fi
 }
 
-charts=( "$node_analyzer_chart_path" "$agent_chart_path" "$kspm_collector_chart_path" "$rapid_response_chart_path" "$admission_controller_chart_path" )
+charts=( "$node_analyzer_chart_path" "$agent_chart_path" "$kspm_collector_chart_path" "$rapid_response_chart_path" "$admission_controller_chart_path" "$common_chart_path" "$cluster_scanner_chart_path")
 for chart in "${charts[@]}"
 do
     check_update_needed "$chart"


### PR DESCRIPTION
## What this PR does / why we need it:

- Bump `cluster-scanner` dependency in `sysdig-deploy` to version **0.5.6**
- Add missing dependency charts to the automatic sysdig-deploy bump script

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
