### PR TITLE
feat(agent): add tag to distinguish delegated deployment agents

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.22.6
+version: 1.22.7

--- a/charts/agent/templates/configmap-deployment.yaml
+++ b/charts/agent/templates/configmap-deployment.yaml
@@ -39,8 +39,11 @@ data:
 {{- $_ := mergeOverwrite .Values.secure (dict "enabled" false) }}
 {{- (include "agent.secureFeatures" .) | nindent 4 }}
 {{- include "agent.logSettings" . }}
+{{- $delegatedAgentTag := "com.sysdig.delegated-agent-deployment:true" }}
 {{- if .Values.global.sysdig.tags }}
-    tags: {{ include "agent.tags" . }}
+    tags: {{ printf "%s,%s" (include "agent.tags" .) $delegatedAgentTag }}
+{{- else }}
+    tags: {{ $delegatedAgentTag }}
 {{- end }}
 {{/*
   Checking here the user is using Custom CA and if http_proxy.ssl = true

--- a/charts/agent/tests/delegated_agent_deployment_test.yaml
+++ b/charts/agent/tests/delegated_agent_deployment_test.yaml
@@ -482,6 +482,34 @@ tests:
       - templates/configmap.yaml
       - templates/configmap-deployment.yaml
 
+  - it: Checking that delegated deployment tag is set in deployment configmap with global tags
+    set:
+      global:
+        sysdig:
+          tags:
+            foo: bar
+      delegatedAgentDeployment:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            tags: foo:bar,com.sysdig.delegated-agent-deployment:true
+    templates:
+      - templates/configmap-deployment.yaml
+
+  - it: Checking that delegated deployment tag is set in deployment configmap
+    set:
+      delegatedAgentDeployment:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            tags: com.sysdig.delegated-agent-deployment:true
+    templates:
+      - templates/configmap-deployment.yaml
+
   - it: Ensure sanity of Agent service account
     set:
       delegatedAgentDeployment:


### PR DESCRIPTION
## What this PR does / why we need it:

Add a tag to be able to easily distinguish delegated deployment agents from regular ones.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
