### PR TITLE
fix(cluster-scanner): Fix generate kubeconfig script to be able handle context name with special characters

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -3,7 +3,7 @@ name: node-analyzer
 description: Sysdig Node Analyzer
 
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.17.5
+version: 1.18.0
 appVersion: 12.8.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/_helpers.tpl
+++ b/charts/node-analyzer/templates/_helpers.tpl
@@ -196,7 +196,7 @@ Determine collector endpoint based on provided region or .Values.nodeAnalyzer.ap
 {{- end -}}
 
 {{- define "deploy-na" -}}
-{{- if .Values.nodeAnalyzer.deploy -}}
+{{- if and .Values.nodeAnalyzer.deploy (or (include "nodeAnalyzer.deployRuntimeScanner" .) (include "nodeAnalyzer.deployHostScanner" .) (include "nodeAnalyzer.deployBenchmarkRunner" .) (include "nodeAnalyzer.deployHostAnalyzer" .) (include "nodeAnalyzer.deployImageAnalyzer" .) .Values.global.kspm.deploy) -}}
 true
 {{- end -}}
 {{- end -}}
@@ -219,6 +219,9 @@ nodeAnalyzer agentConfigmapName
     {{- default .Values.global.agentConfigmapName | default "sysdig-agent" -}}
 {{- end -}}
 
+{{/*
+Deploy nodeAnalyzer components
+*/}}
 {{- define "nodeAnalyzer.deployHostScanner" -}}
 {{- if and (hasKey ((.Values.nodeAnalyzer).hostScanner) "deploy") (not .Values.nodeAnalyzer.hostScanner.deploy ) }}
 {{- else if or ((.Values.secure).vulnerabilityManagement).newEngineOnly (and (hasKey ((.Values.nodeAnalyzer).hostScanner) "deploy") .Values.nodeAnalyzer.hostScanner.deploy) -}}
@@ -227,14 +230,14 @@ true
 {{- end -}}
 
 {{- define "nodeAnalyzer.deployRuntimeScanner" -}}
-{{- if and (hasKey ((.Values.nodeAnalyzer).runtimeScanner) "deploy") (not .Values.nodeAnalyzer.runtimeScanner.deploy ) }}
-{{- else if or ((.Values.secure).vulnerabilityManagement).newEngineOnly (and (hasKey ((.Values.nodeAnalyzer).runtimeScanner) "deploy") .Values.nodeAnalyzer.runtimeScanner.deploy) -}}
+{{- if or (and (hasKey ((.Values.nodeAnalyzer).runtimeScanner) "deploy") (not .Values.nodeAnalyzer.runtimeScanner.deploy )) (include "nodeAnalyzer.gke.autopilot" .) }}
+{{- else if and (not (include "nodeAnalyzer.gke.autopilot" .)) (or ((.Values.secure).vulnerabilityManagement).newEngineOnly (and (hasKey ((.Values.nodeAnalyzer).runtimeScanner) "deploy") .Values.nodeAnalyzer.runtimeScanner.deploy)) -}}
 true
 {{- end -}}
 {{- end -}}
 
 {{- define "nodeAnalyzer.deployBenchmarkRunner" -}}
-{{- if or (not (hasKey .Values.nodeAnalyzer.benchmarkRunner "deploy")) .Values.nodeAnalyzer.benchmarkRunner.deploy }}
+{{- if and (not (include "nodeAnalyzer.gke.autopilot" .)) (or (not (hasKey .Values.nodeAnalyzer.benchmarkRunner "deploy")) .Values.nodeAnalyzer.benchmarkRunner.deploy) }}
 true
 {{- end -}}
 {{- end -}}
@@ -248,14 +251,14 @@ true
 {{- end -}}
 
 {{- define "nodeAnalyzer.deployImageAnalyzer" -}}
-{{- if and (not .Values.secure.vulnerabilityManagement.newEngineOnly) (or (not (hasKey .Values.nodeAnalyzer.imageAnalyzer "deploy")) .Values.nodeAnalyzer.imageAnalyzer.deploy) }}
+{{- if and (not .Values.secure.vulnerabilityManagement.newEngineOnly) (or (not (hasKey .Values.nodeAnalyzer.imageAnalyzer "deploy")) .Values.nodeAnalyzer.imageAnalyzer.deploy) (not (include "nodeAnalyzer.gke.autopilot" .)) }}
 true
 {{- end -}}
 {{- end -}}
 
 # Legacy components #
 {{- define "nodeAnalyzer.deployHostAnalyzer" -}}
-{{- if and (not .Values.secure.vulnerabilityManagement.newEngineOnly) (or (not (hasKey .Values.nodeAnalyzer.hostAnalyzer "deploy")) .Values.nodeAnalyzer.hostAnalyzer.deploy) }}
+{{- if and (not .Values.secure.vulnerabilityManagement.newEngineOnly) (or (not (hasKey .Values.nodeAnalyzer.hostAnalyzer "deploy")) .Values.nodeAnalyzer.hostAnalyzer.deploy) (not (include "nodeAnalyzer.gke.autopilot" .)) }}
 true
 {{- end -}}
 {{- end -}}

--- a/charts/node-analyzer/templates/clusterrole-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/clusterrole-node-analyzer.yaml
@@ -1,4 +1,3 @@
-{{- if not (include "nodeAnalyzer.gke.autopilot" .) }}
 {{- if and (include "deploy-na" .) .Values.rbac.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -111,6 +110,5 @@ rules:
     - "{{ .Release.Name }}-node-analyzer"
   verbs:
     - "use"
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/node-analyzer/templates/clusterrolebinding-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/clusterrolebinding-node-analyzer.yaml
@@ -1,4 +1,3 @@
-{{- if not (include "nodeAnalyzer.gke.autopilot" .) }}
 {{- if and (include "deploy-na" .) .Values.rbac.create }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,5 +13,4 @@ roleRef:
   kind: ClusterRole
   name: {{ .Release.Name }}-node-analyzer
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
 {{- end }}

--- a/charts/node-analyzer/templates/configmap-benchmark-runner.yaml
+++ b/charts/node-analyzer/templates/configmap-benchmark-runner.yaml
@@ -1,4 +1,3 @@
-{{- if not (include "nodeAnalyzer.gke.autopilot" .) }}
 {{- if and .Values.nodeAnalyzer.deploy (include "nodeAnalyzer.deployBenchmarkRunner" .) }}
 apiVersion: v1
 kind: ConfigMap
@@ -22,5 +21,4 @@ data:
   {{- if (.Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy) }}
   no_proxy: {{ .Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy }}
   {{- end -}}
-{{- end }}
 {{- end }}

--- a/charts/node-analyzer/templates/configmap-host-analyzer.yaml
+++ b/charts/node-analyzer/templates/configmap-host-analyzer.yaml
@@ -1,4 +1,3 @@
-{{- if not (include "nodeAnalyzer.gke.autopilot" .) }}
 {{ if not .Values.secure.vulnerabilityManagement.newEngineOnly }}
 {{- if and .Values.nodeAnalyzer.deploy (include "nodeAnalyzer.deployHostAnalyzer" .) }}
 apiVersion: v1
@@ -38,6 +37,5 @@ data:
   {{- if (.Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy) }}
   no_proxy: {{ .Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy }}
   {{- end -}}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/node-analyzer/templates/configmap-host-scanner.yaml
+++ b/charts/node-analyzer/templates/configmap-host-scanner.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (include "nodeAnalyzer.deployHostScanner" .) }}
+{{- if and .Values.nodeAnalyzer.deploy (include "nodeAnalyzer.deployHostScanner" .) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/node-analyzer/templates/configmap-image-analyzer.yaml
+++ b/charts/node-analyzer/templates/configmap-image-analyzer.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.nodeAnalyzer.deploy (not .Values.secure.vulnerabilityManagement.newEngineOnly) (not (include "nodeAnalyzer.gke.autopilot" .)) (include "nodeAnalyzer.deployImageAnalyzer" .) }}
+{{ if and .Values.nodeAnalyzer.deploy (not .Values.secure.vulnerabilityManagement.newEngineOnly) (include "nodeAnalyzer.deployImageAnalyzer" .) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/node-analyzer/templates/configmap-kspm-analyzer.yaml
+++ b/charts/node-analyzer/templates/configmap-kspm-analyzer.yaml
@@ -1,4 +1,3 @@
-{{- if not (include "nodeAnalyzer.gke.autopilot" .) }}
 {{ if .Values.global.kspm.deploy }}
 apiVersion: v1
 kind: ConfigMap
@@ -31,5 +30,4 @@ data:
   {{- if .Values.nodeAnalyzer.kspmAnalyzer.port }}
   agent_port: {{ .Values.nodeAnalyzer.kspmAnalyzer.port | quote }}
   {{- end -}}
-{{- end -}}
 {{- end -}}

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -1,4 +1,3 @@
-{{- if not (include "nodeAnalyzer.gke.autopilot" .) }}
 {{- if (include "deploy-na" .) }}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -909,5 +908,4 @@ spec:
                     - linux
               {{- end }}
       {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/node-analyzer/templates/psp.yaml
+++ b/charts/node-analyzer/templates/psp.yaml
@@ -1,5 +1,4 @@
-{{- if not (include "nodeAnalyzer.gke.autopilot" .) }}
-{{- if and .Values.psp.create (include "nodeAnalyzer.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
+{{- if and (include "deploy-na" .) .Values.psp.create (include "nodeAnalyzer.kubeVersionLessThan" (dict "root" . "major" 1 "minor" 25)) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -25,5 +24,4 @@ spec:
     rule: RunAsAny
   volumes:
   - '*'
-{{- end }}
 {{- end }}

--- a/charts/node-analyzer/templates/runtimeScanner/eveconnector-api-configmap.yaml
+++ b/charts/node-analyzer/templates/runtimeScanner/eveconnector-api-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.nodeAnalyzer.deploy (not (include "nodeAnalyzer.gke.autopilot" .)) (or .Values.nodeAnalyzer.runtimeScanner.deploy .Values.secure.vulnerabilityManagement.newEngineOnly) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and .Values.nodeAnalyzer.deploy (or .Values.nodeAnalyzer.runtimeScanner.deploy .Values.secure.vulnerabilityManagement.newEngineOnly) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/node-analyzer/templates/runtimeScanner/eveconnector-api-deployment.yaml
+++ b/charts/node-analyzer/templates/runtimeScanner/eveconnector-api-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.nodeAnalyzer.deploy (not (include "nodeAnalyzer.gke.autopilot" .)) (or .Values.nodeAnalyzer.runtimeScanner.deploy .Values.secure.vulnerabilityManagement.newEngineOnly) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and .Values.nodeAnalyzer.deploy (or .Values.nodeAnalyzer.runtimeScanner.deploy .Values.secure.vulnerabilityManagement.newEngineOnly) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/node-analyzer/templates/runtimeScanner/eveconnector-api-service.yaml
+++ b/charts/node-analyzer/templates/runtimeScanner/eveconnector-api-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.nodeAnalyzer.deploy (not (include "nodeAnalyzer.gke.autopilot" .)) (or .Values.nodeAnalyzer.runtimeScanner.deploy .Values.secure.vulnerabilityManagement.newEngineOnly) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and .Values.nodeAnalyzer.deploy (or .Values.nodeAnalyzer.runtimeScanner.deploy .Values.secure.vulnerabilityManagement.newEngineOnly) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/node-analyzer/templates/runtimeScanner/runtime-scanner-configmap.yaml
+++ b/charts/node-analyzer/templates/runtimeScanner/runtime-scanner-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.nodeAnalyzer.deploy (not (include "nodeAnalyzer.gke.autopilot" .)) (or .Values.nodeAnalyzer.runtimeScanner.deploy .Values.secure.vulnerabilityManagement.newEngineOnly) }}
+{{- if and .Values.nodeAnalyzer.deploy (or .Values.nodeAnalyzer.runtimeScanner.deploy .Values.secure.vulnerabilityManagement.newEngineOnly) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/node-analyzer/templates/runtimeScanner/sysdig-eve-secret.yaml
+++ b/charts/node-analyzer/templates/runtimeScanner/sysdig-eve-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.nodeAnalyzer.deploy (not (include "nodeAnalyzer.gke.autopilot" .)) (or .Values.nodeAnalyzer.runtimeScanner.deploy .Values.secure.vulnerabilityManagement.newEngineOnly) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
+{{- if and .Values.nodeAnalyzer.deploy (or .Values.nodeAnalyzer.runtimeScanner.deploy .Values.secure.vulnerabilityManagement.newEngineOnly) .Values.nodeAnalyzer.runtimeScanner.eveConnector.deploy }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/node-analyzer/templates/secrets.yaml
+++ b/charts/node-analyzer/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not (include "nodeAnalyzer.gke.autopilot" .) }}
+{{- if (include "deploy-na" .) }}
 {{- if not ( include "nodeAnalyzer.accessKeySecret" . ) }}
 apiVersion: v1
 kind: Secret
@@ -12,7 +12,6 @@ data:
  access-key : {{ include "nodeAnalyzer.accessKey" . | b64enc | quote }}
 {{- end }}
 ---
-{{- end }}
 {{- if eq (include "sysdig.custom_ca.useValues"  (dict "global" .Values.global.ssl "component" .Values.nodeAnalyzer.ssl)) "true" }}
 apiVersion: v1
 kind: Secret
@@ -24,4 +23,5 @@ metadata:
 data:
   {{ include "sysdig.custom_ca.keyName" (dict "global" .Values.global.ssl "component" .Values.nodeAnalyzer.ssl) }}: {{ include "sysdig.custom_ca.cert" (dict "global" .Values.global.ssl "component" .Values.nodeAnalyzer.ssl "Files" .Subcharts.common.Files) | b64enc | quote }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/node-analyzer/templates/securitycontextconstraint.yaml
+++ b/charts/node-analyzer/templates/securitycontextconstraint.yaml
@@ -1,3 +1,4 @@
+{{- if (include "deploy-na" .) }}
 {{- if and .Values.scc.create (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
@@ -40,4 +41,5 @@ volumes:
 - secret
 - configMap
 - downwardAPI
+{{- end }}
 {{- end }}

--- a/charts/node-analyzer/templates/serviceaccount-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/serviceaccount-node-analyzer.yaml
@@ -1,4 +1,3 @@
-{{- if not (include "nodeAnalyzer.gke.autopilot" .) }}
 {{- if and (include "deploy-na" .) .Values.nodeAnalyzer.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,5 +6,4 @@ metadata:
   namespace: {{ include "nodeAnalyzer.namespace" . }}
   labels:
 {{ include "nodeAnalyzer.labels" . | indent 4 }}
-{{- end }}
 {{- end }}

--- a/charts/node-analyzer/tests/gke_autopilot_test.yaml
+++ b/charts/node-analyzer/tests/gke_autopilot_test.yaml
@@ -1,0 +1,68 @@
+# requires unittest plugin: https://github.com/quintush/helm-unittest
+# Run "helm unittest -3 -f ./tests/hostscanner_test.yaml ." from within the `charts/node-analyzer` folder
+suite: Test Node Analyzer configuration when global.GKE.autopilot set to true
+templates:
+  - ../templates/daemonset-node-analyzer.yaml
+
+tests:
+  - it: "HS is deployed if newEngineOnly is active but deploy unset"
+    set:
+      clusterName: "test"
+      secure.vulnerabilityManagement.newEngineOnly: true
+      global.gke.autopilot: true
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: "spec.template.spec.containers[0].name"
+          value: "sysdig-host-scanner"
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+  - it: "HS is deployed if newEngineOnly is true and deploy set to true"
+    set:
+      clusterName: "test"
+      secure.vulnerabilityManagement.newEngineOnly: true
+      nodeAnalyzer.hostScanner.deploy: true
+      global.gke.autopilot: true
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: "spec.template.spec.containers[0].name"
+          value: "sysdig-host-scanner"
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+  - it: "HS is deployed if newEngineOnly is unset and deploy set to true"
+    set:
+      clusterName: "test"
+      nodeAnalyzer.hostScanner.deploy: true
+      global.gke.autopilot: true
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: "spec.template.spec.containers[0].name"
+          value: "sysdig-host-scanner"
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+  - it: "HS and KSPM Analyzer are deployed if newEngineOnly is active and global.kspm.deploy set to true"
+    set:
+      clusterName: "test"
+      secure.vulnerabilityManagement.newEngineOnly: true
+      global.gke.autopilot: true
+      global.kspm.deploy: true
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: "spec.template.spec.containers[0].name"
+          value: "sysdig-kspm-analyzer"
+      - equal:
+          path: "spec.template.spec.containers[1].name"
+          value: "sysdig-host-scanner"
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.24.0
+version: 1.25.0
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com

--- a/scripts/cluster-scanner/generate_kubeconfig.sh
+++ b/scripts/cluster-scanner/generate_kubeconfig.sh
@@ -7,7 +7,7 @@ SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-sysdig-cluster-scanner}
 CONTEXT=$(kubectl config current-context)
 NAMESPACE=${NAMESPACE:-sysdig-cluster-scanner}
 
-NEW_CONTEXT=${CLUSTER_NAME_OVERRIDE:-$(kubectl config view --minify -o jsonpath='{.clusters[].name}')}
+NEW_CONTEXT=${CLUSTER_NAME_OVERRIDE:-$(kubectl config view --minify -o jsonpath='{.clusters[].name}' | tr :/ -)}
 KUBECONFIG_FILE=${KUBECONFIG_FILE:-"${NEW_CONTEXT}.kubeconfig"}
 
 SECRET_NAME=sysdig-cluster-scanner


### PR DESCRIPTION
## What this PR does / why we need it:
Fix generate_kubeconfig.sh script to be able handle context name with special characters, so that context name like `arn:aws:eks:us-east-2:XXXXXXXXX:cluster/eks-i044e3wc` would not cause problems on running script. All `:` and `/` will be replace by `-`

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
