### PR TITLE
feat(agent): update the readiness probes to use localhost

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.18.1
+version: 1.18.2

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -221,6 +221,7 @@ spec:
           readinessProbe:
             {{- if eq (include "agent.enableHttpProbes" .) "true" }}
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: 24483
             {{- else }}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -105,6 +105,7 @@ spec:
           readinessProbe:
             {{- if eq (include "agent.enableHttpProbes" .) "true" }}
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: 24483
             {{- else }}

--- a/charts/agent/tests/readiness_probe_test.yaml
+++ b/charts/agent/tests/readiness_probe_test.yaml
@@ -12,6 +12,7 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe
           value:
              httpGet:
+               host: 127.0.0.1
                path: /healthz
                port: 24483
              initialDelaySeconds: 90
@@ -26,6 +27,7 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe
           value:
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: 24483
             initialDelaySeconds: 90
@@ -90,6 +92,7 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe
           value:
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: 24483
             initialDelaySeconds: 90
@@ -105,6 +108,7 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe
           value:
             httpGet:
+              host: 127.0.0.1
               path: /healthz
               port: 24483
             initialDelaySeconds: 90


### PR DESCRIPTION
## What this PR does / why we need it:
The agent was recently updated to only bind the health endpoint to localhost. Hence, the charts need to be updated accordingly.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
