### PR TITLE
chore(admission-controller): add ports to service conditionally

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.14.17
+version: 0.14.18
 appVersion: 3.9.36
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -68,7 +68,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.14.17  \
+    --create-namespace -n sysdig-admission-controller --version=0.14.18  \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -80,7 +80,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-     --create-namespace -n sysdig-admission-controller --version=0.14.17  \
+     --create-namespace -n sysdig-admission-controller --version=0.14.18  \
     --values values.yaml
 
 ```

--- a/charts/admission-controller/templates/NOTES.txt
+++ b/charts/admission-controller/templates/NOTES.txt
@@ -1,7 +1,7 @@
 {{- if .Values.features.kspmAdmissionController }}
 {{- if include "admissionController.validAccessKeyConfig" . }}{{- end}}
 {{- end }}
-{{- if (or .Values.features.k8sAuditDetections .Values.scanner.enabled) }}
+{{- if (or .Values.features.k8sAuditDetections .Values.scanner.enabled .Values.webhook.acConfig) }}
 {{- if include "admissionController.validTokenConfig" . }}{{- end }}
 {{- end }}
 Sysdig Admission Controller is now installed!

--- a/charts/admission-controller/templates/webhook/service.yaml
+++ b/charts/admission-controller/templates/webhook/service.yaml
@@ -8,12 +8,16 @@ metadata:
 spec:
   type: {{ .Values.webhook.service.type }}
   ports:
+  {{- if .Values.features.kspmAdmissionController }}
   - name: vac
     port: {{ .Values.webhook.v2.service.port }}
     targetPort: vac
+  {{- end }}
+  {{- if (or .Values.features.k8sAuditDetections .Values.scanner.enabled .Values.webhook.acConfig) }}
   - name: http
     port: {{ .Values.webhook.service.port }}
     targetPort: http
     protocol: TCP
+  {{- end }}
   selector:
     {{- include "admissionController.webhook.selectorLabels" . | nindent 4 }}

--- a/charts/admission-controller/tests/conditional_flag_test.yaml
+++ b/charts/admission-controller/tests/conditional_flag_test.yaml
@@ -12,6 +12,7 @@ templates:
   - webhook/secret.yaml
   - webhook/admissionregistration.yaml
   - webhook/podmonitor.yaml
+  - webhook/service.yaml
 tests:
   - it: Checking scanner enabled flag
     set:
@@ -54,6 +55,50 @@ tests:
           path: spec.template.spec.containers[0].name
           value: kspm-admission-controller
         template: webhook/deployment.yaml
+      - contains:
+          path: spec.ports
+          content:
+           name: vac
+           port: 6443
+           targetPort: vac
+          count: 1
+        template: webhook/service.yaml
+      - notContains:
+          path: spec.ports
+          content:
+           name: http
+          any: true
+        template: webhook/service.yaml
+
+  - it: Checking KSPM AC disabled
+    set:
+      features:
+        kspmAdmissionController: false
+        k8sAuditDetections: true
+      clusterName: test-k8s
+      sysdig:
+        secureAPIToken: standard_token
+        accessKey: some_access_key
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: admission-controller
+        template: webhook/deployment.yaml
+      - contains:
+          path: spec.ports
+          content:
+           name: http
+           port: 443
+           targetPort: http
+          any: true
+          count: 1
+        template: webhook/service.yaml
+      - notContains:
+          path: spec.ports
+          content:
+           name: vac
+          any: true
+        template: webhook/service.yaml
 
   - it: Checking podmonitors scanner enabled
     set:


### PR DESCRIPTION
## What this PR does / why we need it:

The service defines the ports for both old AC and new KSPM AC without checking if the containers are deployed. Adding a conditional so the service port is only defined when the container is deployed too.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
