### PR TITLE
fix(agent,sysdig-deploy): /var/data volume mount

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.18.2
+version: 1.18.3

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -282,6 +282,8 @@ spec:
               readOnly: true
             - mountPath: /host/var/lib
               name: varlib-vol
+            - mountPath: /host/var/data
+              name: vardata-vol
             - mountPath: /host/var/run
               name: varrun-vol
             {{- if (include "agent.ebpfEnabled" .) }}
@@ -300,6 +302,8 @@ spec:
               readOnly: true
             - mountPath: /host/var/lib
               name: varlib-vol
+            - mountPath: /host/var/data
+              name: vardata-vol
             - mountPath: /host/var/run
               name: varrun-vol
             {{- if (include "agent.ebpfEnabled" .) }}
@@ -425,6 +429,9 @@ spec:
         - name: varlib-vol
           hostPath:
             path: /var/lib
+        - name: vardata-vol
+          hostPath:
+            path: /var/data
         - name: varrun-vol
           hostPath:
             path: /var/run
@@ -460,6 +467,9 @@ spec:
         - name: varlib-vol
           hostPath:
             path: /var/lib
+        - name: vardata-vol
+          hostPath:
+            path: /var/data
         {{- if (include "agent.ebpfEnabled" .) }}
         - name: bpf-probes
           emptyDir: {}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -160,6 +160,8 @@ spec:
               readOnly: true
             - mountPath: /host/var/lib
               name: varlib-vol
+            - mountPath: /host/var/data
+              name: vardata-vol
             - mountPath: /host/run
               name: run-vol
             - mountPath: /host/var/run
@@ -180,6 +182,8 @@ spec:
               readOnly: true
             - mountPath: /host/var/lib
               name: varlib-vol
+            - mountPath: /host/var/data
+              name: vardata-vol
             - mountPath: /host/run
               name: run-vol
             - mountPath: /host/var/run
@@ -308,6 +312,9 @@ spec:
         - name: varlib-vol
           hostPath:
             path: /var/lib
+        - name: vardata-vol
+          hostPath:
+            path: /var/data
         - name: run-vol
           hostPath:
             path: /run
@@ -331,6 +338,9 @@ spec:
         - name: varlib-vol
           hostPath:
             path: /var/lib
+        - name: vardata-vol
+          hostPath:
+            path: /var/data
         - name: run-vol
           hostPath:
             path: /run

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -14,6 +14,23 @@ tests:
     templates:
       - daemonset.yaml
 
+  - it: Ensure /var/data host volume is mounted as /host/var/data in container
+    set:
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+      delegatedAgentDeployment:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "vardata-vol")].mountPath
+          value: /host/var/data
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "vardata-vol")].hostPath.path
+          value: /var/data
+    templates:
+      - daemonset.yaml
+      - deployment.yaml
+
   - it: Ensure /var/lib host volume is mounted as /host/var/lib in container
     asserts:
       - equal:

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.18.2
+    version: ~1.18.3
     alias: agent
     condition: agent.enabled
   - name: common

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.34.1
+version: 1.34.2
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com


### PR DESCRIPTION
## What this PR does / why we need it:

On IBM Environments runtime is using the path `/var/data` to create container filesystems.
To be able to use the drift detection feature, we have to mount `/var/data` to `/host/var/data` in agent container (same as `/var/lib`).

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
