### PR TITLE
fix(admission-controller): not detecting events in its own namespace

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.14.8
+version: 0.14.9
 appVersion: 3.9.31
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -68,7 +68,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.14.8  \
+    --create-namespace -n sysdig-admission-controller --version=0.14.9  \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -80,7 +80,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-     --create-namespace -n sysdig-admission-controller --version=0.14.8  \
+     --create-namespace -n sysdig-admission-controller --version=0.14.9  \
     --values values.yaml
 
 ```

--- a/charts/admission-controller/templates/_helpers.tpl
+++ b/charts/admission-controller/templates/_helpers.tpl
@@ -458,12 +458,6 @@ webhooks:
 {{- end }}
 {{- if .Values.features.k8sAuditDetections }}
 - name: audit.secure.sysdig.com
-  namespaceSelector:
-    matchExpressions:
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-        - {{ include "admissionController.namespace" . }}
   matchPolicy: Equivalent
   rules:
   {{- with .Values.features.k8sAuditDetectionsRules }}


### PR DESCRIPTION
If we block audit events in the namespace, the AC is not able to detect events in its own namespace.