### PR TITLE
chore(node-analyzer): remove broken link from values.yaml

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.17.4
+version: 1.17.5
 appVersion: 12.8.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -133,7 +133,7 @@ nodeAnalyzer:
   # Can be set to true to show debug logging, useful for troubleshooting.
   debug: false
 
-  # Proxy configuration variables. See also: [Running Node Analyzer Behind a Proxy](https://docs.sysdig.com/en/node-analyzer--multi-feature-installation.html#UUID-35c14c46-b327-c2a8-ed9c-82a2af995218_section-idm51621039128136)
+  # Proxy configuration variables
   httpProxy:
   httpsProxy:
   noProxy:


### PR DESCRIPTION
## What this PR does / why we need it:
a link to a docs page about proxy configuration that no longer exists was referenced in the `values.yaml` file for the node analyzer chart.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
