### PR TITLE
feat(nodeAnalyzer): fix deamonset not being rollout after values changes

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.20.2
+version: 1.20.3
 appVersion: 12.9.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -34,11 +34,13 @@ spec:
         checksum/config-image-analyzer: {{ include (print $.Template.BasePath "/configmap-image-analyzer.yaml") . | sha256sum | quote  }}
         checksum/config-kspm-analyzer: {{ include (print $.Template.BasePath "/configmap-kspm-analyzer.yaml") . | sha256sum | quote  }}
         checksum/config-host-scanner: {{ include (print $.Template.BasePath "/configmap-host-scanner.yaml") . | sha256sum | quote  }}
-        checksum/config-runtime-scanner: {{ include (print $.Template.BasePath "/runtimeScanner/runtime-scanner-configmap.yaml") . | sha256sum | quote  }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum | quote  }}
         checksum/clusterrole: {{ include (print $.Template.BasePath "/clusterrole-node-analyzer.yaml") . | sha256sum | quote  }}
         checksum/clusterrolebinding: {{ include (print $.Template.BasePath "/clusterrolebinding-node-analyzer.yaml") . | sha256sum | quote  }}
         checksum/serviceaccount: {{ include (print $.Template.BasePath "/serviceaccount-node-analyzer.yaml") . | sha256sum | quote  }}
+      {{- if include "nodeAnalyzer.deployRuntimeScanner" . }}
+        checksum/config-runtime-scanner: {{ include (print $.Template.BasePath "/runtimeScanner/runtime-scanner-configmap.yaml") . | sha256sum | quote  }}
+      {{- end }}
 {{- if .Values.daemonset.annotations }}
         {{ toYaml .Values.daemonset.annotations | nindent 8 }}
 {{- end }}

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -32,15 +32,19 @@ spec:
         checksum/config-benchmark: {{ include (print $.Template.BasePath "/configmap-benchmark-runner.yaml") . | sha256sum | quote  }}
         checksum/config-host-analyzer: {{ include (print $.Template.BasePath "/configmap-host-analyzer.yaml") . | sha256sum | quote  }}
         checksum/config-image-analyzer: {{ include (print $.Template.BasePath "/configmap-image-analyzer.yaml") . | sha256sum | quote  }}
-        checksum/config-kspm-analyzer: {{ include (print $.Template.BasePath "/configmap-kspm-analyzer.yaml") . | sha256sum | quote  }}
+        {{- if and .Values.nodeAnalyzer.deploy (not .Values.gke.autopilot) (include "nodeAnalyzer.deployHostScanner" .) }}
         checksum/config-host-scanner: {{ include (print $.Template.BasePath "/configmap-host-scanner.yaml") . | sha256sum | quote  }}
+        {{- end }}
+        {{- if .Values.global.kspm.deploy }}
+        checksum/config-kspm-analyzer: {{ include (print $.Template.BasePath "/configmap-kspm-analyzer.yaml") . | sha256sum | quote  }}
+        {{- end }}
+        {{- if include "nodeAnalyzer.deployRuntimeScanner" . }}
+        checksum/config-runtime-scanner: {{ include (print $.Template.BasePath "/runtimeScanner/runtime-scanner-configmap.yaml") . | sha256sum | quote  }}
+        {{- end }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum | quote  }}
         checksum/clusterrole: {{ include (print $.Template.BasePath "/clusterrole-node-analyzer.yaml") . | sha256sum | quote  }}
         checksum/clusterrolebinding: {{ include (print $.Template.BasePath "/clusterrolebinding-node-analyzer.yaml") . | sha256sum | quote  }}
         checksum/serviceaccount: {{ include (print $.Template.BasePath "/serviceaccount-node-analyzer.yaml") . | sha256sum | quote  }}
-      {{- if include "nodeAnalyzer.deployRuntimeScanner" . }}
-        checksum/config-runtime-scanner: {{ include (print $.Template.BasePath "/runtimeScanner/runtime-scanner-configmap.yaml") . | sha256sum | quote  }}
-      {{- end }}
 {{- if .Values.daemonset.annotations }}
         {{ toYaml .Values.daemonset.annotations | nindent 8 }}
 {{- end }}

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -28,8 +28,18 @@ spec:
         app.kubernetes.io/name: {{ include "nodeAnalyzer.name" . }}
 {{ include "daemonset.labels" . | indent 8 }}
 {{ include "nodeAnalyzer.labels" . | indent 8 }}
-{{- if .Values.daemonset.annotations }}
       annotations:
+        checksum/config-benchmark: {{ include (print $.Template.BasePath "/configmap-benchmark-runner.yaml") . | sha256sum | quote  }}
+        checksum/config-host-analyzer: {{ include (print $.Template.BasePath "/configmap-host-analyzer.yaml") . | sha256sum | quote  }}
+        checksum/config-image-analyzer: {{ include (print $.Template.BasePath "/configmap-image-analyzer.yaml") . | sha256sum | quote  }}
+        checksum/config-kspm-analyzer: {{ include (print $.Template.BasePath "/configmap-kspm-analyzer.yaml") . | sha256sum | quote  }}
+        checksum/config-host-scanner: {{ include (print $.Template.BasePath "/configmap-host-scanner.yaml") . | sha256sum | quote  }}
+        checksum/config-runtime-scanner: {{ include (print $.Template.BasePath "/runtimeScanner/runtime-scanner-configmap.yaml") . | sha256sum | quote  }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum | quote  }}
+        checksum/clusterrole: {{ include (print $.Template.BasePath "/clusterrole-node-analyzer.yaml") . | sha256sum | quote  }}
+        checksum/clusterrolebinding: {{ include (print $.Template.BasePath "/clusterrolebinding-node-analyzer.yaml") . | sha256sum | quote  }}
+        checksum/serviceaccount: {{ include (print $.Template.BasePath "/serviceaccount-node-analyzer.yaml") . | sha256sum | quote  }}
+{{- if .Values.daemonset.annotations }}
         {{ toYaml .Values.daemonset.annotations | nindent 8 }}
 {{- end }}
     spec:

--- a/charts/node-analyzer/tests/agent_tags_test.yaml
+++ b/charts/node-analyzer/tests/agent_tags_test.yaml
@@ -11,9 +11,8 @@ templates:
   - configmap-kspm-analyzer.yaml
   - secrets.yaml
   - serviceaccount-node-analyzer.yaml
-  - runtimeScanner/runtime-scanner-configmap.yaml
 values:
-  - ./default_values.yaml
+  - ./default_required_values.yaml
 
 tests:
   - it: Check agent tags are set from global.settings.tags
@@ -24,6 +23,7 @@ tests:
             tag: value
         kspm:
           deploy: true
+      clusterName: "test"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -37,6 +37,7 @@ tests:
       global:
         kspm:
           deploy: true
+      clusterName: "test"
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].env

--- a/charts/node-analyzer/tests/agent_tags_test.yaml
+++ b/charts/node-analyzer/tests/agent_tags_test.yaml
@@ -1,6 +1,20 @@
 suite: Test node-analyzer Agent Tags
 templates:
   - daemonset-node-analyzer.yaml
+  # For checksums
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - configmap-kspm-analyzer.yaml
+  - secrets.yaml
+  - serviceaccount-node-analyzer.yaml
+  - runtimeScanner/runtime-scanner-configmap.yaml
+values:
+  - ./default_values.yaml
+
 tests:
   - it: Check agent tags are set from global.settings.tags
     set:

--- a/charts/node-analyzer/tests/annotations_test.yaml
+++ b/charts/node-analyzer/tests/annotations_test.yaml
@@ -63,7 +63,7 @@ tests:
         clusterConfig:
           name: "test"
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/node-analyzer/tests/annotations_test.yaml
+++ b/charts/node-analyzer/tests/annotations_test.yaml
@@ -48,9 +48,9 @@ tests:
       # NOTE: not enabled with default config
       - notExists:
           path: spec.template.metadata.annotations['checksum/config-host-scanner']
-      - notExists: 
+      - notExists:
           path: spec.template.metadata.annotations['checksum/config-runtime-scanner']
-      - notExists: 
+      - notExists:
           path: spec.template.metadata.annotations['checksum/config-kspm-analyzer']
   - it: Test checksum annotations for new scanning engine
     templates:
@@ -71,5 +71,5 @@ tests:
           path: spec.template.metadata.annotations['checksum/clusterrole']
       - isNotEmpty:
           path: spec.template.metadata.annotations['checksum/config-host-scanner']
-      - isNotEmpty: 
+      - isNotEmpty:
           path: spec.template.metadata.annotations['checksum/config-runtime-scanner']

--- a/charts/node-analyzer/tests/annotations_test.yaml
+++ b/charts/node-analyzer/tests/annotations_test.yaml
@@ -1,13 +1,24 @@
 suite: Test specifying annotations to the Node Analyzer DaemonSet
 templates:
   - templates/daemonset-node-analyzer.yaml
-tests:
-  - it: Test no annotations by default
-    asserts:
-      - isNull:
-          path: template.metadata.annotations
+  # For checksums
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - configmap-kspm-analyzer.yaml
+  - secrets.yaml
+  - serviceaccount-node-analyzer.yaml
+  - runtimeScanner/runtime-scanner-configmap.yaml
+values:
+  - ./default_values.yaml
 
+tests:
   - it: Test annotations are added as expected
+    templates:
+      - templates/daemonset-node-analyzer.yaml
     set:
       daemonset:
         annotations:
@@ -16,3 +27,28 @@ tests:
       - equal:
           path: spec.template.metadata.annotations['super']
           value: annotation
+  - it: Test checksums annotations
+    templates:
+      - templates/daemonset-node-analyzer.yaml
+    asserts:
+      - isNotEmpty:
+          path: spec.template.metadata.annotations['checksum/config-benchmark']
+      - isNotEmpty:
+          path: spec.template.metadata.annotations['checksum/config-host-analyzer']
+      - isNotEmpty:
+          path: spec.template.metadata.annotations['checksum/config-image-analyzer']
+      - isNotEmpty:
+          path: spec.template.metadata.annotations['checksum/config-kspm-analyzer']
+      - isNotEmpty:
+          path: spec.template.metadata.annotations['checksum/config-host-scanner']
+      - notExists: # NOTE: not enabled with default config
+          path: spec.template.metadata.annotations['checksum/config-runtime-scanner']
+      - isNotEmpty:
+          path: spec.template.metadata.annotations['checksum/secret']
+      - isNotEmpty:
+          path: spec.template.metadata.annotations['checksum/clusterrole']
+      - isNotEmpty:
+          path: spec.template.metadata.annotations['checksum/clusterrolebinding']
+      - isNotEmpty:
+          path: spec.template.metadata.annotations['checksum/serviceaccount']
+

--- a/charts/node-analyzer/tests/annotations_test.yaml
+++ b/charts/node-analyzer/tests/annotations_test.yaml
@@ -1,6 +1,6 @@
 suite: Test specifying annotations to the Node Analyzer DaemonSet
 templates:
-  - templates/daemonset-node-analyzer.yaml
+  - daemonset-node-analyzer.yaml
   # For checksums
   - clusterrole-node-analyzer.yaml
   - clusterrolebinding-node-analyzer.yaml
@@ -13,12 +13,12 @@ templates:
   - serviceaccount-node-analyzer.yaml
   - runtimeScanner/runtime-scanner-configmap.yaml
 values:
-  - ./default_values.yaml
+  - ./default_required_values.yaml
 
 tests:
-  - it: Test annotations are added as expected
+  - it: Test additional annotations are added as expected
     templates:
-      - templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     set:
       daemonset:
         annotations:
@@ -27,9 +27,9 @@ tests:
       - equal:
           path: spec.template.metadata.annotations['super']
           value: annotation
-  - it: Test checksums annotations
+  - it: Test checksum annotations
     templates:
-      - templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     asserts:
       - isNotEmpty:
           path: spec.template.metadata.annotations['checksum/config-benchmark']
@@ -38,12 +38,6 @@ tests:
       - isNotEmpty:
           path: spec.template.metadata.annotations['checksum/config-image-analyzer']
       - isNotEmpty:
-          path: spec.template.metadata.annotations['checksum/config-kspm-analyzer']
-      - isNotEmpty:
-          path: spec.template.metadata.annotations['checksum/config-host-scanner']
-      - notExists: # NOTE: not enabled with default config
-          path: spec.template.metadata.annotations['checksum/config-runtime-scanner']
-      - isNotEmpty:
           path: spec.template.metadata.annotations['checksum/secret']
       - isNotEmpty:
           path: spec.template.metadata.annotations['checksum/clusterrole']
@@ -51,4 +45,31 @@ tests:
           path: spec.template.metadata.annotations['checksum/clusterrolebinding']
       - isNotEmpty:
           path: spec.template.metadata.annotations['checksum/serviceaccount']
-
+      # NOTE: not enabled with default config
+      - notExists:
+          path: spec.template.metadata.annotations['checksum/config-host-scanner']
+      - notExists: 
+          path: spec.template.metadata.annotations['checksum/config-runtime-scanner']
+      - notExists: 
+          path: spec.template.metadata.annotations['checksum/config-kspm-analyzer']
+  - it: Test checksum annotations for new scanning engine
+    templates:
+      - daemonset-node-analyzer.yaml
+    set:
+      secure:
+        vulnerabilityManagement:
+          newEngineOnly: true
+      global:
+        clusterConfig:
+          name: "test"
+        sysdig:
+          accessKey: "XXX"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotEmpty:
+          path: spec.template.metadata.annotations['checksum/clusterrole']
+      - isNotEmpty:
+          path: spec.template.metadata.annotations['checksum/config-host-scanner']
+      - isNotEmpty: 
+          path: spec.template.metadata.annotations['checksum/config-runtime-scanner']

--- a/charts/node-analyzer/tests/ca_cert_test.yaml
+++ b/charts/node-analyzer/tests/ca_cert_test.yaml
@@ -5,6 +5,19 @@ templates:
   - runtimeScanner/eveconnector-api-deployment.yaml
   - runtimeScanner/sysdig-eve-secret.yaml
   - runtimeScanner/eveconnector-api-configmap.yaml
+  # For checksums
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - templates/configmap-benchmark-runner.yaml
+  - templates/configmap-host-analyzer.yaml
+  - templates/configmap-host-scanner.yaml
+  - templates/configmap-image-analyzer.yaml
+  - templates/configmap-kspm-analyzer.yaml
+  - templates/serviceaccount-node-analyzer.yaml
+  - templates/runtimeScanner/runtime-scanner-configmap.yaml
+values:
+  - ./default_values.yaml
+
 tests:
   - it: Checking node-analyzer CA Cert Secret
     set:

--- a/charts/node-analyzer/tests/ca_cert_test.yaml
+++ b/charts/node-analyzer/tests/ca_cert_test.yaml
@@ -8,15 +8,15 @@ templates:
   # For checksums
   - clusterrole-node-analyzer.yaml
   - clusterrolebinding-node-analyzer.yaml
-  - templates/configmap-benchmark-runner.yaml
-  - templates/configmap-host-analyzer.yaml
-  - templates/configmap-host-scanner.yaml
-  - templates/configmap-image-analyzer.yaml
-  - templates/configmap-kspm-analyzer.yaml
-  - templates/serviceaccount-node-analyzer.yaml
-  - templates/runtimeScanner/runtime-scanner-configmap.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - configmap-kspm-analyzer.yaml
+  - serviceaccount-node-analyzer.yaml
+  - runtimeScanner/runtime-scanner-configmap.yaml
 values:
-  - ./default_values.yaml
+  - ./default_required_values.yaml
 
 tests:
   - it: Checking node-analyzer CA Cert Secret
@@ -26,6 +26,9 @@ tests:
       secure:
         vulnerabilityManagement:
           newEngineOnly: true
+      global:
+        clusterConfig:
+          name: "test"
       sysdig:
         accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
       nodeAnalyzer:
@@ -53,6 +56,9 @@ tests:
       secure:
         vulnerabilityManagement:
           newEngineOnly: true
+      global:
+        clusterConfig:
+          name: "test"
       sysdig:
         accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
       nodeAnalyzer:
@@ -121,6 +127,8 @@ tests:
         vulnerabilityManagement:
           newEngineOnly: true
       global:
+        clusterConfig:
+          name: "test"
         kspm:
           deploy: false
         ssl:

--- a/charts/node-analyzer/tests/conditional_flag_test.yaml
+++ b/charts/node-analyzer/tests/conditional_flag_test.yaml
@@ -22,7 +22,7 @@ tests:
     set:
       global:
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
         kspm:
           deploy: true
       clusterName: test-cluster
@@ -37,7 +37,7 @@ tests:
     set:
       global:
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
         kspm:
           deploy: true
       clusterName: test-cluster
@@ -51,7 +51,7 @@ tests:
     set:
       global:
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
       nodeAnalyzer:
         benchmarkRunner:
           deploy: true
@@ -70,7 +70,7 @@ tests:
         kspm:
           deploy: true
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
     asserts:
       - failedTemplate:
           errorMessage: "A valid clusterName is required"
@@ -79,7 +79,7 @@ tests:
     set:
       global:
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
       nodeAnalyzer:
         imageAnalyzer:
           deploy: true
@@ -96,7 +96,7 @@ tests:
     set:
       global:
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
       nodeAnalyzer:
         hostAnalyzer:
           deploy: true
@@ -113,7 +113,7 @@ tests:
     set:
       global:
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
       nodeAnalyzer:
         benchmarkRunner:
           deploy: true
@@ -132,7 +132,7 @@ tests:
         clusterConfig:
           name: "test"
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
       nodeAnalyzer:
         runtimeScanner:
           deploy: true
@@ -149,7 +149,7 @@ tests:
     set:
       global:
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
       nodeAnalyzer:
         runtimeScanner:
           deploy: true
@@ -181,7 +181,7 @@ tests:
     set:
       global:
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
       nodeAnalyzer:
         imageAnalyzer:
           deploy: false
@@ -198,7 +198,7 @@ tests:
     set:
       global:
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
       nodeAnalyzer:
         hostAnalyzer:
           deploy: false
@@ -215,7 +215,7 @@ tests:
     set:
       global:
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
       nodeAnalyzer:
         benchmarkRunner:
           deploy: false
@@ -232,7 +232,7 @@ tests:
     set:
       global:
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
       nodeAnalyzer:
         runtimeScanner:
           deploy: false
@@ -249,7 +249,7 @@ tests:
     set:
       global:
         sysdig:
-          accessKey: "XXX"
+          accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
       nodeAnalyzer:
         runtimeScanner:
           deploy: true

--- a/charts/node-analyzer/tests/conditional_flag_test.yaml
+++ b/charts/node-analyzer/tests/conditional_flag_test.yaml
@@ -6,10 +6,22 @@ templates:
   - runtimeScanner/eveconnector-api-service.yaml
   - runtimeScanner/eveconnector-api-deployment.yaml
   - runtimeScanner/sysdig-eve-secret.yaml
+    # For checksums
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - secrets.yaml
+  - serviceaccount-node-analyzer.yaml
+
 tests:
   - it: Check global kspm deploy
     set:
       global:
+        sysdig:
+          accessKey: "XXX"
         kspm:
           deploy: true
       clusterName: test-cluster
@@ -23,6 +35,8 @@ tests:
   - it: Check hostPID is true if global.kspm.deploy is true
     set:
       global:
+        sysdig:
+          accessKey: "XXX"
         kspm:
           deploy: true
       clusterName: test-cluster
@@ -34,6 +48,9 @@ tests:
 
   - it: Check hostPID is true if nodeAnalyzer.benchmarkRunner.deploy is true
     set:
+      global:
+        sysdig:
+          accessKey: "XXX"
       nodeAnalyzer:
         benchmarkRunner:
           deploy: true
@@ -49,13 +66,19 @@ tests:
       global:
         kspm:
           deploy: true
-    template: configmap-kspm-analyzer.yaml
+        sysdig:
+          accessKey: "XXX"
+    templates: 
+      - configmap-kspm-analyzer.yaml
     asserts:
       - failedTemplate:
           errorMessage: "A valid clusterName is required"
 
   - it: Check nodeAnalyzer imageAnalyzer deploy
     set:
+      global:
+        sysdig:
+          accessKey: "XXX"
       nodeAnalyzer:
         imageAnalyzer:
           deploy: true
@@ -70,6 +93,9 @@ tests:
 
   - it: Check nodeAnalyzer hostAnalyzer deploy
     set:
+      global:
+        sysdig:
+          accessKey: "XXX"
       nodeAnalyzer:
         hostAnalyzer:
           deploy: true
@@ -84,6 +110,9 @@ tests:
 
   - it: Check nodeAnalyzer benchmarkRunner deploy
     set:
+      global:
+        sysdig:
+          accessKey: "XXX"
       nodeAnalyzer:
         benchmarkRunner:
           deploy: true
@@ -98,6 +127,9 @@ tests:
 
   - it: Check nodeAnalyzer runtimeScanner deploy
     set:
+      global:
+        sysdig:
+          accessKey: "XXX"
       nodeAnalyzer:
         runtimeScanner:
           deploy: true
@@ -112,6 +144,9 @@ tests:
 
   - it: Check nodeAnalyzer runtimeScanner eveConnector deploy
     set:
+      global:
+        sysdig:
+          accessKey: "XXX"
       nodeAnalyzer:
         runtimeScanner:
           deploy: true
@@ -141,6 +176,9 @@ tests:
 
   - it: Check nodeAnalyzer imageAnalyzer deploy set to false
     set:
+      global:
+        sysdig:
+          accessKey: "XXX"
       nodeAnalyzer:
         imageAnalyzer:
           deploy: false
@@ -155,6 +193,9 @@ tests:
 
   - it: Check nodeAnalyzer hostAnalyzer deploy set to false
     set:
+      global:
+        sysdig:
+          accessKey: "XXX"
       nodeAnalyzer:
         hostAnalyzer:
           deploy: false
@@ -169,6 +210,9 @@ tests:
 
   - it: Check nodeAnalyzer benchmarkRunner deploy set to false
     set:
+      global:
+        sysdig:
+          accessKey: "XXX"
       nodeAnalyzer:
         benchmarkRunner:
           deploy: false
@@ -183,6 +227,9 @@ tests:
 
   - it: Check nodeAnalyzer runtimeScanner deploy set to false
     set:
+      global:
+        sysdig:
+          accessKey: "XXX"
       nodeAnalyzer:
         runtimeScanner:
           deploy: false
@@ -197,6 +244,9 @@ tests:
 
   - it: Check nodeAnalyzer runtimeScanner EVE_INTEGRATION_ENABLED is true even if eveConnector deploy set to false
     set:
+      global:
+        sysdig:
+          accessKey: "XXX"
       nodeAnalyzer:
         runtimeScanner:
           deploy: true

--- a/charts/node-analyzer/tests/conditional_flag_test.yaml
+++ b/charts/node-analyzer/tests/conditional_flag_test.yaml
@@ -15,6 +15,7 @@ templates:
   - configmap-image-analyzer.yaml
   - secrets.yaml
   - serviceaccount-node-analyzer.yaml
+  - runtimeScanner/runtime-scanner-configmap.yaml
 
 tests:
   - it: Check global kspm deploy
@@ -62,14 +63,14 @@ tests:
           value: true
 
   - it: Check global kspm deploy without clusterName
+    templates: 
+      - daemonset-node-analyzer.yaml
     set:
       global:
         kspm:
           deploy: true
         sysdig:
           accessKey: "XXX"
-    templates: 
-      - configmap-kspm-analyzer.yaml
     asserts:
       - failedTemplate:
           errorMessage: "A valid clusterName is required"
@@ -128,6 +129,8 @@ tests:
   - it: Check nodeAnalyzer runtimeScanner deploy
     set:
       global:
+        clusterConfig:
+          name: "test"
         sysdig:
           accessKey: "XXX"
       nodeAnalyzer:

--- a/charts/node-analyzer/tests/conditional_flag_test.yaml
+++ b/charts/node-analyzer/tests/conditional_flag_test.yaml
@@ -63,7 +63,7 @@ tests:
           value: true
 
   - it: Check global kspm deploy without clusterName
-    templates: 
+    templates:
       - daemonset-node-analyzer.yaml
     set:
       global:

--- a/charts/node-analyzer/tests/daemonset_affinity_test.yaml
+++ b/charts/node-analyzer/tests/daemonset_affinity_test.yaml
@@ -13,7 +13,7 @@ templates:
   - serviceaccount-node-analyzer.yaml
   - runtimeScanner/runtime-scanner-configmap.yaml
 values:
-  - ./default_values.yaml
+  - ./default_required_values.yaml
 tests:
   - it: Test the default affinity annotations (<1.14)
     capabilities:

--- a/charts/node-analyzer/tests/daemonset_affinity_test.yaml
+++ b/charts/node-analyzer/tests/daemonset_affinity_test.yaml
@@ -1,11 +1,26 @@
 suite: Test specifying affinity settings on the Node Analyzer DaemonSet
 templates:
-  - templates/daemonset-node-analyzer.yaml
+  - daemonset-node-analyzer.yaml
+  # For checksums
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - configmap-kspm-analyzer.yaml
+  - secrets.yaml
+  - serviceaccount-node-analyzer.yaml
+  - runtimeScanner/runtime-scanner-configmap.yaml
+values:
+  - ./default_values.yaml
 tests:
   - it: Test the default affinity annotations (<1.14)
     capabilities:
       majorVersion: '1'
       minorVersion: '13'
+    templates: 
+      - daemonset-node-analyzer.yaml
     asserts:
       - equal:
           path: spec.template.spec['affinity']
@@ -28,6 +43,8 @@ tests:
     capabilities:
       majorVersion: '1'
       minorVersion: '14'
+    templates: 
+      - daemonset-node-analyzer.yaml
     asserts:
       - equal:
           path: spec.template.spec['affinity']
@@ -47,6 +64,8 @@ tests:
                         - linux
 
   - it: Test adding custom affinity settings
+    templates: 
+      - daemonset-node-analyzer.yaml
     set:
       nodeAnalyzer:
         affinity:

--- a/charts/node-analyzer/tests/daemonset_affinity_test.yaml
+++ b/charts/node-analyzer/tests/daemonset_affinity_test.yaml
@@ -19,7 +19,7 @@ tests:
     capabilities:
       majorVersion: '1'
       minorVersion: '13'
-    templates: 
+    templates:
       - daemonset-node-analyzer.yaml
     asserts:
       - equal:
@@ -43,7 +43,7 @@ tests:
     capabilities:
       majorVersion: '1'
       minorVersion: '14'
-    templates: 
+    templates:
       - daemonset-node-analyzer.yaml
     asserts:
       - equal:
@@ -64,7 +64,7 @@ tests:
                         - linux
 
   - it: Test adding custom affinity settings
-    templates: 
+    templates:
       - daemonset-node-analyzer.yaml
     set:
       nodeAnalyzer:

--- a/charts/node-analyzer/tests/daemonset_update_strategy_test.yaml
+++ b/charts/node-analyzer/tests/daemonset_update_strategy_test.yaml
@@ -12,7 +12,7 @@ templates:
   - secrets.yaml
   - serviceaccount-node-analyzer.yaml
 values:
-  - ./default_values.yaml
+  - ./default_required_values.yaml
 tests:
   - it: set default updateStrategy
     asserts:

--- a/charts/node-analyzer/tests/daemonset_update_strategy_test.yaml
+++ b/charts/node-analyzer/tests/daemonset_update_strategy_test.yaml
@@ -1,6 +1,18 @@
 suite: Test Daemonset Update Strategy
 templates:
   - templates/daemonset-node-analyzer.yaml
+  # For checksums
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - configmap-kspm-analyzer.yaml
+  - secrets.yaml
+  - serviceaccount-node-analyzer.yaml
+values:
+  - ./default_values.yaml
 tests:
   - it: set default updateStrategy
     asserts:
@@ -48,3 +60,5 @@ tests:
               maxSurge: 1
               maxUnavailable: 2
             type: RollingUpdate
+    templates:
+      - templates/daemonset-node-analyzer.yaml

--- a/charts/node-analyzer/tests/default_required_values.yaml
+++ b/charts/node-analyzer/tests/default_required_values.yaml
@@ -1,5 +1,3 @@
 global:
-  clusterConfig:
-    name: "test"
   sysdig:
     accessKey: "xxx"

--- a/charts/node-analyzer/tests/default_required_values.yaml
+++ b/charts/node-analyzer/tests/default_required_values.yaml
@@ -1,3 +1,3 @@
 global:
   sysdig:
-    accessKey: "xxx"
+    accessKey: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"

--- a/charts/node-analyzer/tests/default_values.yaml
+++ b/charts/node-analyzer/tests/default_values.yaml
@@ -1,0 +1,5 @@
+global:
+  clusterConfig:
+    name: "test"
+  sysdig:
+    accessKey: "xxx"

--- a/charts/node-analyzer/tests/global_overrides_test.yaml
+++ b/charts/node-analyzer/tests/global_overrides_test.yaml
@@ -5,6 +5,19 @@ templates:
   - runtimeScanner/eveconnector-api-deployment.yaml
   - runtimeScanner/eveconnector-api-configmap.yaml
   - runtimeScanner/sysdig-eve-secret.yaml
+  # For checksums
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - configmap-kspm-analyzer.yaml
+  - serviceaccount-node-analyzer.yaml
+  - runtimeScanner/runtime-scanner-configmap.yaml
+values:
+  - ./default_values.yaml
+
 tests:
   - it: check value of accessKey without local chart override - local value provided
     set:

--- a/charts/node-analyzer/tests/global_overrides_test.yaml
+++ b/charts/node-analyzer/tests/global_overrides_test.yaml
@@ -136,8 +136,6 @@ tests:
         template: daemonset-node-analyzer.yaml
 
   - it: check imagePullPolicy for eveconnector-api-deployment with global
-    values:
-      - ./default_required_values.yaml
     set:
       global:
         kspm:
@@ -163,8 +161,6 @@ tests:
       - runtimeScanner/eveconnector-api-deployment.yaml
 
   - it: check imagePullPolicy for daemonset-node-analyzer with global
-    values:
-      - ./default_required_values.yaml
     set:
       global:
         kspm:
@@ -211,8 +207,6 @@ tests:
       - daemonset-node-analyzer.yaml
 
   - it: check imagePullPolicy for eveconnector-api-deployment with legacy
-    values:
-      - ./default_required_values.yaml
     set:
       global:
         kspm:
@@ -238,8 +232,6 @@ tests:
       - runtimeScanner/eveconnector-api-deployment.yaml
 
   - it: check imagePullPolicy for eveconnector-api-deployment with local override
-    values:
-      - ./default_required_values.yaml
     set:
       global:
         kspm:

--- a/charts/node-analyzer/tests/global_overrides_test.yaml
+++ b/charts/node-analyzer/tests/global_overrides_test.yaml
@@ -16,7 +16,7 @@ templates:
   - serviceaccount-node-analyzer.yaml
   - runtimeScanner/runtime-scanner-configmap.yaml
 values:
-  - ./default_values.yaml
+  - ./default_required_values.yaml
 
 tests:
   - it: check value of accessKey without local chart override - local value provided
@@ -136,6 +136,8 @@ tests:
         template: daemonset-node-analyzer.yaml
 
   - it: check imagePullPolicy for eveconnector-api-deployment with global
+    values:
+      - ./default_required_values.yaml
     set:
       global:
         kspm:
@@ -161,6 +163,8 @@ tests:
       - runtimeScanner/eveconnector-api-deployment.yaml
 
   - it: check imagePullPolicy for daemonset-node-analyzer with global
+    values:
+      - ./default_required_values.yaml
     set:
       global:
         kspm:
@@ -207,6 +211,8 @@ tests:
       - daemonset-node-analyzer.yaml
 
   - it: check imagePullPolicy for eveconnector-api-deployment with legacy
+    values:
+      - ./default_required_values.yaml
     set:
       global:
         kspm:
@@ -232,6 +238,8 @@ tests:
       - runtimeScanner/eveconnector-api-deployment.yaml
 
   - it: check imagePullPolicy for eveconnector-api-deployment with local override
+    values:
+      - ./default_required_values.yaml
     set:
       global:
         kspm:

--- a/charts/node-analyzer/tests/golden_template_test.yaml
+++ b/charts/node-analyzer/tests/golden_template_test.yaml
@@ -12,9 +12,8 @@ templates:
   - configmap-kspm-analyzer.yaml
   - secrets.yaml
   - serviceaccount-node-analyzer.yaml
-  - runtimeScanner/runtime-scanner-configmap.yaml
 values:
-  - ./default_values.yaml
+  - ./default_required_values.yaml
 
 tests:
   - it: Testing node-analyzer deployed

--- a/charts/node-analyzer/tests/golden_template_test.yaml
+++ b/charts/node-analyzer/tests/golden_template_test.yaml
@@ -2,6 +2,20 @@ suite: Testing pre-generated values and best-known edge cases
 templates:
   - daemonset-node-analyzer.yaml
   - configmap-benchmark-runner.yaml
+  # For checksums
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - configmap-kspm-analyzer.yaml
+  - secrets.yaml
+  - serviceaccount-node-analyzer.yaml
+  - runtimeScanner/runtime-scanner-configmap.yaml
+values:
+  - ./default_values.yaml
+
 tests:
   - it: Testing node-analyzer deployed
     set:

--- a/charts/node-analyzer/tests/hostscanner_test.yaml
+++ b/charts/node-analyzer/tests/hostscanner_test.yaml
@@ -15,7 +15,7 @@ templates:
   - serviceaccount-node-analyzer.yaml
   - runtimeScanner/runtime-scanner-configmap.yaml
 values:
-  - ./default_values.yaml
+  - ./default_required_values.yaml
   - ../values.yaml
 
 tests:
@@ -84,6 +84,7 @@ tests:
     set:
       secure.vulnerabilityManagement.newEngineOnly: true
       nodeAnalyzer.hostScanner.deploy: false
+      global.clusterConfig.name: "test"
     templates:
       - daemonset-node-analyzer.yaml
     asserts:

--- a/charts/node-analyzer/tests/hostscanner_test.yaml
+++ b/charts/node-analyzer/tests/hostscanner_test.yaml
@@ -2,15 +2,26 @@
 # Run "helm unittest -3 -f ./tests/hostscanner_test.yaml ." from within the `charts/node-analyzer` folder
 suite: Test HostScanner configuration
 templates:
-  - ../templates/daemonset-node-analyzer.yaml
-  - ../templates/configmap-host-scanner.yaml
+  - daemonset-node-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - configmap-kspm-analyzer.yaml
+  - secrets.yaml
+  - serviceaccount-node-analyzer.yaml
+  - runtimeScanner/runtime-scanner-configmap.yaml
 values:
+  - ./default_values.yaml
   - ../values.yaml
 
 tests:
   - it: "HS not deployed by default"
     templates:
-      - ../templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     asserts:
       - isKind:
           of: DaemonSet
@@ -31,7 +42,7 @@ tests:
       clusterName: "test"
       secure.vulnerabilityManagement.newEngineOnly: true
     templates:
-      - ../templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     asserts:
       - isKind:
           of: DaemonSet
@@ -53,7 +64,7 @@ tests:
       secure.vulnerabilityManagement.newEngineOnly: true
       nodeAnalyzer.hostScanner.deploy: true
     templates:
-      - ../templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     asserts:
       - isKind:
           of: DaemonSet
@@ -74,7 +85,7 @@ tests:
       secure.vulnerabilityManagement.newEngineOnly: true
       nodeAnalyzer.hostScanner.deploy: false
     templates:
-      - ../templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     asserts:
       - isKind:
           of: DaemonSet
@@ -92,7 +103,7 @@ tests:
       clusterName: "test"
       nodeAnalyzer.hostScanner.deploy: true
     templates:
-      - ../templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     asserts:
       - isKind:
           of: DaemonSet
@@ -115,7 +126,7 @@ tests:
     set:
       nodeAnalyzer.hostScanner.deploy: false
     templates:
-      - ../templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     asserts:
       - isKind:
           of: DaemonSet
@@ -138,7 +149,7 @@ tests:
       nodeAnalyzer.hostScanner.additionalDirsToScan: "/hello,/world"
       nodeAnalyzer.hostScanner.deploy: true
     templates:
-      - ../templates/configmap-host-scanner.yaml
+      - configmap-host-scanner.yaml
     asserts:
       - isKind:
           of: ConfigMap
@@ -150,7 +161,7 @@ tests:
       clusterName: "test"
       nodeAnalyzer.hostScanner.deploy: true
     templates:
-      - ../templates/configmap-host-scanner.yaml
+      - configmap-host-scanner.yaml
     asserts:
       - isKind:
           of: ConfigMap

--- a/charts/node-analyzer/tests/label_test.yaml
+++ b/charts/node-analyzer/tests/label_test.yaml
@@ -11,9 +11,8 @@ templates:
   - configmap-kspm-analyzer.yaml
   - secrets.yaml
   - serviceaccount-node-analyzer.yaml
-  - runtimeScanner/runtime-scanner-configmap.yaml
 values:
-  - ./default_values.yaml
+  - ./default_required_values.yaml
 
 tests:
   - it: check application of node-analyzer labels example 1

--- a/charts/node-analyzer/tests/label_test.yaml
+++ b/charts/node-analyzer/tests/label_test.yaml
@@ -1,8 +1,24 @@
 suite: Testing if labels are applied correctly
 templates:
   - daemonset-node-analyzer.yaml
+  # For checksums
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - configmap-kspm-analyzer.yaml
+  - secrets.yaml
+  - serviceaccount-node-analyzer.yaml
+  - runtimeScanner/runtime-scanner-configmap.yaml
+values:
+  - ./default_values.yaml
+
 tests:
   - it: check application of node-analyzer labels example 1
+    templates:
+      - daemonset-node-analyzer.yaml
     set:
       sysdig:
         accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
@@ -16,6 +32,8 @@ tests:
         path: metadata.labels['my.label/key2']
         value: testlabel2
   - it: check application of node-analyzer example 2
+    templates:
+      - daemonset-node-analyzer.yaml
     set:
       sysdig:
         accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
@@ -31,6 +49,8 @@ tests:
         path: metadata.labels['my.label/key2']
         value: testlabel2
   - it: check application of node-analyzer labels example 3
+    templates:
+      - daemonset-node-analyzer.yaml
     set:
       sysdig:
         accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
@@ -46,6 +66,8 @@ tests:
         path: metadata.labels['my.label/version']
         value: 2.7.3
   - it: check application of correct node-analyzer labels with value of label empty
+    templates:
+      - daemonset-node-analyzer.yaml
     set:
       sysdig:
         accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
@@ -56,6 +78,8 @@ tests:
         path: metadata.labels['my.label/key1']
         value:
   - it: check application of incorrect node-analyzer labels with yaml
+    templates:
+      - daemonset-node-analyzer.yaml
     set:
       sysdig:
         accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
@@ -65,6 +89,8 @@ tests:
     - failedTemplate:
         errorMessage: "daemonset.label does not seem to be of the type key:[space]value"
   - it: check application of incorrect node-analyzer labels with yaml key is empty
+    templates:
+      - daemonset-node-analyzer.yaml
     set:
       sysdig:
         accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE

--- a/charts/node-analyzer/tests/priorityclass_test.yaml
+++ b/charts/node-analyzer/tests/priorityclass_test.yaml
@@ -2,6 +2,19 @@ suite: Node Analyzer PriorityClass tests
 templates:
   - templates/daemonset-node-analyzer.yaml
   - templates/priorityclass.yaml
+  # For checksums
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - configmap-kspm-analyzer.yaml
+  - secrets.yaml
+  - serviceaccount-node-analyzer.yaml
+  - runtimeScanner/runtime-scanner-configmap.yaml
+values:
+  - ./default_values.yaml
 tests:
   - it: Check PriorityClass limits are correctly set
     set:

--- a/charts/node-analyzer/tests/priorityclass_test.yaml
+++ b/charts/node-analyzer/tests/priorityclass_test.yaml
@@ -12,9 +12,8 @@ templates:
   - configmap-kspm-analyzer.yaml
   - secrets.yaml
   - serviceaccount-node-analyzer.yaml
-  - runtimeScanner/runtime-scanner-configmap.yaml
 values:
-  - ./default_values.yaml
+  - ./default_required_values.yaml
 tests:
   - it: Check PriorityClass limits are correctly set
     set:

--- a/charts/node-analyzer/tests/psp_test.yaml
+++ b/charts/node-analyzer/tests/psp_test.yaml
@@ -11,9 +11,8 @@ templates:
   - configmap-kspm-analyzer.yaml
   - secrets.yaml
   - serviceaccount-node-analyzer.yaml
-  - runtimeScanner/runtime-scanner-configmap.yaml
 values:
-  - ./default_values.yaml
+  - ./default_required_values.yaml
 
 tests:
   - it: Ensure PSP is created on k8s <1.25

--- a/charts/node-analyzer/tests/psp_test.yaml
+++ b/charts/node-analyzer/tests/psp_test.yaml
@@ -1,6 +1,15 @@
 suite: PSP create test
 templates:
   - templates/psp.yaml
+  # For checksums
+  - templates/configmap-benchmark-runner.yaml
+  - templates/configmap-host-analyzer.yaml
+  - templates/configmap-host-scanner.yaml
+  - templates/configmap-image-analyzer.yaml
+  - templates/configmap-kspm-analyzer.yaml
+  - templates/secrets.yaml
+  - templates/serviceaccount-node-analyzer.yaml
+  - templates/runtimeScanner/runtime-scanner-configmap.yaml
 tests:
   - it: Ensure PSP is created on k8s <1.25
     capabilities:

--- a/charts/node-analyzer/tests/psp_test.yaml
+++ b/charts/node-analyzer/tests/psp_test.yaml
@@ -2,16 +2,23 @@ suite: PSP create test
 templates:
   - templates/psp.yaml
   # For checksums
-  - templates/configmap-benchmark-runner.yaml
-  - templates/configmap-host-analyzer.yaml
-  - templates/configmap-host-scanner.yaml
-  - templates/configmap-image-analyzer.yaml
-  - templates/configmap-kspm-analyzer.yaml
-  - templates/secrets.yaml
-  - templates/serviceaccount-node-analyzer.yaml
-  - templates/runtimeScanner/runtime-scanner-configmap.yaml
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - configmap-kspm-analyzer.yaml
+  - secrets.yaml
+  - serviceaccount-node-analyzer.yaml
+  - runtimeScanner/runtime-scanner-configmap.yaml
+values:
+  - ./default_values.yaml
+
 tests:
   - it: Ensure PSP is created on k8s <1.25
+    templates:
+      - templates/psp.yaml
     capabilities:
       majorVersion: 1
       minorVersion: 24
@@ -24,6 +31,8 @@ tests:
           kind: PodSecurityPolicy
 
   - it: Ensure PSP is not created on k8s >=1.25
+    templates:
+      - templates/psp.yaml
     capabilities:
       majorVersion: 1
       minorVersion: 25
@@ -32,6 +41,8 @@ tests:
           count: 0
 
   - it: Ensure PSP is created on k8s <1.25 with '+' character in minor version
+    templates:
+      - templates/psp.yaml
     capabilities:
       majorVersion: 1
       minorVersion: "24+"
@@ -44,6 +55,8 @@ tests:
           kind: PodSecurityPolicy
 
   - it: Ensure PSP is not created on k8s >=1.25 with '+' character in minor version
+    templates:
+      - templates/psp.yaml
     capabilities:
       majorVersion: 1
       minorVersion: "25+"

--- a/charts/node-analyzer/tests/runtimescanner_test.yaml
+++ b/charts/node-analyzer/tests/runtimescanner_test.yaml
@@ -2,7 +2,7 @@
 # Run "helm unittest -3 -f ./tests/runtimescanner_test.yaml ." from within the `charts/node-analyzer` folder
 suite: Test RuntimeScanner configuration
 templates:
-  - ../templates/daemonset-node-analyzer.yaml
+  - daemonset-node-analyzer.yaml
   # For checksums
   - clusterrole-node-analyzer.yaml
   - clusterrolebinding-node-analyzer.yaml
@@ -15,13 +15,13 @@ templates:
   - serviceaccount-node-analyzer.yaml
   - runtimeScanner/runtime-scanner-configmap.yaml
 values:
-  - ./default_values.yaml
+  - ./default_required_values.yaml
   - ../values.yaml
 
 tests:
   - it: "Add extra volume through nodeAnalyzer.imageAnalyzer.extraVolumes parameter (deprecated)"
     templates:
-      - ../templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     set:
       nodeAnalyzer:
         imageAnalyzer:
@@ -42,7 +42,7 @@ tests:
 
   - it: "Add extra volume through nodeAnalyzer.extraVolumes parameter"
     templates:
-      - ../templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     set:
       nodeAnalyzer:
           extraVolumes:
@@ -64,8 +64,9 @@ tests:
     set:
       secure.vulnerabilityManagement.newEngineOnly: true
       nodeAnalyzer.runtimeScanner.deploy: false
+      global.clusterConfig.name: "test"
     templates:
-      - ../templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     asserts:
       - isKind:
           of: DaemonSet
@@ -81,7 +82,7 @@ tests:
 
   - it: "is disabled by default, legacy will be deployed"
     templates:
-      - ../templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     asserts:
       - isKind:
           of: DaemonSet
@@ -101,8 +102,9 @@ tests:
   - it: "is enabled when newEngineOnly is set"
     set:
       secure.vulnerabilityManagement.newEngineOnly: true
+      global.clusterConfig.name: "test"
     templates:
-      - ../templates/daemonset-node-analyzer.yaml
+      - daemonset-node-analyzer.yaml
     asserts:
       - isKind:
           of: DaemonSet

--- a/charts/node-analyzer/tests/runtimescanner_test.yaml
+++ b/charts/node-analyzer/tests/runtimescanner_test.yaml
@@ -3,7 +3,19 @@
 suite: Test RuntimeScanner configuration
 templates:
   - ../templates/daemonset-node-analyzer.yaml
+  # For checksums
+  - clusterrole-node-analyzer.yaml
+  - clusterrolebinding-node-analyzer.yaml
+  - configmap-benchmark-runner.yaml
+  - configmap-host-analyzer.yaml
+  - configmap-host-scanner.yaml
+  - configmap-image-analyzer.yaml
+  - configmap-kspm-analyzer.yaml
+  - secrets.yaml
+  - serviceaccount-node-analyzer.yaml
+  - runtimeScanner/runtime-scanner-configmap.yaml
 values:
+  - ./default_values.yaml
   - ../values.yaml
 
 tests:

--- a/charts/node-analyzer/tests/runtimescanner_test.yaml
+++ b/charts/node-analyzer/tests/runtimescanner_test.yaml
@@ -123,6 +123,9 @@ tests:
 
   - it: "always expose the EVE_ENABLED and EVE_INTEGRATION_ENABLED variables when eveEnabled is not specified"
     set:
+      global:
+        clusterConfig:
+          name: "test"
       nodeAnalyzer:
         runtimeScanner:
           deploy: true
@@ -136,6 +139,9 @@ tests:
 
   - it: "always expose the EVE_ENABLED and EVE_INTEGRATION_ENABLED variables when eveEnabled is true"
     set:
+      global:
+        clusterConfig:
+          name: "test"
       nodeAnalyzer:
         runtimeScanner:
           deploy: true
@@ -151,6 +157,9 @@ tests:
 
   - it: "always expose the EVE_ENABLED and EVE_INTEGRATION_ENABLED variables when eveEnabled is false"
     set:
+      global:
+        clusterConfig:
+          name: "test"
       nodeAnalyzer:
         runtimeScanner:
           deploy: true

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.34.4
+version: 1.34.5
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -36,7 +36,7 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.20.2
+    version: ~1.20.3
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: cluster-scanner

--- a/charts/sysdig-deploy/tests/golden_template_test.yaml
+++ b/charts/sysdig-deploy/tests/golden_template_test.yaml
@@ -5,6 +5,17 @@ templates:
   - charts/agent/templates/secrets.yaml
   - charts/nodeAnalyzer/templates/daemonset-node-analyzer.yaml
   - charts/nodeAnalyzer/templates/configmap-benchmark-runner.yaml
+  # For checksums
+  - charts/nodeAnalyzer/templates/clusterrole-node-analyzer.yaml
+  - charts/nodeAnalyzer/templates/clusterrolebinding-node-analyzer.yaml
+  - charts/nodeAnalyzer/templates/configmap-benchmark-runner.yaml
+  - charts/nodeAnalyzer/templates/configmap-host-analyzer.yaml
+  - charts/nodeAnalyzer/templates/configmap-host-scanner.yaml
+  - charts/nodeAnalyzer/templates/configmap-image-analyzer.yaml
+  - charts/nodeAnalyzer/templates/configmap-kspm-analyzer.yaml
+  - charts/nodeAnalyzer/templates/secrets.yaml
+  - charts/nodeAnalyzer/templates/serviceaccount-node-analyzer.yaml
+  - charts/nodeAnalyzer/templates/runtimeScanner/runtime-scanner-configmap.yaml
 tests:
   - it: Testing agent and node-analyzer deployed
     set:


### PR DESCRIPTION
## What this PR does / why we need it:

Force rollout when configmap(s)/secrets & co changes

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts

