### PR TITLE
fix(agent): add mount for host's `/run` vol for all deployment types

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -3,7 +3,7 @@ name: agent
 description: Sysdig Monitor and Secure agent
 type: application
 # currently matching sysdig 1.14.32
-version: 1.13.10
+version: 1.13.11
 appVersion: 12.16.1
 keywords:
   - monitoring

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -217,6 +217,8 @@ spec:
             - mountPath: /host/proc
               name: proc-vol
               readOnly: true
+            - mountPath: /host/run
+              name: run-vol
             - mountPath: /dev/shm
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
@@ -251,8 +253,6 @@ spec:
               readOnly: true
             - mountPath: /host/var/lib
               name: varlib-vol
-            - mountPath: /host/run
-              name: run-vol
             - mountPath: /host/var/run
               name: varrun-vol
             {{- if (include "agent.ebpfEnabled" .) }}
@@ -271,8 +271,6 @@ spec:
               readOnly: true
             - mountPath: /host/var/lib
               name: varlib-vol
-            - mountPath: /host/run
-              name: run-vol
             - mountPath: /host/var/run
               name: varrun-vol
             {{- if (include "agent.ebpfEnabled" .) }}
@@ -298,8 +296,6 @@ spec:
             - mountPath: /host/usr
               name: usr-vol
               readOnly: true
-            - mountPath: /host/run
-              name: run-vol
             - mountPath: /host/var/run
               name: varrun-vol
           {{- end }}
@@ -326,6 +322,9 @@ spec:
         - name: proc-vol
           hostPath:
             path: /proc
+        - name: run-vol
+          hostPath:
+            path: /run
         - name: dshm
           emptyDir:
             medium: Memory
@@ -386,9 +385,6 @@ spec:
         - name: varlib-vol
           hostPath:
             path: /var/lib
-        - name: run-vol
-          hostPath:
-            path: /run
         - name: varrun-vol
           hostPath:
             path: /var/run
@@ -415,9 +411,6 @@ spec:
         - name: usr-vol
           hostPath:
             path: /usr
-        - name: run-vol
-          hostPath:
-            path: /run
         - name: varrun-vol
           hostPath:
             path: /var/run
@@ -450,9 +443,6 @@ spec:
         - name: usr-vol
           hostPath:
             path: /usr
-        - name: run-vol
-          hostPath:
-            path: /run
         - name: varrun-vol
           hostPath:
             path: /var/run

--- a/charts/agent/tests/gke_autopilot_volumes_test.yaml
+++ b/charts/agent/tests/gke_autopilot_volumes_test.yaml
@@ -53,6 +53,8 @@ tests:
       - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/boot")]
       - isNotNull:
+          path: spec.template.spec.volumes[?(@.hostPath.path == "/run")]
+      - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/var/run/containerd/containerd.sock")]
       # This seems not work as expected, need deeper investigation
       # - lengthEqual:
@@ -60,7 +62,7 @@ tests:
       #     count: 5
       # We are going to use this "workaround" until we found a proper solution
       - isNull:
-          path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/var/run/containerd/containerd.sock")]
+          path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/run" && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/var/run/containerd/containerd.sock")]
 
   - it: Ensure only the right volumes are mounted when running on GKE Autopilot, the agent is slim mode with eBPF
     set:
@@ -109,6 +111,8 @@ tests:
       - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/proc")]
       - isNotNull:
+          path: spec.template.spec.volumes[?(@.hostPath.path == "/run")]
+      - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/etc/os-release")]
       - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/boot")]
@@ -120,4 +124,4 @@ tests:
       #     count: 5
       # We are going to use this "workaround" until we found a proper solution
       - isNull:
-          path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/var/run/containerd/containerd.sock")]
+          path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/run" && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/var/run/containerd/containerd.sock")]


### PR DESCRIPTION
## What this PR does / why we need it:
When installing on GKE Autopilot clusters with the agent slim mode selected the host's `/run` volume was not being mounted into the agent container. This was preventing the correct retrieval of container metrics.

Since the problematic scenario was the only case where the host's `/run` volume was not being mounted into the agent container, that volume has now been elevated to the "always requested" section.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
