### PR TITLE
fix(agent): do not render universal ebpf env vars in gke autopilot

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.14.0
+version: 1.14.1

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -96,7 +96,7 @@ spec:
             - name: SYSDIG_BPF_PROBE
               value:
           {{- end }}
-          {{- if (include "agent.legacyEbpfEnforced" .) }}
+          {{- if and (include "agent.legacyEbpfEnforced" .) (not (include "agent.gke.autopilot" .)) }}
             - name: SYSDIG_AGENT_DRIVER
               value: legacy_ebpf
           {{- end }}
@@ -187,10 +187,10 @@ spec:
             - name: SYSDIG_BPF_PROBE
               value:
             {{- end }}
-            {{- if (include "agent.universalEbpfEnforced" .) }}
+            {{- if and (include "agent.universalEbpfEnforced" .) (not (include "agent.gke.autopilot" .)) }}
             - name: SYSDIG_AGENT_DRIVER
               value: universal_ebpf
-            {{- else if (include "agent.legacyEbpfEnforced" .) }}
+            {{- else if and (include "agent.legacyEbpfEnforced" .) (not (include "agent.gke.autopilot" .)) }}
             - name: SYSDIG_AGENT_DRIVER
               value: legacy_ebpf
             {{- end }}

--- a/charts/agent/tests/gke_autopilot_volumes_test.yaml
+++ b/charts/agent/tests/gke_autopilot_volumes_test.yaml
@@ -125,3 +125,14 @@ tests:
       # We are going to use this "workaround" until we found a proper solution
       - isNull:
           path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/run" && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/var/run/containerd/containerd.sock")]
+
+  - it: Ensure the SYSDIG_AGENT_DRIVER env var is not set
+    set:
+      gke:
+        autopilot:
+          enabled: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainer[0].env[?(@.name != "SYSDIG_BPF_PROBE")]
+      - isNull:
+          path: spec.template.spec.containers[0].env[?(@.name != "SYSDIG_BPF_PROBE" && @.name != "K8S_NODE")]


### PR DESCRIPTION
The new environment variables needed for selecting universal eBPF were causing issues when installing on GKE Autopilot environments. This commit ensures that they are not used in those environments.

## What this PR does / why we need it:

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
