### PR TITLE
fix(node-analyzer): Add explicit dnsPolicy to node-analyzer

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.24.1
+version: 1.24.2
 appVersion: 12.9.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -148,6 +148,7 @@ spec:
       # Use the Host Network Namespace.
       # This is required by the Benchmark and the HostScanner containers to determine the hostname and host mac address
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       {{- if include "nodeAnalyzer.useHostPID" . }}
       # Use the Host PID namespace.


### PR DESCRIPTION
## What this PR does / why we need it:
Since `hostNetworking` is set to `true`, it is a recommended[1] to explicitly set the `dnsPolicy` to `ClusterFirstWithHostNet`. Failing to do this defaults `dnsPolicy` to `ClusterFirst` which could create unintended consqeuences in terms of dns resolution.

Fixes issue #1631 

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix