### PR TITLE
feat(agent): ensure os-release file is mounted

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.22.2
+version: 1.22.3

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -305,6 +305,9 @@ spec:
             - mountPath: /host/etc
               name: etc-vol
               readOnly: true
+            - mountPath: /host/usr/lib/os-release
+              name: osrel-usr
+              readOnly: true
             - mountPath: /host/var/lib
               name: varlib-vol
             - mountPath: /host/var/data
@@ -342,6 +345,9 @@ spec:
           {{- if and (.Values.slim.enabled) (include "agent.gke.autopilot" .) }}
             - mountPath: /host/etc/os-release
               name: osrel
+              readOnly: true
+            - mountPath: /host/usr
+              name: usr-vol
               readOnly: true
             - mountPath: /host/var/run/containerd/containerd.sock
               name: containerdsock-vol
@@ -463,6 +469,9 @@ spec:
         - name: usr-vol
           hostPath:
             path: /usr
+        - name: osrel-usr
+          hostPath:
+            path: /usr/lib/os-release
         - name: varrun-vol
           hostPath:
             path: /var/run
@@ -511,6 +520,9 @@ spec:
         - name: osrel
           hostPath:
             path: /etc/os-release
+        - name: usr-vol
+          hostPath:
+            path: /usr
         - name: bpf-probes
           emptyDir: {}
         - name: containerdsock-vol

--- a/charts/agent/tests/gke_autopilot_volumes_test.yaml
+++ b/charts/agent/tests/gke_autopilot_volumes_test.yaml
@@ -2,7 +2,7 @@ suite: Host volumes are available for agent
 templates:
   - templates/daemonset.yaml
 tests:
-  - it: Ensure only the right volumes are mounted when running on GKE Autopilot, the agent is slim mode without eBPF
+  - it: Ensure only the right volumes are mounted when running on GKE Autopilot, the agent is not slim mode without eBPF
     set:
       gke:
         autopilot: true
@@ -22,8 +22,6 @@ tests:
       - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/lib/modules")]
       - isNotNull:
-          path: spec.template.spec.volumes[?(@.hostPath.path == "/usr")]
-      - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/run")]
       - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/var/run")]
@@ -33,7 +31,7 @@ tests:
       #     count: 8
       # We are going to use this "workaround" until we found a proper solution
       - isNull:
-          path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/lib/modules" && @.hostPath.path != "/usr" && @.hostPath.path != "/run" && @.hostPath.path != "/var/run")]
+          path: spec.template.spec.volumes[?(@.hostPath.path == "/usr" && @.hostPath.path =~ /\/.*/ && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/lib/modules" && @.hostPath.path != "/usr" && @.hostPath.path != "/run" && @.hostPath.path != "/var/run")]
 
   - it: Ensure only the right volumes are mounted when running on GKE Autopilot, the agent is slim mode without eBPF
     set:
@@ -51,6 +49,8 @@ tests:
       - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/etc/os-release")]
       - isNotNull:
+          path: spec.template.spec.volumes[?(@.hostPath.path == "/usr")]
+      - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/boot")]
       - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/run")]
@@ -62,9 +62,9 @@ tests:
       #     count: 5
       # We are going to use this "workaround" until we found a proper solution
       - isNull:
-          path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/run" && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/var/run/containerd/containerd.sock")]
+          path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/usr" && @.hostPath.path != "/run" && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/var/run/containerd/containerd.sock")]
 
-  - it: Ensure only the right volumes are mounted when running on GKE Autopilot, the agent is slim mode with eBPF
+  - it: Ensure only the right volumes are mounted when running on GKE Autopilot, the agent is not slim mode with eBPF
     set:
       gke:
         autopilot: true
@@ -84,8 +84,6 @@ tests:
       - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/lib/modules")]
       - isNotNull:
-          path: spec.template.spec.volumes[?(@.hostPath.path == "/usr")]
-      - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/run")]
       - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/var/run")]
@@ -95,7 +93,7 @@ tests:
       #     count: 8
       # We are going to use this "workaround" until we found a proper solution
       - isNull:
-          path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/lib/modules" && @.hostPath.path != "/usr" && @.hostPath.path != "/run" && @.hostPath.path != "/var/run")]
+          path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/usr" && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/lib/modules" && @.hostPath.path != "/usr" && @.hostPath.path != "/run" && @.hostPath.path != "/var/run")]
 
   - it: Ensure only the right volumes are mounted when running on GKE Autopilot, the agent is slim mode with eBPF
     set:
@@ -115,6 +113,8 @@ tests:
       - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/etc/os-release")]
       - isNotNull:
+          path: spec.template.spec.volumes[?(@.hostPath.path == "/usr")]
+      - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/boot")]
       - isNotNull:
           path: spec.template.spec.volumes[?(@.hostPath.path == "/var/run/containerd/containerd.sock")]
@@ -124,7 +124,7 @@ tests:
       #     count: 5
       # We are going to use this "workaround" until we found a proper solution
       - isNull:
-          path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/run" && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/var/run/containerd/containerd.sock")]
+          path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/usr" && @.hostPath.path != "/run" && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/var/run/containerd/containerd.sock")]
 
   - it: Ensure the SYSDIG_AGENT_DRIVER env var is not set
     set:

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -124,3 +124,126 @@ tests:
     templates:
       - deployment.yaml
       - daemonset.yaml
+
+  - it: Check for os-release mounts in slim=false, autopilot=false
+    set:
+      slim:
+        enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: etc-vol
+            hostPath:
+              path: /etc
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: usr-vol
+            hostPath:
+              path: /usr
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig")].volumeMounts
+          content:
+              mountPath: /host/etc
+              name: etc-vol
+              readOnly: true
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig")].volumeMounts
+          content:
+            mountPath: /host/usr
+            name: usr-vol
+            readOnly: true
+    template: daemonset.yaml
+
+  - it: Check for os-release mounts in slim=true, autopilot=false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: etc-vol
+            hostPath:
+              path: /etc
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: osrel-usr
+            hostPath:
+              path: /usr/lib/os-release
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig")].volumeMounts
+          content:
+            mountPath: /host/etc
+            name: etc-vol
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig")].volumeMounts
+          content:
+            mountPath: /host/usr/lib/os-release
+            name: osrel-usr
+            readOnly: true
+    template: daemonset.yaml
+
+  - it: Check for os-release mounts in slim=false, autopilot=true
+    set:
+      slim:
+        enabled: false
+      gke:
+        autopilot: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: osrel
+            hostPath:
+              path: /etc/os-release
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: usr-vol
+            hostPath:
+              path: /usr
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig")].volumeMounts
+          content:
+            mountPath: /host/etc/os-release
+            name: osrel
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig")].volumeMounts
+          content:
+            mountPath: /host/usr
+            name: usr-vol
+            readOnly: true
+    template: daemonset.yaml
+
+  - it: Check for os-release mounts in slim=true, autopilot=true
+    set:
+      gke:
+        autopilot: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: osrel
+            hostPath:
+              path: /etc/os-release
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: usr-vol
+            hostPath:
+              path: /usr
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig")].volumeMounts
+          content:
+            mountPath: /host/etc/os-release
+            name: osrel
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig")].volumeMounts
+          content:
+            mountPath: /host/usr
+            name: usr-vol
+            readOnly: true
+    template: daemonset.yaml


### PR DESCRIPTION
## What this PR does / why we need it:
The agent has added the distribution and release names as reported in the host's os-release file into the agent_info metric. Depending on platform the file can be located in the following locations on the host:

* /etc/os-release
* /usr/lib/os-release

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. feat(agent,node-analyzer,sysdig-deploy):)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix
