### PR TITLE
fix(cluster-scanner): corrected onPremCompatibilityVersion to 7.0.0

### DIFF
--- a/charts/cluster-scanner/Chart.yaml
+++ b/charts/cluster-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Cluster Scanner
 
 type: application
 
-version: 0.8.2
+version: 0.8.3
 
 appVersion: "0.1.0"
 home: https://www.sysdig.com/

--- a/charts/cluster-scanner/README.md
+++ b/charts/cluster-scanner/README.md
@@ -25,7 +25,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-      --create-namespace -n sysdig --version=0.8.2  \
+      --create-namespace -n sysdig --version=0.8.3  \
       --set global.clusterConfig.name=CLUSTER_NAME \
       --set global.sysdig.region=SYSDIG_REGION \
       --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -55,7 +55,7 @@ To install the chart with the release name `cluster-scanner`, run:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-       --create-namespace -n sysdig --version=0.8.2 \
+       --create-namespace -n sysdig --version=0.8.3 \
        --set global.clusterConfig.name=CLUSTER_NAME \
        --set global.sysdig.region=SYSDIG_REGION \
        --set global.sysdig.accessKey=YOUR-KEY-HERE
@@ -161,7 +161,7 @@ Specify each parameter using the **`--set key=value[,key=value]`** argument to `
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.8.2 \
+    --create-namespace -n sysdig --version=0.8.3 \
     --set global.sysdig.region="us1"
 ```
 
@@ -170,7 +170,7 @@ installing the chart. For example:
 
 ```console
 $ helm upgrade --install sysdig-cluster-scanner sysdig/cluster-scanner \
-    --create-namespace -n sysdig --version=0.8.2 \
+    --create-namespace -n sysdig --version=0.8.3 \
     --values values.yaml
 ```
 

--- a/charts/cluster-scanner/templates/_helpers.tpl
+++ b/charts/cluster-scanner/templates/_helpers.tpl
@@ -206,11 +206,11 @@ Define the proper imageRegistry to use for imageSbomExtractor
 {{- end -}}
 
 {{/*
-Generates configmap data to enable platform services if onPremCompatibility version is not set, or it is greater than 6.6.0
+Generates configmap data to enable platform services if onPremCompatibility version is not set, or it is greater than 7.0.0
 It also makes sure that the platform services are enabled in regions which support them when onPremCompatibility is not defined.
 */}}
 {{- define "cluster-scanner.enablePlatformServicesConfig" -}}
-{{- if ( semverCompare ">= 6.6.0" (.Values.onPremCompatibilityVersion | default "6.6.0" )) -}}
+{{- if ( semverCompare ">= 7.0.0" (.Values.onPremCompatibilityVersion | default "7.0.0" )) -}}
     {{- $regionsPlatformEnabled := list "us1" "us2" "us3" "us4" "au1" "eu1" -}}
     {{- if or (has .Values.global.sysdig.region $regionsPlatformEnabled) .Values.onPremCompatibilityVersion -}}
 enable_platform_services: "true"

--- a/charts/cluster-scanner/tests/configmap_test.yaml
+++ b/charts/cluster-scanner/tests/configmap_test.yaml
@@ -359,7 +359,7 @@ tests:
           path: data.enable_platform_services
           value: "true"
 
-  - it: "has correct platform services value when onPremCompatibilityVersion is < 6.6 and region does NOT support platform services"
+  - it: "has correct platform services value when onPremCompatibilityVersion is < 7.0 and region does NOT support platform services"
     set:
       global.sysdig.apiHost: "http://test.com"
       onPremCompatibilityVersion: "6.5.99"
@@ -368,7 +368,7 @@ tests:
       - isNull:
           path: data.enable_platform_services
 
-  - it: "has correct platform services value when onPremCompatibilityVersion is < 6.6 and region supports platform services"
+  - it: "has correct platform services value when onPremCompatibilityVersion is < 7.0 and region supports platform services"
     set:
       global.sysdig.apiHost: "http://test.com"
       onPremCompatibilityVersion: "6.5.99"
@@ -395,20 +395,20 @@ tests:
       - isNull:
           path: data.enable_platform_services
 
-  - it: "has correct platform services value when onPremCompatibilityVersion is = 6.6.0 and region does NOT support platform services"
+  - it: "has correct platform services value when onPremCompatibilityVersion is = 7.0.0 and region does NOT support platform services"
     set:
       global.sysdig.apiHost: "http://test.com"
-      onPremCompatibilityVersion: "6.6.0"
+      onPremCompatibilityVersion: "7.0.0"
       global.sysdig.region: ""
     asserts:
       - equal:
           path: data.enable_platform_services
           value: "true"
 
-  - it: "has correct platform services value when onPremCompatibilityVersion is = 6.6.0 and region supports platform services"
+  - it: "has correct platform services value when onPremCompatibilityVersion is = 7.0.0 and region supports platform services"
     set:
       global.sysdig.apiHost: "http://test.com"
-      onPremCompatibilityVersion: "6.6.0"
+      onPremCompatibilityVersion: "7.0.0"
       global.sysdig.region: "us1"
     asserts:
       - equal:
@@ -418,16 +418,16 @@ tests:
   - it: "has correct platform services value when onPremCompatibilityVersion is just a major.minor version"
     set:
       global.sysdig.apiHost: "http://test.com"
-      onPremCompatibilityVersion: "6.6"
+      onPremCompatibilityVersion: "7.0"
     asserts:
       - equal:
           path: data.enable_platform_services
           value: "true"
 
-  - it: "has correct platform services value when onPremCompatibilityVersion is > 6.6.0"
+  - it: "has correct platform services value when onPremCompatibilityVersion is > 7.0.0"
     set:
       global.sysdig.apiHost: "http://test.com"
-      onPremCompatibilityVersion: "6.6.1"
+      onPremCompatibilityVersion: "7.0.1"
     asserts:
       - equal:
           path: data.enable_platform_services

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.29.5
+version: 1.29.6
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -42,7 +42,7 @@ dependencies:
   - name: cluster-scanner
     # repository: https://charts.sysdig.com
     repository: file://../cluster-scanner
-    version: ~0.8.2
+    version: ~0.8.3
     alias: clusterScanner
     condition: clusterScanner.enabled
   - name: kspm-collector


### PR DESCRIPTION
## What this PR does / why we need it:

As per the title, we changed the minimum value of the onprem version for which platform services are available in the backend, since they are not yet available in 6.6.0.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
