### PR TITLE
feat(registry-scanner): Add flag to enable mem profile dumps on a PVC

### DIFF
--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
 version: 1.1.17
-appVersion: 0.2.55
+appVersion: 0.2.56
 maintainers:
   - name: giuse-sysdig
     email: giuseppe.esposito@sysdig.com

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,8 +4,8 @@ description: Sysdig Registry Scanner
 type: application
 home: https://sysdiglabs.github.io/registry-scanner/
 icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 1.1.16
-appVersion: 0.2.54
+version: 1.1.17
+appVersion: 0.2.55
 maintainers:
   - name: giuse-sysdig
     email: giuseppe.esposito@sysdig.com

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -115,6 +115,7 @@ The following table lists the configurable parameters of the Sysdig Registry Sca
 | scanOnStart.jobName                              | The name of the job created for the post-install scanner job                                                                                                                                                                               | <code>"registry-scanner-start-test"</code>   |
 | scanOnStart.asPostInstallHook                    | Specify whether to launch the job as a post-install helm hook. <br/>Used for testing purpose.                                                                                                                                              | <code>false</code>                           |
 | extraEnvVars                                     | The additional environment variables to be set.                                                                                                                                                                                            | <code>[]</code>                              |
+| memProfileToPersistentVolumeClaim                | Write memory profile dumps to Persistent Volume Claim (provide PVC name)                                                                                                                                                                   | <code>""</code>                              |
 
 ## On-Prem Deployment
 
@@ -126,7 +127,7 @@ Use the following command to deploy:
 helm upgrade --install registry-scanner \
    --namespace sysdig-agent \
    --create-namespace \
-   --version=1.1.16  \
+   --version=1.1.17  \
    --set config.secureBaseURL=<SYSDIG_SECURE_URL> \
    --set config.secureAPIToken=<SYSDIG_SECURE_API_TOKEN> \
    --set config.secureSkipTLS=true \

--- a/charts/registry-scanner/templates/_job.tpl
+++ b/charts/registry-scanner/templates/_job.tpl
@@ -38,6 +38,10 @@
         - name: report-storage
           mountPath: "/output"
         {{- end }}
+        {{- if .Values.memProfileToPersistentVolumeClaim }}
+        - name: profile-storage
+          mountPath: "/profiling"
+        {{- end }}
         {{- if .Values.ssl.ca.certs }}
         - name: ca-certs
           mountPath: "/ca-certs"
@@ -120,6 +124,10 @@
           - name: GROUP_LIMIT
             value: "{{ .Values.config.parallelGoRoutines }}"
           {{- end }}
+          {{- if .Values.memProfileToPersistentVolumeClaim }}
+          - name: PROFILING_ENABLED
+            value: /profiling
+          {{- end }}
           {{- if .Values.extraEnvVars }}
           {{- toYaml .Values.extraEnvVars | nindent 10 }}
           {{- end }}
@@ -153,5 +161,10 @@
       - name: report-storage
         persistentVolumeClaim:
           claimName: {{ .Values.reportToPersistentVolumeClaim }}
+      {{- end }}
+      {{- if .Values.memProfileToPersistentVolumeClaim }}
+      - name: profile-storage
+        persistentVolumeClaim:
+          claimName: {{ .Values.memProfileToPersistentVolumeClaim }}
       {{- end }}
 {{- end }}

--- a/charts/registry-scanner/values.yaml
+++ b/charts/registry-scanner/values.yaml
@@ -224,3 +224,6 @@ scanOnStart:
 extraEnvVars: []
 #  - name: FOO
 #    value: bar
+
+# Write memory profile dumps to Persistent Volume Claim (provide PVC name)
+memProfileToPersistentVolumeClaim: ""


### PR DESCRIPTION
## What this PR does / why we need it:

registry-scanner has a new environment variable to write a memory profile (heap dump) periodically to a folder.

This version bumps the registry-scanner to 0.2.56 to include that functionality and adds an option to specify a PVC. When that option is set, the PVC is mounted, mem profile enabled, and the dumps will be written to the PVC

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
