### PR TITLE
fix(agent): Properly set ephemeral-storage on kmod container when slim+autopilot are enabled

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.20.0
+version: 1.20.1

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -93,9 +93,13 @@ Sysdig Agent resources
     {{- toYaml .Values.resources -}}
 {{- else if not (hasKey $resourceProfiles .Values.resourceProfile) }}
     {{- fail (printf "Invalid value for resourceProfile provided: %s" .Values.resourceProfile) }}
-{{- else if include "agent.gke.autopilot" . }}
+{{- else if and (include "agent.gke.autopilot" .) (not .Values.slim.enabled) }}
     {{- toYaml (dict "requests" (dict "cpu" "250m"
                                       "ephemeral-storage" .Values.gke.ephemeralStorage
+                                      "memory" "512Mi")
+                     "limits"   (get $resourceProfiles .Values.resourceProfile)) }}
+{{- else if (include "agent.gke.autopilot" .) }}
+    {{- toYaml (dict "requests" (dict "cpu" "250m"
                                       "memory" "512Mi")
                      "limits"   (get $resourceProfiles .Values.resourceProfile)) }}
 {{- else }}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -90,7 +90,12 @@ spec:
             readOnlyRootFilesystem: false
             allowPrivilegeEscalation: true
           resources:
-            {{ toYaml .Values.slim.resources | nindent 12 }}
+            {{- if (include "agent.gke.autopilot" .) }}
+              {{- $resources := merge .Values.slim.resources (dict "requests" (dict "ephemeral-storage" .Values.gke.ephemeralStorage))}}
+              {{- toYaml $resources | nindent 12 }}
+            {{- else }}
+              {{ toYaml .Values.slim.resources | nindent 12 }}
+            {{- end }}
           env:
           {{- if or (include "agent.ebpfEnabled" .) (include "agent.gke.autopilot" .) }}
             - name: SYSDIG_BPF_PROBE

--- a/charts/agent/tests/gke_test.yaml
+++ b/charts/agent/tests/gke_test.yaml
@@ -9,6 +9,8 @@ tests:
       gke:
         autopilot: true
         createPriorityClass: true
+      slim:
+        enabled: false
     asserts:
       - containsDocument:
           kind: DaemonSet
@@ -29,6 +31,8 @@ tests:
         autopilot: true
         createPriorityClass: true
         ephemeralStorage: 256Mi
+      slim:
+        enabled: false
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
@@ -101,3 +105,39 @@ tests:
             drift_killer:
               enabled: false
     template: templates/configmap.yaml
+
+  - it: Ensure ephemeral storage is set correctly on kmod container when slim mode is enabled
+    set:
+      gke:
+        autopilot: true
+        createPriorityClass: true
+      slim:
+        enabled: true
+    asserts:
+        - equal:
+            path: spec.template.spec.initContainers[0].resources.requests.ephemeral-storage
+            value: 500Mi
+    template: templates/daemonset.yaml
+
+  - it: Custom value for ephemeral-storage with slim mode enabled
+    set:
+      gke:
+        autopilot: true
+        createPriorityClass: true
+        ephemeralStorage: 603Mi
+      slim:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.ephemeral-storage
+          value: 603Mi
+    template: templates/daemonset.yaml
+
+  - it: Ensure we are not setting the ephemeral storage on kmod container when slim mode is enabled and not autopilot
+    set:
+      slim:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[0].resources.requests.ephemeral-storage
+    template: templates/daemonset.yaml


### PR DESCRIPTION
## What this PR does / why we need it:
When GKE Autopilot and `agent.slim` were both enabled, the `ephemeral-storage` request on the kmodule container was not being set as expected. This change accomplishes two things:
1. Sets `resources.requests.ephemeral-storage` to `.Values.gke.ephemeral-storage` for the kmodule container if GKE Autopilot and `agent.slim` are enabled.
2. Corrects the behavior of unnecessarily setting `resources.requests.ephemeral-storage` on the agent container when GKE Autopilot and `agent.slim` mode are enabled

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
