### PR TITLE
chore(node-analyzer): Improve template to reflect eveEnabled settings in CM

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.20.0
+version: 1.20.1
 appVersion: 12.9.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -712,7 +712,6 @@ spec:
           - name: "{{ $key }}"
             value: "{{ $value }}"
           {{- end }}
-          {{- if .Values.nodeAnalyzer.runtimeScanner.settings.eveEnabled }}
           - name: EVE_ENABLED
             valueFrom:
               configMapKeyRef:
@@ -725,7 +724,6 @@ spec:
                 name: {{ .Release.Name }}-runtime-scanner
                 key: eve_integration_enabled
                 optional: true
-          {{- end }}
         volumeMounts:
           # Needed for some IBM OpenShift clusters which symlink /var/run/containers/storage to contents of /var/data by default
           - mountPath: /var/data

--- a/charts/node-analyzer/templates/runtimeScanner/runtime-scanner-configmap.yaml
+++ b/charts/node-analyzer/templates/runtimeScanner/runtime-scanner-configmap.yaml
@@ -14,28 +14,26 @@ data:
   {{- end }}
   {{- if (.Values.nodeAnalyzer.runtimeScanner.httpProxy | default .Values.nodeAnalyzer.httpProxy | default .Values.global.proxy.httpProxy) }}
   http_proxy: {{ .Values.nodeAnalyzer.runtimeScanner.httpProxy | default .Values.nodeAnalyzer.httpProxy | default .Values.global.proxy.httpProxy }}
-  {{- end -}}
+  {{- end }}
   {{- if (.Values.nodeAnalyzer.runtimeScanner.httpsProxy | default .Values.nodeAnalyzer.httpsProxy | default .Values.global.proxy.httpsProxy) }}
   https_proxy: {{ .Values.nodeAnalyzer.runtimeScanner.httpsProxy | default .Values.nodeAnalyzer.httpsProxy | default .Values.global.proxy.httpsProxy }}
-  {{- end -}}
+  {{- end }}
   {{- if (.Values.nodeAnalyzer.runtimeScanner.noProxy | default .Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy) }}
   no_proxy: {{ .Values.nodeAnalyzer.runtimeScanner.noProxy | default .Values.nodeAnalyzer.noProxy | default .Values.global.proxy.noProxy }}
-  {{- end -}}
-  {{- if .Values.nodeAnalyzer.runtimeScanner.settings.eveEnabled }}
-  eve_enabled: "true"
-  eve_integration_enabled: "true"
-  {{- end -}}
+  {{- end }}
+  eve_enabled: {{ .Values.nodeAnalyzer.runtimeScanner.settings.eveEnabled | quote }}
+  eve_integration_enabled: {{ .Values.nodeAnalyzer.runtimeScanner.settings.eveEnabled | quote }}
   {{- if hasKey .Values.nodeAnalyzer.runtimeScanner "settings" }}
   prom_port: {{ .Values.nodeAnalyzer.runtimeScanner.settings.prometheusPort | default 25001 | quote }}
-  {{- end -}}
+  {{- end }}
 
   {{- if .Values.nodeAnalyzer.runtimeScanner.settings.maxImageSizeAllowed }}
   max_image_size_allowed: {{ .Values.nodeAnalyzer.runtimeScanner.settings.maxImageSizeAllowed | int64 | quote }}
-  {{- end -}}
+  {{- end }}
   {{- if .Values.nodeAnalyzer.runtimeScanner.settings.maxFileSizeAllowed }}
   analyzer.maxFileSizeAllowed: {{ .Values.nodeAnalyzer.runtimeScanner.settings.maxFileSizeAllowed | int64 | quote }}
-  {{- end -}}
+  {{- end }}
   {{- if .Values.nodeAnalyzer.runtimeScanner.settings.vulnerabilityDBVersion }}
   vuln_db_version: {{ .Values.nodeAnalyzer.runtimeScanner.settings.vulnerabilityDBVersion | quote }}
-  {{- end -}}
+  {{- end }}
 {{- end }}

--- a/charts/node-analyzer/tests/runtimescanner_test.yaml
+++ b/charts/node-analyzer/tests/runtimescanner_test.yaml
@@ -106,3 +106,46 @@ tests:
       - lengthEqual:
           path: spec.template.spec.containers
           count: 3
+
+  - it: "always expose the EVE_ENABLED and EVE_INTEGRATION_ENABLED variables when eveEnabled is not specified"
+    set:
+      nodeAnalyzer:
+        runtimeScanner:
+          deploy: true
+    templates:
+      - ../templates/daemonset-node-analyzer.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "sysdig-runtime-scanner")].env[?(@.name == "EVE_ENABLED")]
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "sysdig-runtime-scanner")].env[?(@.name == "EVE_INTEGRATION_ENABLED")]
+
+  - it: "always expose the EVE_ENABLED and EVE_INTEGRATION_ENABLED variables when eveEnabled is true"
+    set:
+      nodeAnalyzer:
+        runtimeScanner:
+          deploy: true
+          settings:
+            eveEnabled: true
+    templates:
+      - ../templates/daemonset-node-analyzer.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "sysdig-runtime-scanner")].env[?(@.name == "EVE_ENABLED")]
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "sysdig-runtime-scanner")].env[?(@.name == "EVE_INTEGRATION_ENABLED")]
+
+  - it: "always expose the EVE_ENABLED and EVE_INTEGRATION_ENABLED variables when eveEnabled is false"
+    set:
+      nodeAnalyzer:
+        runtimeScanner:
+          deploy: true
+          settings:
+            eveEnabled: false
+    templates:
+      - ../templates/daemonset-node-analyzer.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "sysdig-runtime-scanner")].env[?(@.name == "EVE_ENABLED")]
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "sysdig-runtime-scanner")].env[?(@.name == "EVE_INTEGRATION_ENABLED")]


### PR DESCRIPTION
## What this PR does / why we need it:

As discussed in an internal escalation. Although we consider that manually updating a Configmap after rendering helm templates should be avoided, this change reflects the value of eveEnabled in the configmap variables instead of hardcoding to "true". This allows disabling / enabling eve integration just by updating the configmap. 

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
