### PR TITLE
feature(agent,sysdig-deploy): [SMAGENT-6754] add permissions to read configmaps in clusterrole

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.21.1
+version: 1.21.2

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.21.2
+version: 1.22.0

--- a/charts/agent/templates/clusterrole.yaml
+++ b/charts/agent/templates/clusterrole.yaml
@@ -22,6 +22,7 @@ rules:
       - resourcequotas
       - persistentvolumes
       - persistentvolumeclaims
+      - configmaps
     verbs:
       - get
       - list

--- a/charts/agent/tests/clusterrole_test.yaml
+++ b/charts/agent/tests/clusterrole_test.yaml
@@ -83,29 +83,8 @@ tests:
               - "create"
               - "patch"
 
-  - it: Test can be read core resources in kubernetes
+  - it: SMAGENT-6299 - Test agent can read configmaps in kubernetes to publish the "kube_configmap_info" metric
     asserts:
       - contains:
-          path: rules
-          content:
-            apiGroups:
-              - ""
-            resources:
-              - pods
-              - replicationcontrollers
-              - services
-              - endpoints
-              - events
-              - limitranges
-              - namespaces
-              - nodes
-              - nodes/metrics
-              - nodes/proxy
-              - resourcequotas
-              - persistentvolumes
-              - persistentvolumeclaims
-              - configmaps
-            verbs:
-              - "get"
-              - "list"
-              - "watch"
+          path: rules[0].resources
+          content: configmaps

--- a/charts/agent/tests/clusterrole_test.yaml
+++ b/charts/agent/tests/clusterrole_test.yaml
@@ -83,7 +83,7 @@ tests:
               - "create"
               - "patch"
 
-  - it: Test ConfigMaps can be read in kubernetes
+  - it: Test can be read core resources in kubernetes
     asserts:
       - contains:
           path: rules
@@ -91,7 +91,20 @@ tests:
             apiGroups:
               - ""
             resources:
-              - "configmaps"
+              - pods
+              - replicationcontrollers
+              - services
+              - endpoints
+              - events
+              - limitranges
+              - namespaces
+              - nodes
+              - nodes/metrics
+              - nodes/proxy
+              - resourcequotas
+              - persistentvolumes
+              - persistentvolumeclaims
+              - configmaps
             verbs:
               - "get"
               - "list"

--- a/charts/agent/tests/clusterrole_test.yaml
+++ b/charts/agent/tests/clusterrole_test.yaml
@@ -82,3 +82,17 @@ tests:
             verbs:
               - "create"
               - "patch"
+
+  - it: Test ConfigMaps can be read in kubernetes
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - "configmaps"
+            verbs:
+              - "get"
+              - "list"
+              - "watch"

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.44.1
+version: 1.45.0
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -26,7 +26,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.21.1
+    version: ~1.22.0
     alias: agent
     condition: agent.enabled
   - name: common


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

replace #1644 