### PR TITLE
chore: rename to universal_ebpf and legacy_ebpf & remove auto

### DIFF
--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -224,13 +224,13 @@ it can act like a boolean
 {{- end -}}
 
 {{- define "agent.universalEbpfEnforced" -}}
-  {{- if (and (eq "true" (include "agent.ebpfEnabled" .)) (eq "universal" .Values.ebpf.kind )) -}}
+  {{- if (and (eq "true" (include "agent.ebpfEnabled" .)) (or (eq "universal" .Values.ebpf.kind ) (eq "universal_ebpf" .Values.ebpf.kind ))) -}}
     true
   {{- end -}}
 {{- end -}}
 
 {{- define "agent.legacyEbpfEnforced" -}}
-  {{- if (and (eq "true" (include "agent.ebpfEnabled" .)) (eq "legacy" .Values.ebpf.kind )) -}}
+  {{- if (and (eq "true" (include "agent.ebpfEnabled" .)) (or (eq "legacy" .Values.ebpf.kind ) (eq "legacy_ebpf" .Values.ebpf.kind ))) -}}
     true
   {{- end -}}
 {{- end -}}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -190,7 +190,7 @@ spec:
             {{- if (include "agent.universalEbpfEnforced" .) }}
             - name: SYSDIG_AGENT_DRIVER
               value: universal_ebpf
-            {{- else if (and (include "agent.ebpfEnabled" .) (eq "legacy" .Values.ebpf.kind )) }}
+            {{- else if (include "agent.legacyEbpfEnforced" .) }}
             - name: SYSDIG_AGENT_DRIVER
               value: legacy_ebpf
             {{- end }}

--- a/charts/agent/tests/universal_ebpf_test.yaml
+++ b/charts/agent/tests/universal_ebpf_test.yaml
@@ -16,19 +16,38 @@ tests:
       - isNull:
           path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")]
 
-  - it: Ensure that when the eBPF is enabled with the default driver we create the sysdig container with the SYSDIG_BPF_PROBE and without SYSDIG_AGENT_DRIVER environment variables
+  - it: Ensure that when the eBPF is enabled the default driver is "legacy_ebpf" we create the sysdig container with the SYSDIG_BPF_PROBE and SYSDIG_AGENT_DRIVER=legacy_ebpf environment variables
     set:
       ebpf:
         enabled: true
     asserts:
       - isEmpty:
           path: spec.template.spec.initContainers[*].env[?(@.name == "SYSDIG_BPF_PROBE")].value
-      - isNull:
-          path: spec.template.spec.initContainers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")]
+      - equal:
+          path: spec.template.spec.initContainers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
+          value: legacy_ebpf
       - isEmpty:
           path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_BPF_PROBE")].value
-      - isNull:
-          path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")]
+      - equal:
+          path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
+          value: legacy_ebpf
+
+  - it: Ensure that when the eBPF is enabled and we specify to use the "legacy_ebpf" driver we create the sysdig container with the SYSDIG_BPF_PROBE and with SYSDIG_AGENT_DRIVER environment variables
+    set:
+      ebpf:
+        enabled: true
+        kind: legacy_ebpf
+    asserts:
+      - isEmpty:
+          path: spec.template.spec.initContainers[*].env[?(@.name == "SYSDIG_BPF_PROBE")].value
+      - equal:
+          path: spec.template.spec.initContainers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
+          value: legacy_ebpf
+      - isEmpty:
+          path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_BPF_PROBE")].value
+      - equal:
+          path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
+          value: legacy_ebpf
 
   # TODO: remove before merge
   - it: Ensure that when the eBPF is enabled and we specify to use the "legacy" driver we create the sysdig container with the SYSDIG_BPF_PROBE and with SYSDIG_AGENT_DRIVER environment variables
@@ -48,29 +67,11 @@ tests:
           path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
           value: legacy_ebpf
 
-  - it: Ensure that when the eBPF is enabled and we specify to use the "legacy_ebpf" driver we create the sysdig container with the SYSDIG_BPF_PROBE and with SYSDIG_AGENT_DRIVER environment variables
+  - it: Ensure that when the eBPF is enabled and we specify to use the "universal_ebpf" driver we create the sysdig container without the SYSDIG_BPF_PROBE and with the SYSDIG_AGENT_DRIVER environment variables
     set:
       ebpf:
         enabled: true
-        kind: legacy
-    asserts:
-      - isEmpty:
-          path: spec.template.spec.initContainers[*].env[?(@.name == "SYSDIG_BPF_PROBE")].value
-      - equal:
-          path: spec.template.spec.initContainers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
-          value: legacy_ebpf
-      - isEmpty:
-          path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_BPF_PROBE")].value
-      - equal:
-          path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
-          value: legacy_ebpf
-
-  # TODO: remove before merge
-  - it: Ensure that when the eBPF is enabled and we specify to use the "universal" driver we create the sysdig container without the SYSDIG_BPF_PROBE and with the SYSDIG_AGENT_DRIVER environment variables
-    set:
-      ebpf:
-        enabled: true
-        kind: universal
+        kind: universal_ebpf
     asserts:
       - isNull:
           path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_BPF_PROBE")]
@@ -78,11 +79,12 @@ tests:
           path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
           value: universal_ebpf
 
-  - it: Ensure that when the eBPF is enabled and we specify to use the "universal_ebpf" driver we create the sysdig container without the SYSDIG_BPF_PROBE and with the SYSDIG_AGENT_DRIVER environment variables
+  # TODO: remove before merge
+  - it: Ensure that when the eBPF is enabled and we specify to use the "universal" driver we create the sysdig container without the SYSDIG_BPF_PROBE and with the SYSDIG_AGENT_DRIVER environment variables
     set:
       ebpf:
         enabled: true
-        kind: universal_ebpf
+        kind: universal
     asserts:
       - isNull:
           path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_BPF_PROBE")]

--- a/charts/agent/tests/universal_ebpf_test.yaml
+++ b/charts/agent/tests/universal_ebpf_test.yaml
@@ -30,6 +30,7 @@ tests:
       - isNull:
           path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")]
 
+  # TODO: remove before merge
   - it: Ensure that when the eBPF is enabled and we specify to use the "legacy" driver we create the sysdig container with the SYSDIG_BPF_PROBE and with SYSDIG_AGENT_DRIVER environment variables
     set:
       ebpf:
@@ -47,6 +48,24 @@ tests:
           path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
           value: legacy_ebpf
 
+  - it: Ensure that when the eBPF is enabled and we specify to use the "legacy_ebpf" driver we create the sysdig container with the SYSDIG_BPF_PROBE and with SYSDIG_AGENT_DRIVER environment variables
+    set:
+      ebpf:
+        enabled: true
+        kind: legacy
+    asserts:
+      - isEmpty:
+          path: spec.template.spec.initContainers[*].env[?(@.name == "SYSDIG_BPF_PROBE")].value
+      - equal:
+          path: spec.template.spec.initContainers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
+          value: legacy_ebpf
+      - isEmpty:
+          path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_BPF_PROBE")].value
+      - equal:
+          path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
+          value: legacy_ebpf
+
+  # TODO: remove before merge
   - it: Ensure that when the eBPF is enabled and we specify to use the "universal" driver we create the sysdig container without the SYSDIG_BPF_PROBE and with the SYSDIG_AGENT_DRIVER environment variables
     set:
       ebpf:
@@ -59,6 +78,28 @@ tests:
           path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
           value: universal_ebpf
 
+  - it: Ensure that when the eBPF is enabled and we specify to use the "universal_ebpf" driver we create the sysdig container without the SYSDIG_BPF_PROBE and with the SYSDIG_AGENT_DRIVER environment variables
+    set:
+      ebpf:
+        enabled: true
+        kind: universal_ebpf
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_BPF_PROBE")]
+      - equal:
+          path: spec.template.spec.containers[*].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
+          value: universal_ebpf
+
+  - it: Ensure that when the eBPF is enabled and we specify to use the "universal_ebpf" driver we don't create the init container
+    set:
+      ebpf:
+        enabled: true
+        kind: universal_ebpf
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainers
+
+  # TODO: remove before merge
   - it: Ensure that when the eBPF is enabled and we specify to use the "universal" driver we don't create the init container
     set:
       ebpf:
@@ -68,6 +109,17 @@ tests:
       - isNull:
           path: spec.template.spec.initContainers
 
+  - it: Ensure that when the eBPF is enabled and we specify to use the "legacy_ebpf" driver we create the init container
+    set:
+      ebpf:
+        enabled: true
+        kind: legacy_ebpf
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[*].image
+          pattern: quay.io/sysdig/agent-kmodule:.*
+
+  # TODO: remove before merge
   - it: Ensure that when the eBPF is enabled and we specify to use the "legacy" driver we create the init container
     set:
       ebpf:
@@ -78,6 +130,17 @@ tests:
           path: spec.template.spec.initContainers[*].image
           pattern: quay.io/sysdig/agent-kmodule:.*
 
+  - it: Ensure that when the eBPF is enabled and we specify to use the "universal_ebpf" driver we use the slim container
+    set:
+      ebpf:
+        enabled: true
+        kind: universal_ebpf
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[*].image
+          pattern: quay.io/sysdig/agent-slim:.*
+
+  # TODO: remove before merge
   - it: Ensure that when the eBPF is enabled and we specify to use the "universal" driver we use the slim container
     set:
       ebpf:
@@ -88,6 +151,19 @@ tests:
           path: spec.template.spec.containers[*].image
           pattern: quay.io/sysdig/agent-slim:.*
 
+  - it: Ensure that when the eBPF is enabled and we specify to use the "universal_ebpf" driver we use the slim container also if is slim container is not enabled
+    set:
+      slim:
+        enabled: false
+      ebpf:
+        enabled: true
+        kind: universal_ebpf
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[*].image
+          pattern: quay.io/sysdig/agent-slim:.*
+
+  # TODO: remove before merge
   - it: Ensure that when the eBPF is enabled and we specify to use the "universal" driver we use the slim container also if is slim container is not enabled
     set:
       slim:

--- a/charts/agent/values.schema.json
+++ b/charts/agent/values.schema.json
@@ -20,7 +20,9 @@
           "enum": [
             "auto",
             "legacy",
-            "universal"
+            "universal",
+            "legacy_ebpf",
+            "universal_ebpf"
           ]
         }
       }

--- a/charts/agent/values.schema.json
+++ b/charts/agent/values.schema.json
@@ -18,7 +18,6 @@
         "kind": {
           "type": "string",
           "enum": [
-            "auto",
             "legacy",
             "universal",
             "legacy_ebpf",

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -170,7 +170,7 @@ ebpf:
   # Enable eBPF support for Sysdig Agent
   enabled: false
 
-  # Define the kind of eBPF driver that can be used in the agent. Can be `auto`, `legacy` or `universal`
+  # Define the kind of eBPF driver that can be used in the agent. Can be `auto`, `legacy_ebpf` or `universal_ebpf`
   kind: auto
 
 slim:

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -170,8 +170,8 @@ ebpf:
   # Enable eBPF support for Sysdig Agent
   enabled: false
 
-  # Define the kind of eBPF driver that can be used in the agent. Can be `auto`, `legacy_ebpf` or `universal_ebpf`
-  kind: auto
+  # Define the kind of eBPF driver that can be used in the agent. Can be `legacy_ebpf` or `universal_ebpf`
+  kind: legacy_ebpf
 
 slim:
   # Uses a slim version of the Sysdig Agent


### PR DESCRIPTION
## What this PR does / why we need it:

- Use `legacy_ebpf` and `universal_ebpf` as name
- Remove `auto` as way to define the driver mode.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
