### PR TITLE
fix(agent): properly render security block content

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.19.2
+version: 1.19.3

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -339,10 +339,8 @@ and set the agent chart parameters accordingly
     {{- if and (not .Values.secure.enabled) $secureFeatProvided }}
         {{ fail "Set secure.enabled=true when specifying sysdig.settings.feature.mode is `secure` or `secure_light`" }}
     {{- end }}
-
 {{ include "agent.monitorFeatures" . }}
 {{ include "agent.secureFeatures" . }}
-
 {{- end -}}
 
 {{/*
@@ -431,6 +429,14 @@ agent config to prevent a backend push from enabling them after installation.
         {{- $_ := set $secureConfig "drift_control" (dict "enabled" false) }}
         {{- $_ := set $secureConfig "drift_killer" (dict "enabled" false) }}
     {{- end }}
+
+    {{/* Finally, check sysdig.settings for any additional security block confiugration.
+         If so, merge it with $secureConfig and unset .Values.sysdig.settings.security */}}
+    {{- if hasKey .Values.sysdig.settings "security" }}
+        {{- $secureConfig := merge $secureConfig.security .Values.sysdig.settings.security }}
+        {{- $_ := unset .Values.sysdig.settings "security"}}
+    {{- end }}
+
 {{ toYaml $secureConfig }}
 {{- end }}
 

--- a/charts/agent/tests/secure_enable_test.yaml
+++ b/charts/agent/tests/secure_enable_test.yaml
@@ -170,3 +170,26 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: 'Set secure.enabled=true when specifying sysdig.settings.feature.mode is `secure` or `secure_light`'
+
+  - it: Test secure.enabled=true when manually specifying security block content
+    set:
+      secure:
+        enabled: true
+      sysdig:
+        settings:
+          security:
+            goodFeatureEnabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            security:
+              enabled: true
+              goodFeatureEnabled: true
+      - notMatchRegex:  # Catch the case of duplications due to sysdig.settings.security being specified
+          path: data['dragent.yaml']
+          pattern: |-
+            security:
+              goodFeatureEnabled: true


### PR DESCRIPTION
## What this PR does / why we need it:
There had been an issue where if the user set the `agent.secure.enabled` flag to true in the charts, any custom data in `agent.sysdig.settings.security` would not be properly rendered. This change addresses the issue by inspecting `agent.sysdig.settings` for any security block content when the rest of the Sysdig Secure items are being computed.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
