### PR TITLE
fix(cluster-scanner): Fix generate kubeconfig script to be able handle context name with special characters

### DIFF
--- a/scripts/cluster-scanner/generate_kubeconfig.sh
+++ b/scripts/cluster-scanner/generate_kubeconfig.sh
@@ -7,7 +7,7 @@ SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-sysdig-cluster-scanner}
 CONTEXT=$(kubectl config current-context)
 NAMESPACE=${NAMESPACE:-sysdig-cluster-scanner}
 
-NEW_CONTEXT=${CLUSTER_NAME_OVERRIDE:-$(kubectl config view --minify -o jsonpath='{.clusters[].name}')}
+NEW_CONTEXT=${CLUSTER_NAME_OVERRIDE:-$(kubectl config view --minify -o jsonpath='{.clusters[].name}' | tr :/ -)}
 KUBECONFIG_FILE=${KUBECONFIG_FILE:-"${NEW_CONTEXT}.kubeconfig"}
 
 SECRET_NAME=sysdig-cluster-scanner


### PR DESCRIPTION
## What this PR does / why we need it:
Fix generate_kubeconfig.sh script to be able handle context name with special characters, so that context name like `arn:aws:eks:us-east-2:XXXXXXXXX:cluster/eks-i044e3wc` would not cause problems on running script. All `:` and `/` will be replace by `-`

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix