### PR TITLE
fix(agent): GKE Autopilot do not accept HTTP probe

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.17.2
+version: 1.17.3

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -513,9 +513,11 @@ true
 {{- end }}
 
 {{- define "agent.enableHttpProbes" }}
+{{- if not (include "agent.gke.autopilot" .) }}
 {{- if regexMatch "^v?([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?$" .Values.image.tag }}
 {{- if semverCompare ">= 12.18.0-0" .Values.image.tag }}
 {{- printf "true" -}}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/agent/tests/readiness_probe_test.yaml
+++ b/charts/agent/tests/readiness_probe_test.yaml
@@ -179,3 +179,38 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.periodSeconds
           value: 3
+
+  - it: "Do not use the HTTP Readiness Probe on GKE Autopilot"
+    set:
+      global:
+        gke:
+          autopilot: true
+    template: templates/daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[*].readinessProbe
+          value:
+            exec:
+              command:
+                - test
+                - -e
+                - /opt/draios/logs/running
+            initialDelaySeconds: 90
+            periodSeconds: 3
+
+  - it: "Do not use the HTTP Readiness Probe on GKE Autopilot"
+    set:
+      gke:
+        autopilot: true
+    template: templates/daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[*].readinessProbe
+          value:
+            exec:
+              command:
+                - test
+                - -e
+                - /opt/draios/logs/running
+            initialDelaySeconds: 90
+            periodSeconds: 3


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix