### PR TITLE
fix(ci): pin version of `chart-doc-gen` used by pre-commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: unittest
 
 deps-docs:
-	go install kubepack.dev/chart-doc-gen@latest
+	go install kubepack.dev/chart-doc-gen@v0.4.7
 
 docs: deps-docs
 	find . -name "doc.yaml" | \


### PR DESCRIPTION
## What this PR does / why we need it:
`chart-doc-gen` v0.5.0 was released and appears to change the way they handle `key: {}` entries like we have for documentation purposes in our default `values.yaml` files. in the new release `chart-doc-gen` will remove those entries entirely, which in turn will remove the entries from the generated readme files.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
