### PR TITLE
feat(agent): mount agent http-proxy credentials as secret

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.17.4
+version: 1.18.0

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.17.3
+version: 1.17.4

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -183,6 +183,16 @@ Return the default only if the value is not defined in sysdig.settings.<agent_se
 The following helper functions are all designed to use global values where
 possible, but accept overrides from the chart values.
 */}}
+
+{{- define "agent.httpProxyCredentials" -}}
+    {{- if hasKey .Values.sysdig.settings "http_proxy" -}}
+        {{- if and (hasKey .Values.sysdig.settings.http_proxy "proxy_user") (hasKey .Values.sysdig.settings.http_proxy "proxy_password") -}}
+proxy_user: {{ .Values.sysdig.settings.http_proxy.proxy_user | toString | b64enc | quote }}
+proxy_password: {{ .Values.sysdig.settings.http_proxy.proxy_password | toString | b64enc | quote }}
+        {{- end }}
+    {{- end }}
+{{- end -}}
+
 {{- define "agent.accessKey" -}}
     {{- required "A valid accessKey is required" (.Values.sysdig.accessKey | default .Values.global.sysdig.accessKey) -}}
 {{- end -}}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
     tags: {{ include "agent.tags" . }}
 {{- end }}
 {{/*
-  Unset proxy_user and proxy_password if present in the settings block.
+  Unset proxy_user and proxy_password if present and gke autopilot is disabled.
 */}}
 {{- if and (hasKey .Values.sysdig.settings "http_proxy") (not (include "agent.gke.autopilot" .)) }}
   {{- $_ := unset .Values.sysdig.settings.http_proxy "proxy_user" -}}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -29,7 +29,7 @@ data:
 {{/*
   Unset proxy_user and proxy_password if present in the settings block.
 */}}
-{{- if hasKey .Values.sysdig.settings "http_proxy" }}
+{{- if and (hasKey .Values.sysdig.settings "http_proxy") (not (include "agent.gke.autopilot" .)) }}
   {{- $_ := unset .Values.sysdig.settings.http_proxy "proxy_user" -}}
   {{- $_ := unset .Values.sysdig.settings.http_proxy "proxy_password" -}}
 {{- end }}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -27,6 +27,13 @@ data:
     tags: {{ include "agent.tags" . }}
 {{- end }}
 {{/*
+  Unset proxy_user and proxy_password if present in the settings block.
+*/}}
+{{- if hasKey .Values.sysdig.settings "http_proxy" }}
+  {{- $_ := unset .Values.sysdig.settings.http_proxy "proxy_user" -}}
+  {{- $_ := unset .Values.sysdig.settings.http_proxy "proxy_password" -}}
+{{- end }}
+{{/*
   Checking here the user is using Custom CA and if http_proxy.ssl = true
   If these conditions are true, then we use the agent.sslCaFileName for the http_proxy.ca_certificate
 */}}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -249,7 +249,7 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
-            {{- if (include "agent.httpProxyCredentials" .) }}
+            {{- if and (include "agent.httpProxyCredentials" .) (not (include "agent.gke.autopilot" .)) }}
             - mountPath: /opt/draios/etc/secrets/http_proxy
               name: sysdig-agent-http-proxy-secrets
             {{- end }}
@@ -373,7 +373,7 @@ spec:
             {{- else }}
             secretName: {{ include "agent.accessKeySecret" . }}
             {{- end }}
-        {{- if (include "agent.httpProxyCredentials" .) }}
+        {{- if and (include "agent.httpProxyCredentials" .) (not (include "agent.gke.autopilot" .)) }}
         - name: sysdig-agent-http-proxy-secrets
           secret:
             secretName: {{ template "agent.fullname" . }}-proxy

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -249,6 +249,10 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
+            {{- if (include "agent.httpProxyCredentials" .) }}
+            - mountPath: /opt/draios/etc/secrets/http_proxy
+              name: sysdig-agent-http-proxy-secrets
+            {{- end }}
             - mountPath: /etc/podinfo
               name: podinfo
 
@@ -369,6 +373,11 @@ spec:
             {{- else }}
             secretName: {{ include "agent.accessKeySecret" . }}
             {{- end }}
+        {{- if (include "agent.httpProxyCredentials" .) }}
+        - name: sysdig-agent-http-proxy-secrets
+          secret:
+            secretName: {{ template "agent.fullname" . }}-proxy
+        {{- end }}
         - name: podinfo
           downwardAPI:
             defaultMode: 420

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -128,6 +128,10 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
+            {{- if (include "agent.httpProxyCredentials" .) }}
+            - mountPath: /opt/draios/etc/secrets/http_proxy
+              name: sysdig-agent-http-proxy-secrets
+            {{- end }}
             - mountPath: /etc/podinfo
               name: podinfo
             {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
@@ -252,6 +256,11 @@ spec:
             {{- else }}
             secretName: {{ include "agent.accessKeySecret" . }}
             {{- end }}
+        {{- if (include "agent.httpProxyCredentials" .) }}
+        - name: sysdig-agent-http-proxy-secrets
+          secret:
+            secretName: {{ template "agent.fullname" . }}-proxy
+        {{- end }}
         - name: podinfo
           downwardAPI:
             defaultMode: 420

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -128,7 +128,7 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
-            {{- if (include "agent.httpProxyCredentials" .) }}
+            {{- if and (include "agent.httpProxyCredentials" .) (not (include "agent.gke.autopilot" .)) }}
             - mountPath: /opt/draios/etc/secrets/http_proxy
               name: sysdig-agent-http-proxy-secrets
             {{- end }}
@@ -256,7 +256,7 @@ spec:
             {{- else }}
             secretName: {{ include "agent.accessKeySecret" . }}
             {{- end }}
-        {{- if (include "agent.httpProxyCredentials" .) }}
+        {{- if and (include "agent.httpProxyCredentials" .) (not (include "agent.gke.autopilot" .)) }}
         - name: sysdig-agent-http-proxy-secrets
           secret:
             secretName: {{ template "agent.fullname" . }}-proxy

--- a/charts/agent/templates/secrets.yaml
+++ b/charts/agent/templates/secrets.yaml
@@ -36,3 +36,16 @@ metadata:
 data:
   {{ include "sysdig.custom_ca.keyName" (dict "global" .Values.global.ssl "component" .Values.ssl) }}: {{ include "sysdig.custom_ca.cert" (dict "global" .Values.global.ssl "component" .Values.ssl "Files" .Subcharts.common.Files) | b64enc | quote }}
 {{- end }}
+{{- if ( include "agent.httpProxyCredentials" . ) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "agent.fullname" . }}-proxy
+  namespace: {{ include "agent.namespace" $ }}
+  labels:
+{{ include "agent.labels" $ | indent 4 }}
+type: Opaque
+data:
+{{ include "agent.httpProxyCredentials" . | indent 2 }}
+{{- end }}

--- a/charts/agent/templates/secrets.yaml
+++ b/charts/agent/templates/secrets.yaml
@@ -36,7 +36,7 @@ metadata:
 data:
   {{ include "sysdig.custom_ca.keyName" (dict "global" .Values.global.ssl "component" .Values.ssl) }}: {{ include "sysdig.custom_ca.cert" (dict "global" .Values.global.ssl "component" .Values.ssl "Files" .Subcharts.common.Files) | b64enc | quote }}
 {{- end }}
-{{- if ( include "agent.httpProxyCredentials" . ) }}
+{{- if and (include "agent.httpProxyCredentials" .) (not (include "agent.gke.autopilot" .)) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/agent/tests/api_endpoint_region_test.yaml
+++ b/charts/agent/tests/api_endpoint_region_test.yaml
@@ -510,3 +510,18 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "global.sysdig.region=us7 provided is not recognized."
+
+  - it: Checking proxy_user and proxy_password are not set
+    set:
+      sysdig:
+        settings:
+          http_proxy:
+            proxy_user: "user"
+            proxy_password: "password"
+    asserts:
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: .*username.*
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: .*password.*

--- a/charts/agent/tests/secrets_test.yaml
+++ b/charts/agent/tests/secrets_test.yaml
@@ -53,3 +53,23 @@ tests:
           path: data.sysdig-new-password-key1
           value: bXlwYXNzd29yZA==
         documentIndex: 2
+
+  - it: Check proxy secret
+    set:
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+        settings:
+          http_proxy:
+            proxy_user: username
+            proxy_password: password
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: data.proxy_user
+          value: dXNlcm5hbWU=
+        documentIndex: 1
+      - equal:
+          path: data.proxy_password
+          value: cGFzc3dvcmQ=
+        documentIndex: 1

--- a/charts/agent/tests/secrets_test.yaml
+++ b/charts/agent/tests/secrets_test.yaml
@@ -54,7 +54,7 @@ tests:
           value: bXlwYXNzd29yZA==
         documentIndex: 2
 
-  - it: Check proxy secret
+  - it: Should create proxy secret with http_proxy settings
     set:
       sysdig:
         accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
@@ -73,3 +73,19 @@ tests:
           path: data.proxy_password
           value: cGFzc3dvcmQ=
         documentIndex: 1
+
+  - it: Should not create proxy secret with http_proxy settings and autopilot enabled
+    set:
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+        settings:
+          http_proxy:
+            proxy_user: username
+            proxy_password: password
+      gke:
+        autopilot: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -37,3 +37,34 @@ tests:
           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "varlib-vol")]
       - isNull:
           path: spec.template.spec.volumes[?(@.name == "varlib-vol")]
+
+  - it: Ensure agent http proxy volume is not mounted when http_proxy settings is not set
+    set:
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+    asserts:
+      - isNull:
+          path: spec.template.spec.volumes[?(@.name == "sysdig-agent-http-proxy-secrets")]
+        template: daemonset.yaml
+      - isNull:
+          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "sysdig-agent-http-proxy-secrets")]
+        template: daemonset.yaml
+
+  - it: Ensure agent http proxy volume is mounted when http_proxy settings is set
+    set:
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+        settings:
+          http_proxy:
+            proxy_user: username
+            proxy_password: password
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "sysdig-agent-http-proxy-secrets")].secret
+          value:
+            secretName: RELEASE-NAME-agent-proxy
+        template: daemonset.yaml
+      - equal:
+          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "sysdig-agent-http-proxy-secrets")].mountPath
+          value: /opt/draios/etc/secrets/http_proxy
+        template: daemonset.yaml

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -1,6 +1,7 @@
 suite: Host volumes are available for agent
 templates:
-  - templates/daemonset.yaml
+  - daemonset.yaml
+  - deployment.yaml
 tests:
   - it: Ensure /var/run host volume is mounted as /host/var/run in container
     asserts:
@@ -10,6 +11,9 @@ tests:
       - equal:
           path: spec.template.spec.volumes[?(@.name == "varrun-vol")].hostPath.path
           value: /var/run
+    templates:
+      - daemonset.yaml
+
   - it: Ensure /var/lib host volume is mounted as /host/var/lib in container
     asserts:
       - equal:
@@ -18,6 +22,9 @@ tests:
       - equal:
           path: spec.template.spec.volumes[?(@.name == "varlib-vol")].hostPath.path
           value: /var/lib
+    templates:
+      - daemonset.yaml
+
   - it: Ensure /var/lib host volume is not mounted as /host/var/lib in container when running on gke.autopilot
     set:
       gke:
@@ -27,6 +34,9 @@ tests:
           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "varlib-vol")]
       - isNull:
           path: spec.template.spec.volumes[?(@.name == "varlib-vol")]
+    templates:
+      - daemonset.yaml
+
   - it: Ensure /var/lib host volume is not mounted as /host/var/lib in container when running on global.gke.autopilot
     set:
       global:
@@ -37,21 +47,28 @@ tests:
           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "varlib-vol")]
       - isNull:
           path: spec.template.spec.volumes[?(@.name == "varlib-vol")]
+    templates:
+      - daemonset.yaml
 
   - it: Ensure agent http proxy volume is not mounted when http_proxy settings is not set
     set:
       sysdig:
         accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+      delegatedAgentDeployment:
+        enabled: true
     asserts:
       - isNull:
           path: spec.template.spec.volumes[?(@.name == "sysdig-agent-http-proxy-secrets")]
-        template: daemonset.yaml
       - isNull:
           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "sysdig-agent-http-proxy-secrets")]
-        template: daemonset.yaml
+    templates:
+      - deployment.yaml
+      - daemonset.yaml
 
   - it: Ensure agent http proxy volume is mounted when http_proxy settings is set
     set:
+      delegatedAgentDeployment:
+        enabled: true
       sysdig:
         accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
         settings:
@@ -63,8 +80,9 @@ tests:
           path: spec.template.spec.volumes[?(@.name == "sysdig-agent-http-proxy-secrets")].secret
           value:
             secretName: RELEASE-NAME-agent-proxy
-        template: daemonset.yaml
       - equal:
           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "sysdig-agent-http-proxy-secrets")].mountPath
           value: /opt/draios/etc/secrets/http_proxy
-        template: daemonset.yaml
+    templates:
+      - deployment.yaml
+      - daemonset.yaml

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -65,6 +65,27 @@ tests:
       - deployment.yaml
       - daemonset.yaml
 
+  - it: Ensure agent http proxy volume is not mounted when http_proxy settings is set and autopilot is enabled
+    set:
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+        settings:
+          http_proxy:
+            proxy_user: username
+            proxy_password: password
+      delegatedAgentDeployment:
+        enabled: true
+      gke:
+        autopilot: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.volumes[?(@.name == "sysdig-agent-http-proxy-secrets")]
+      - isNull:
+          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "sysdig-agent-http-proxy-secrets")]
+    templates:
+      - deployment.yaml
+      - daemonset.yaml
+
   - it: Ensure agent http proxy volume is mounted when http_proxy settings is set
     set:
       delegatedAgentDeployment:

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.32.1
+version: 1.33.0
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -26,7 +26,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.17.3
+    version: ~1.18.0
     alias: agent
     condition: agent.enabled
   - name: common


### PR DESCRIPTION
## What this PR does / why we need it:

Mount agent http-proxy credentials as a secret in both agent `DaemonSet` and `Deployment` except when gke autopilot is enabled.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
