### PR TITLE
chore: update github actions using dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "draios/team-tools-agent"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## What this PR does / why we need it:

Keep GHA updated via dependabot