### PR TITLE
fix(cluster-scanner): temporarily disabling backend-scanning by default

### DIFF
--- a/charts/cluster-scanner/Chart.yaml
+++ b/charts/cluster-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Cluster Scanner
 
 type: application
 
-version: 0.6.1
+version: 0.6.2
 
 appVersion: "0.1.0"
 home: https://www.sysdig.com/

--- a/charts/cluster-scanner/README.md
+++ b/charts/cluster-scanner/README.md
@@ -25,7 +25,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-      --create-namespace -n sysdig --version=0.6.1  \
+      --create-namespace -n sysdig --version=0.6.2  \
       --set global.clusterConfig.name=CLUSTER_NAME \
       --set global.sysdig.region=SYSDIG_REGION \
       --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -55,7 +55,7 @@ To install the chart with the release name `cluster-scanner`, run:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-       --create-namespace -n sysdig --version=0.6.1 \
+       --create-namespace -n sysdig --version=0.6.2 \
        --set global.clusterConfig.name=CLUSTER_NAME \
        --set global.sysdig.region=SYSDIG_REGION \
        --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -160,7 +160,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.6.1 \
+    --create-namespace -n sysdig --version=0.6.2 \
     --set global.sysdig.region="us1"
 ```
 
@@ -169,7 +169,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.6.1 \
+    --create-namespace -n sysdig --version=0.6.2 \
     --values values.yaml
 ```
 

--- a/charts/cluster-scanner/templates/_helpers.tpl
+++ b/charts/cluster-scanner/templates/_helpers.tpl
@@ -234,9 +234,7 @@ Version tags must be semver2-compatible otherwise no check will be performed.
 Generates configmap data to enable platform services if onPremCompatibility version is not set, or it is greater than 6.6.0
 */}}
 {{- define "cluster-scanner.enablePlatformServicesConfig" -}}
-{{- if ( semverCompare ">= 6.6.0" (.Values.onPremCompatibilityVersion | default "6.6.0" )) -}}
-enable_platform_services: "true"
-{{- end -}}
+enable_platform_services: "false"
 {{- end -}}
 
 {{/*

--- a/charts/cluster-scanner/templates/configmap.yaml
+++ b/charts/cluster-scanner/templates/configmap.yaml
@@ -39,4 +39,4 @@ data:
   ise_cache_type: {{ .Values.imageSbomExtractor.cache.type }}
 {{- include "cluster-scanner.redisCacheConfig" . | nindent 2 }}
 {{- include "cluster-scanner.localCacheConfig" . | nindent 2 }}
-{{- include "cluster-scanner.enablePlatformServicesConfig" . | nindent 2 }}
+  enable_platform_services: "false"

--- a/charts/cluster-scanner/tests/configmap_test.yaml
+++ b/charts/cluster-scanner/tests/configmap_test.yaml
@@ -348,15 +348,16 @@ tests:
     asserts:
       - equal:
           path: data.enable_platform_services
-          value: "true"
+          value: "false"
 
   - it: "has correct platform services value when onPremCompatibilityVersion is < 6.6"
     set:
       global.sysdig.apiHost: "http://test.com"
       onPremCompatibilityVersion: "6.5.99"
     asserts:
-      - isNull:
+      - equal:
           path: data.enable_platform_services
+          value: "false"
 
   - it: "has correct platform services value when onPremCompatibilityVersion is = 6.6.0"
     set:
@@ -365,7 +366,7 @@ tests:
     asserts:
       - equal:
           path: data.enable_platform_services
-          value: "true"
+          value: "false"
 
   - it: "has correct platform services value when onPremCompatibilityVersion is > 6.6.0"
     set:
@@ -374,4 +375,4 @@ tests:
     asserts:
       - equal:
           path: data.enable_platform_services
-          value: "true"
+          value: "false"

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.23.8
+version: 1.23.9
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -42,7 +42,7 @@ dependencies:
   - name: cluster-scanner
     # repository: https://charts.sysdig.com
     repository: file://../cluster-scanner
-    version: ~0.6.1
+    version: ~0.6.2
     alias: clusterScanner
     condition: clusterScanner.enabled
   - name: kspm-collector


### PR DESCRIPTION
## What this PR does / why we need it:

Due to an issue on BE side, we temporarily disable backend-scanning by default.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
