### PR TITLE
chore: update chart tesing action to sove the cosign dependency issue

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -38,7 +38,7 @@ jobs:
           git clean -df .
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Expand templates for CI
         run: |
@@ -113,7 +113,7 @@ jobs:
           git clean -df .
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Expand templates for CI
         run: |


### PR DESCRIPTION
## What this PR does / why we need it:

Bump the GHA for chart testing to fix the issue with cosign we see in our CI.

NB: other PRs need to be rebased once this is merged.