### PR TITLE
chore(ci): no longer update sysdig chart on agent releases

### DIFF
--- a/.github/updatecli.d/config-agent-release.yaml
+++ b/.github/updatecli.d/config-agent-release.yaml
@@ -54,23 +54,3 @@ targets:
       file: Chart.yaml
       key: "$.appVersion"
       versionincrement: patch
-
-  updateSysdigChartValues:
-    name: "update agent tag in sysdig chart"
-    kind: yaml
-    scmid: github
-    spec:
-      file: "charts/sysdig/values.yaml"
-      key: "$.image.tag"
-
-  bumpSysdigChart:
-    name: "bump the chart version of the sysdig chart"
-    kind: helmchart
-    scmid: github
-    dependson:
-      - updateSysdigChartValues
-    spec:
-      name: "charts/sysdig/"
-      file: Chart.yaml
-      key: "$.appVersion"
-      versionincrement: patch


### PR DESCRIPTION
## What this PR does / why we need it:
the legacy sysdig chart is being deprecated, so we are removing the automation to automatically update the chart when new versions of the agent are released.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
