### PR TITLE
fix(agent): allows to specify non semver tags [SMAGENT-6093] 

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.17.1
+version: 1.17.2

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -511,3 +511,11 @@ true
 {{- define "agent.localForwarderConfigMapName" }}
 {{- include "agent.configmapName" . | trunc 46 | trimSuffix "-" | printf "%s-local-forwarder" }}
 {{- end }}
+
+{{- define "agent.enableHttpProbes" }}
+{{- if regexMatch "^v?([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?$" .Values.image.tag }}
+{{- if semverCompare ">= 12.18.0-0" .Values.image.tag }}
+{{- printf "true" -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -219,7 +219,7 @@ spec:
               value: /opt/draios/etc/ca-certs/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
             {{- end }}
           readinessProbe:
-            {{- if ge (semver "12.18.0" | (semver .Values.image.tag).Compare) 0 }}
+            {{- if eq (include "agent.enableHttpProbes" .) "true" }}
             httpGet:
               path: /healthz
               port: 24483

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -103,7 +103,7 @@ spec:
             value: /opt/draios/etc/ca-certs/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
           {{- end }}
           readinessProbe:
-            {{- if ge (semver "12.18.0" | (semver .Values.image.tag).Compare) 0 }}
+            {{- if eq (include "agent.enableHttpProbes" .) "true" }}
             httpGet:
               path: /healthz
               port: 24483

--- a/charts/agent/tests/readiness_probe_test.yaml
+++ b/charts/agent/tests/readiness_probe_test.yaml
@@ -47,6 +47,38 @@ tests:
             initialDelaySeconds: 90
             periodSeconds: 3
     template: templates/daemonset.yaml
+  - it: "[DaemonSet] Readiness Probe (agent == dev)"
+    set:
+      image:
+        tag: dev
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            exec:
+              command:
+                - test
+                - -e
+                - /opt/draios/logs/running
+            initialDelaySeconds: 90
+            periodSeconds: 3
+    template: templates/daemonset.yaml
+  - it: "[DaemonSet] Readiness Probe (agent == latest)"
+    set:
+      image:
+        tag: latest
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            exec:
+              command:
+                - test
+                - -e
+                - /opt/draios/logs/running
+            initialDelaySeconds: 90
+            periodSeconds: 3
+    template: templates/daemonset.yaml
   - it: "[DelegatedAgentDeployment] Readiness Probe (agent > 12.18.0)"
     set:
       delegatedAgentDeployment:
@@ -83,6 +115,40 @@ tests:
         enabled: true
       image:
         tag: 12.16.3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            exec:
+              command:
+                - test
+                - -e
+                - /opt/draios/logs/running
+            initialDelaySeconds: 90
+            periodSeconds: 3
+  - it: "[DelegatedAgentDeployment] Readiness Probe (agent == dev)"
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      image:
+        tag: dev
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            exec:
+              command:
+                - test
+                - -e
+                - /opt/draios/logs/running
+            initialDelaySeconds: 90
+            periodSeconds: 3
+  - it: "[DelegatedAgentDeployment] Readiness Probe (agent == latest)"
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+      image:
+        tag: latest
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe


### PR DESCRIPTION
## What this PR does / why we need it:

Due to the introduction of some features that are available since version `12.18.0` we introduced a check on the version which fails if the provided tag is not a valid semantic version.


## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
