### PR TITLE
fix: update chart-version-bump.sh to bump only the chart version

### DIFF
--- a/scripts/chart-version-bump.sh
+++ b/scripts/chart-version-bump.sh
@@ -4,7 +4,7 @@ set -e
 
 awk '
 {
-    if ($1 == "version:")
+    if ($0 ~ /^version:/)
     {
         l = split($NF, v, ".");
         v[l]++;


### PR DESCRIPTION
## What this PR does / why we need it:

fix `chart-version-bump.sh` in order to bump only the chart version.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
