### PR TITLE
ci(agent): update agent image tag in readme on release

### DIFF
--- a/.github/updatecli.d/config-agent-release.yaml
+++ b/.github/updatecli.d/config-agent-release.yaml
@@ -43,6 +43,15 @@ targets:
       file: "charts/agent/values.yaml"
       key: "$.image.tag"
 
+  updateAgentReadme:
+    name: "update agent tag in readme table"
+    kind: file
+    scmid: github
+    spec:
+      file: "charts/agent/README.md"
+      matchpattern: '\| `\d+.\d+.\d+`'
+      replacepattern: '| `{{ requiredEnv "AGENT_RELEASE" }}`'
+
   bumpAgentChart:
     name: "bump the chart version of the agent chart"
     kind: helmchart


### PR DESCRIPTION
## What this PR does / why we need it:
when a new version of the agent is released, make sure we increment the default value for image.tag mentioned in the readme file in addition to the values file

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
