### PR TITLE
fix(agent): [SMAGENT-6037] fix the template failure for helm 3.9

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.19.2
+version: 1.19.3

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -37,14 +37,21 @@ data:
   Checking here the user is using Custom CA and if http_proxy.ssl = true
   If these conditions are true, then we use the agent.sslCaFileName for the http_proxy.ca_certificate
 */}}
-{{- if and (eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") (.Values.sysdig.settings) (hasKey .Values.sysdig.settings "http_proxy") (hasKey (default dict .Values.sysdig.settings.http_proxy) "ssl") (eq (get (default (dict "ssl" false) .Values.sysdig.settings.http_proxy) "ssl") true) }}
-  {{- $baseSettings := .Values.sysdig.settings -}}
-  {{- $caFilePath := printf "%s%s" "/etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
-  {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}
-  {{ toYaml $mergedSettings | nindent 4 }}
-{{- else if .Values.sysdig.settings }}
-  {{ toYaml .Values.sysdig.settings | nindent 4 }}
+{{- if and (eq (include "sysdig.custom_ca.enabled" (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") }}
+  {{- if (hasKey .Values.sysdig.settings "http_proxy") }}
+    {{- if (hasKey .Values.sysdig.settings.http_proxy "ssl") }}
+      {{- if (.Values.sysdig.settings.http_proxy.ssl) }}
+        {{- $baseSettings := .Values.sysdig.settings -}}
+        {{- $caFilePath := printf "%s%s" "/etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
+        {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}
+        {{ toYaml $mergedSettings | nindent 4 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
+{{- if .Values.sysdig.settings }}
+  {{ toYaml .Values.sysdig.settings | nindent 4 }}
+{{ end }}
 {{- if .Values.leaderelection.enable }}
     k8s_delegation_election: true
     k8s_coldstart:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy)`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix
