### PR TITLE
chose(admission-controller): set latest AC image version to v3.9.37

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.14.23
-appVersion: 3.9.36
+version: 0.14.24
+appVersion: 3.9.37
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
 maintainers:

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -68,7 +68,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.14.23  \
+    --create-namespace -n sysdig-admission-controller --version=0.14.24  \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -80,7 +80,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-     --create-namespace -n sysdig-admission-controller --version=0.14.23  \
+     --create-namespace -n sysdig-admission-controller --version=0.14.24  \
     --values values.yaml
 
 ```


### PR DESCRIPTION
## What this PR does / why we need it:

Image version (appVersion in chart.yam) had been reverted to 3.9.36 by mistake. Setting latest one.

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
