### PR TITLE
chore(admission-controller): Update to version 3.9.31

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.14.7
-appVersion: 3.9.30
+version: 0.14.8
+appVersion: 3.9.31
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 maintainers:

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -68,7 +68,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.14.7  \
+    --create-namespace -n sysdig-admission-controller --version=0.14.8  \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -80,7 +80,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-     --create-namespace -n sysdig-admission-controller --version=0.14.7  \
+     --create-namespace -n sysdig-admission-controller --version=0.14.8  \
     --values values.yaml
 
 ```


### PR DESCRIPTION
## Bug fixes

- Solve incorrect append in rules/lists/macros. When loading the rules from the backend, we restricted the number of rules loaded. If the customer has custom rules in place, appending rules, lists or macros to other non-existing rules (because we don't load them anymore) is an error. This fixes it, and ignores the append to non-existing previous rules.

- Solve incorrect append in exceptions.