### PR TITLE
fix(agent): ephemeral-storage on gke autopilot and slim enabled

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.18.0
+version: 1.18.1

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -93,7 +93,7 @@ Sysdig Agent resources
     {{- toYaml .Values.resources -}}
 {{- else if not (hasKey $resourceProfiles .Values.resourceProfile) }}
     {{- fail (printf "Invalid value for resourceProfile provided: %s" .Values.resourceProfile) }}
-{{- else if and (include "agent.gke.autopilot" .) (not .Values.slim.enabled) }}
+{{- else if include "agent.gke.autopilot" . }}
     {{- toYaml (dict "requests" (dict "cpu" "250m"
                                       "ephemeral-storage" .Values.gke.ephemeralStorage
                                       "memory" "512Mi")

--- a/charts/agent/tests/gke_test.yaml
+++ b/charts/agent/tests/gke_test.yaml
@@ -9,8 +9,6 @@ tests:
       gke:
         autopilot: true
         createPriorityClass: true
-      slim:
-        enabled: false
     asserts:
       - containsDocument:
           kind: DaemonSet
@@ -31,8 +29,6 @@ tests:
         autopilot: true
         createPriorityClass: true
         ephemeralStorage: 256Mi
-      slim:
-        enabled: false
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.ephemeral-storage

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.33.0
+version: 1.33.1
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -26,7 +26,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.18.0
+    version: ~1.18.1
     alias: agent
     condition: agent.enabled
   - name: common


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
