### PR TITLE
feat(agent): allow to configure minReadySeconds on the daemonset

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.22.7
+version: 1.22.8

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -512,6 +512,7 @@ spec:
       {{- if .Values.extraVolumes.volumes }}
         {{ toYaml .Values.extraVolumes.volumes | nindent 8 }}
       {{- end }}
+  minReadySeconds: {{ .Values.daemonset.minReadySeconds }}
   updateStrategy:
     type: {{ .Values.daemonset.updateStrategy.type }}
     rollingUpdate:

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -120,6 +120,7 @@ serviceAccount:
   name: null
 daemonset:
   deploy: true
+  minReadySeconds: 1
   # Perform rolling updates by default in the DaemonSet agent
   # ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
   updateStrategy:


### PR DESCRIPTION
## What this PR does / why we need it:

The daemonset RollingUpdate strategy doesn't seems to wait for pods to become ready before proceeding with the next batch in the sequence. By setting the `minReadySeconds` this can be achieved.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
