### PR TITLE
feat(agent): add tolerations for rke2 master nodes

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.18.3
+version: 1.18.4

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -279,6 +279,10 @@ tolerations:
     key: node-role.kubernetes.io/etcd
     operator: Equal
     value: "true"
+  - effect: NoExecute
+    key: CriticalAddonsOnly
+    operator: Equal
+    value: "true"
 leaderelection:
   enable: false
 localForwarder:


### PR DESCRIPTION
## What this PR does / why we need it:
rke2 uses unique taints on their master nodes and were not accounted for by the default set of tolerations used by the agent pods

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
