### PR TITLE
chore(admission-controller,cloud-connector,cluster-scanner,node-analyzer,registry-scanner,sysdig-deploy): change charts ownership

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -8,8 +8,6 @@ home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 maintainers:
   - name: sysdiglabs
-  - name: hayk
-    email: hayk.kocharyan@sysdig.com
 dependencies:
   - name: common
     repository: file://../common

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,13 +2,12 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.14.14
+version: 0.14.15
 appVersion: 3.9.35
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 maintainers:
-  - name: giuse-sysdig
-    email: giuseppe.esposito@sysdig.com
+  - name: sysdiglabs
   - name: hayk
     email: hayk.kocharyan@sysdig.com
 dependencies:

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -68,7 +68,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.14.14  \
+    --create-namespace -n sysdig-admission-controller --version=0.14.15  \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -80,7 +80,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-     --create-namespace -n sysdig-admission-controller --version=0.14.14  \
+     --create-namespace -n sysdig-admission-controller --version=0.14.15  \
     --values values.yaml
 
 ```

--- a/charts/cloud-connector/Chart.yaml
+++ b/charts/cloud-connector/Chart.yaml
@@ -3,10 +3,9 @@ name: cloud-connector
 description: Sysdig Cloud Connector
 
 type: application
-version: 0.8.6
+version: 0.8.7
 appVersion: 0.16.48
 home: https://sysdiglabs.github.io/cloud-connector
 
 maintainers:
-  - name: giuse-sysdig
-    email: giuseppe.esposito@sysdig.com
+  - name: sysdiglabs

--- a/charts/cloud-connector/README.md
+++ b/charts/cloud-connector/README.md
@@ -36,7 +36,7 @@ To install the chart:
 helm repo add sysdig https://charts.sysdig.com
 helm repo update
 helm upgrade --install cloud-connector sysdig/cloud-connector \
-     --create-namespace -n cloud-connector --version=0.8.6  \
+     --create-namespace -n cloud-connector --version=0.8.7  \
      --set sysdig.secureAPIToken=<SECURE_API_TOKEN>
 ```
 
@@ -60,7 +60,7 @@ For example:
 
 ```bash
 helm upgrade --install cloud-connector sysdig/cloud-connector \
-     --create-namespace -n cloud-connector --version=0.8.6  \
+     --create-namespace -n cloud-connector --version=0.8.7  \
      --set sysdig.secureAPIToken=<SECURE_API_TOKEN>
 ```
 
@@ -72,7 +72,7 @@ For example:
 
 ```bash
 helm upgrade --install cloud-connector sysdig/cloud-connector \
-     --create-namespace -n cloud-connector --version=0.8.6  \
+     --create-namespace -n cloud-connector --version=0.8.7  \
     --values values.yaml
 ```
 

--- a/charts/cluster-scanner/Chart.yaml
+++ b/charts/cluster-scanner/Chart.yaml
@@ -3,15 +3,12 @@ name: cluster-scanner
 description: Sysdig Cluster Scanner
 
 type: application
-
-version: 0.8.5
-
+version: 0.8.6
 appVersion: "0.1.0"
 home: https://www.sysdig.com/
 
 maintainers:
-  - name: giuse-sysdig
-    email: giuseppe.esposito@sysdig.com
+  - name: sysdiglabs
 dependencies:
   - name: common
     # repository: https://charts.sysdig.com

--- a/charts/cluster-scanner/README.md
+++ b/charts/cluster-scanner/README.md
@@ -25,7 +25,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-      --create-namespace -n sysdig --version=0.8.5  \
+      --create-namespace -n sysdig --version=0.8.6  \
       --set global.clusterConfig.name=CLUSTER_NAME \
       --set global.sysdig.region=SYSDIG_REGION \
       --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -55,7 +55,7 @@ To install the chart with the release name `cluster-scanner`, run:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-       --create-namespace -n sysdig --version=0.8.5 \
+       --create-namespace -n sysdig --version=0.8.6 \
        --set global.clusterConfig.name=CLUSTER_NAME \
        --set global.sysdig.region=SYSDIG_REGION \
        --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -162,7 +162,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.8.5 \
+    --create-namespace -n sysdig --version=0.8.6 \
     --set global.sysdig.region="us1"
 ```
 
@@ -171,7 +171,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.8.5 \
+    --create-namespace -n sysdig --version=0.8.6 \
     --values values.yaml
 ```
 

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -20,8 +20,7 @@ sources:
 maintainers:
   - name: chen-shmilovich-sysdig
     email: chen.shmilovich@sysdig.com
-  - name: giuse-sysdig
-    email: giuseppe.esposito@sysdig.com
+  - name: sysdiglabs
 dependencies:
   - name: common
     # repository: https://charts.sysdig.com

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.19.0
+version: 1.19.1
 appVersion: 12.9.0
 keywords:
   - monitoring

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -8,5 +8,3 @@ version: 1.1.24
 appVersion: 0.2.60
 maintainers:
   - name: sysdiglabs
-  - name: hayk
-    email: hayk.kocharyan@sysdig.com

--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -2,12 +2,11 @@ apiVersion: v2
 name: registry-scanner
 description: Sysdig Registry Scanner
 type: application
-home: https://sysdiglabs.github.io/registry-scanner/
-icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/uploads/2019/02/Shovel_600px.png
-version: 1.1.23
+home: https://www.sysdig.com/
+icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
+version: 1.1.24
 appVersion: 0.2.60
 maintainers:
-  - name: giuse-sysdig
-    email: giuseppe.esposito@sysdig.com
+  - name: sysdiglabs
   - name: hayk
     email: hayk.kocharyan@sysdig.com

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -130,7 +130,6 @@ helm upgrade --install registry-scanner \
    --namespace sysdig-agent \
    --create-namespace \
    --version=1.1.24  \
-   --version=1.1.22  \
    --set config.secureBaseURL=<SYSDIG_SECURE_URL> \
    --set config.secureAPIToken=<SYSDIG_SECURE_API_TOKEN> \
    --set config.secureSkipTLS=true \

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -129,7 +129,8 @@ Use the following command to deploy:
 helm upgrade --install registry-scanner \
    --namespace sysdig-agent \
    --create-namespace \
-   --version=1.1.23  \
+   --version=1.1.24  \
+   --version=1.1.22  \
    --set config.secureBaseURL=<SYSDIG_SECURE_URL> \
    --set config.secureAPIToken=<SYSDIG_SECURE_API_TOKEN> \
    --set config.secureSkipTLS=true \

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
   - name: cluster-scanner
     # repository: https://charts.sysdig.com
     repository: file://../cluster-scanner
-    version: ~0.8.5
+    version: ~0.8.6
     alias: clusterScanner
     condition: clusterScanner.enabled
   - name: kspm-collector

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.33.1
+version: 1.33.2
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -20,7 +20,7 @@ dependencies:
   - name: admission-controller
     # repository: https://charts.sysdig.com
     repository: file://../admission-controller
-    version: ~0.14.14
+    version: ~0.14.15
     alias: admissionController
     condition: admissionController.enabled
   - name: agent
@@ -36,7 +36,7 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.19.0
+    version: ~1.19.1
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: cluster-scanner


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix