### PR TITLE
feat(admission-controller,node-analyzer): set dnsPolicy when we allow hostNetwork in the Pod 

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admission-controller
 description: Sysdig Admission Controller using Sysdig Secure inline image scanner
 type: application
-version: 0.15.1
+version: 0.15.2
 appVersion: 3.9.40
 home: https://sysdiglabs.github.io/admission-controller/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/admission-controller/README.md
+++ b/charts/admission-controller/README.md
@@ -68,7 +68,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-    --create-namespace -n sysdig-admission-controller --version=0.15.1  \
+    --create-namespace -n sysdig-admission-controller --version=0.15.2  \
     --set sysdig.secureAPIToken=YOUR-KEY-HERE,clusterName=YOUR-CLUSTER-NAME
 ```
 
@@ -80,7 +80,7 @@ For example:
 
 ```bash
 helm upgrade --install admission-controller sysdig/admission-controller \
-     --create-namespace -n sysdig-admission-controller --version=0.15.1  \
+     --create-namespace -n sysdig-admission-controller --version=0.15.2  \
     --values values.yaml
 
 ```

--- a/charts/admission-controller/templates/webhook/deployment.yaml
+++ b/charts/admission-controller/templates/webhook/deployment.yaml
@@ -47,6 +47,7 @@ spec:
         {{- end }}
       {{- if .Values.webhook.hostNetwork }}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       containers:
       {{- if .Values.features.kspmAdmissionController}}

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.24.3
+version: 1.24.4
 appVersion: 12.9.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -148,6 +148,7 @@ spec:
       # Use the Host Network Namespace.
       # This is required by the Benchmark and the HostScanner containers to determine the hostname and host mac address
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       {{- if include "nodeAnalyzer.useHostPID" . }}
       # Use the Host PID namespace.


### PR DESCRIPTION
## What this PR does / why we need it:

replace #1637 and fix #1631

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix
