### PR TITLE
fix(agent,kspm-collector,node-analyzer,sysdig): whitespace errors

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.15.1
+version: 1.15.2

--- a/charts/agent/templates/secrets.yaml
+++ b/charts/agent/templates/secrets.yaml
@@ -1,4 +1,5 @@
 {{- if not ( include "agent.accessKeySecret" . ) }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,10 +9,10 @@ metadata:
 {{ include "agent.labels" . | indent 4 }}
 type: Opaque
 data:
- access-key : {{ include "agent.accessKey" . | b64enc | quote }}
----
+  access-key: {{ include "agent.accessKey" . | b64enc | quote }}
 {{- end }}
 {{- range .Values.extraSecrets }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,9 +23,9 @@ metadata:
 type: Opaque
 data:
 {{ toYaml .data | indent 2 }}
----
 {{- end }}
 {{- if eq (include "sysdig.custom_ca.useValues"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -34,5 +35,4 @@ metadata:
 {{ include "agent.labels" . | indent 4 }}
 data:
   {{ include "sysdig.custom_ca.keyName" (dict "global" .Values.global.ssl "component" .Values.ssl) }}: {{ include "sysdig.custom_ca.cert" (dict "global" .Values.global.ssl "component" .Values.ssl "Files" .Subcharts.common.Files) | b64enc | quote }}
----
 {{- end }}

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
 
-version: 0.9.1
+version: 0.9.2
 appVersion: 1.34.0
 
 keywords:

--- a/charts/kspm-collector/templates/secret.yaml
+++ b/charts/kspm-collector/templates/secret.yaml
@@ -1,4 +1,5 @@
 {{- if not ( include "kspmCollector.accessKeySecret" . ) }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,10 +9,10 @@ metadata:
 {{ include "kspmCollector.labels" . | indent 4 }}
 type: Opaque
 data:
- access-key : {{ include "kspmCollector.accessKey" . | b64enc | quote }}
----
+  access-key: {{ include "kspmCollector.accessKey" . | b64enc | quote }}
 {{- end }}
 {{- if eq (include "sysdig.custom_ca.enabled" (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,5 +22,4 @@ metadata:
 {{ include "kspmCollector.labels" . | indent 4 }}
 data:
   {{ include "sysdig.custom_ca.keyName" (dict "global" .Values.global.ssl "component" .Values.ssl) }}: {{ include "sysdig.custom_ca.cert" (dict "global" .Values.global.ssl "component" .Values.ssl "Files" .Subcharts.common.Files) | b64enc | quote }}
----
 {{- end }}

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.18.1
+version: 1.18.2
 appVersion: 12.8.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/secrets.yaml
+++ b/charts/node-analyzer/templates/secrets.yaml
@@ -1,5 +1,6 @@
 {{- if not (include "nodeAnalyzer.gke.autopilot" .) }}
-{{- if not ( include "nodeAnalyzer.accessKeySecret" . ) }}
+{{- if not (include "nodeAnalyzer.accessKeySecret" .) }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,11 +10,11 @@ metadata:
 {{ include "nodeAnalyzer.labels" . | indent 4 }}
 type: Opaque
 data:
- access-key : {{ include "nodeAnalyzer.accessKey" . | b64enc | quote }}
+  access-key: {{ include "nodeAnalyzer.accessKey" . | b64enc | quote }}
 {{- end }}
+{{- end }}
+{{- if eq (include "sysdig.custom_ca.useValues" (dict "global" .Values.global.ssl "component" .Values.nodeAnalyzer.ssl)) "true" }}
 ---
-{{- end }}
-{{- if eq (include "sysdig.custom_ca.useValues"  (dict "global" .Values.global.ssl "component" .Values.nodeAnalyzer.ssl)) "true" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -23,5 +24,4 @@ metadata:
 {{ include "nodeAnalyzer.labels" . | indent 4 }}
 data:
   {{ include "sysdig.custom_ca.keyName" (dict "global" .Values.global.ssl "component" .Values.nodeAnalyzer.ssl) }}: {{ include "sysdig.custom_ca.cert" (dict "global" .Values.global.ssl "component" .Values.nodeAnalyzer.ssl "Files" .Subcharts.common.Files) | b64enc | quote }}
----
 {{- end }}

--- a/charts/sysdig/Chart.yaml
+++ b/charts/sysdig/Chart.yaml
@@ -15,4 +15,4 @@ name: sysdig
 sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
-version: 1.16.19
+version: 1.16.20

--- a/charts/sysdig/templates/secrets.yaml
+++ b/charts/sysdig/templates/secrets.yaml
@@ -1,4 +1,5 @@
 {{- if not .Values.sysdig.existingAccessKeySecret }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,10 +8,10 @@ metadata:
 {{ include "sysdig.labels" . | indent 4 }}
 type: Opaque
 data:
- access-key : {{ required "A valid .Values.sysdig.accessKey is required" .Values.sysdig.accessKey | b64enc | quote }}
----
+  access-key: {{ required "A valid .Values.sysdig.accessKey is required" .Values.sysdig.accessKey | b64enc | quote }}
 {{- end }}
 {{- range .Values.extraSecrets }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -20,5 +21,4 @@ metadata:
 type: Opaque
 data:
 {{ toYaml .data | indent 2 }}
----
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:

Fix some whitespace errors in the four mentioned charts.

According to [the YAML spec version 1.2 section 2.2 Structures](https://yaml.org/spec/1.2.2/#22-structures), `---` signals the start (not the end) of a document.  Also, `access-key` was missing a leading space and had an extra trailing space in each of the charts.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
