### PR TITLE
chore(agent,sysdig-deploy): set promscrape port to 9091 by default when gke autopilot is enabled

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.20.1
+version: 1.20.2

--- a/charts/agent/templates/configmap-deployment.yaml
+++ b/charts/agent/templates/configmap-deployment.yaml
@@ -47,9 +47,6 @@ data:
   If these conditions are true, then we use the agent.sslCaFileName for the http_proxy.ca_certificate
 */}}
 {{- $baseSettings := .Values.sysdig.settings -}}
-{{- if and (include "agent.gke.autopilot" .) (or (not (hasKey $baseSettings "promscrape_web_address")) (eq (get $baseSettings "promscrape_web_address") "127.0.0.1:9990") ) }}
-  {{- $baseSettings := mergeOverwrite $baseSettings (dict "promscrape_web_address" "127.0.0.1:9991") -}}
-{{- end }}
 {{- if and (eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") (.Values.sysdig.settings) (hasKey .Values.sysdig.settings "http_proxy") (hasKey .Values.sysdig.settings.http_proxy "ssl") (eq (get .Values.sysdig.settings.http_proxy "ssl") true) }}
   {{- $caFilePath := printf "%s%s" "/etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
   {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}

--- a/charts/agent/templates/configmap-deployment.yaml
+++ b/charts/agent/templates/configmap-deployment.yaml
@@ -47,6 +47,9 @@ data:
   If these conditions are true, then we use the agent.sslCaFileName for the http_proxy.ca_certificate
 */}}
 {{- $baseSettings := .Values.sysdig.settings -}}
+{{- if and (include "agent.gke.autopilot" .) (or (not (hasKey $baseSettings "promscrape_web_address")) (eq (get $baseSettings "promscrape_web_address") "127.0.0.1:9990") ) }}
+  {{- $baseSettings := mergeOverwrite $baseSettings (dict "promscrape_web_address" "127.0.0.1:9991") -}}
+{{- end }}
 {{- if and (eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") (.Values.sysdig.settings) (hasKey .Values.sysdig.settings "http_proxy") (hasKey .Values.sysdig.settings.http_proxy "ssl") (eq (get .Values.sysdig.settings.http_proxy "ssl") true) }}
   {{- $caFilePath := printf "%s%s" "/etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
   {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -37,8 +37,11 @@ data:
   Checking here the user is using Custom CA and if http_proxy.ssl = true
   If these conditions are true, then we use the agent.sslCaFileName for the http_proxy.ca_certificate
 */}}
+{{- $baseSettings := .Values.sysdig.settings -}}
+{{- if and (include "agent.gke.autopilot" .) (or (not (hasKey $baseSettings "promscrape_web_address")) (eq (get $baseSettings "promscrape_web_address") "127.0.0.1:9990") ) }}
+  {{- $baseSettings := mergeOverwrite $baseSettings (dict "promscrape_web_address" "127.0.0.1:9991") -}}
+{{- end }}
 {{- if and (eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") (.Values.sysdig.settings) (hasKey .Values.sysdig.settings "http_proxy") (hasKey (default dict .Values.sysdig.settings.http_proxy) "ssl") (eq (get (default (dict "ssl" false) .Values.sysdig.settings.http_proxy) "ssl") true) }}
-  {{- $baseSettings := .Values.sysdig.settings -}}
   {{- $caFilePath := printf "%s%s" "/etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
   {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}
   {{ toYaml $mergedSettings | nindent 4 }}

--- a/charts/agent/tests/gke_test.yaml
+++ b/charts/agent/tests/gke_test.yaml
@@ -106,6 +106,45 @@ tests:
               enabled: false
     template: templates/configmap.yaml
 
+  - it: Ensure promscrape_web_address is set 127.0.0.1:9991 when autopilot is enabled
+    set:
+      gke:
+        autopilot: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            promscrape_web_address: 127.0.0.1:9991
+    template: templates/configmap.yaml
+
+  - it: Ensure promscrape_web_ddress is unaltered when is set on settings and autopilot is enabled
+    set:
+      gke:
+        autopilot: true
+      sysdig:
+        settings:
+          promscrape_web_address: test:1234
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            promscrape_web_address: test:1234
+    template: templates/configmap.yaml
+
+  - it: Ensure promscrape_web_address is unaltered when autopilot is disabled
+    set:
+      gke:
+        autopilot: false
+      sysdig:
+        settings:
+          promscrape_web_address: test:1234
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            promscrape_web_address: test:1234
+    template: templates/configmap.yaml
+
   - it: Ensure ephemeral storage is set correctly on kmod container when slim mode is enabled
     set:
       gke:

--- a/charts/agent/tests/gke_test.yaml
+++ b/charts/agent/tests/gke_test.yaml
@@ -117,7 +117,7 @@ tests:
             promscrape_web_address: 127.0.0.1:9991
     template: templates/configmap.yaml
 
-  - it: Ensure promscrape_web_ddress is unaltered when is set on settings and autopilot is enabled
+  - it: Ensure promscrape_web_address is unaltered when is set on settings and autopilot is enabled
     set:
       gke:
         autopilot: true

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.39.0
+version: 1.39.1
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -26,7 +26,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.20.1
+    version: ~1.20.2
     alias: agent
     condition: agent.enabled
   - name: common


### PR DESCRIPTION

## What this PR does / why we need it:

## Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

Check Contribution guidelines in README.md for more insight.
