### PR TITLE
chore(agent): allow to configure probes failureThreshold

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.23.0
+version: 1.23.1

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -235,6 +235,7 @@ spec:
             {{- end }}
             initialDelaySeconds: {{ .Values.daemonset.probes.initialDelay }}
             periodSeconds: {{ .Values.daemonset.probes.periodDelay }}
+            failureThreshold: {{ .Values.daemonset.probes.failureThreshold }}
           volumeMounts:
           {{- if .Values.localForwarder.enabled }}
             - mountPath: /opt/draios/etc/local_forwarder_config.yaml

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -114,6 +114,7 @@ spec:
             {{- end }}
             initialDelaySeconds: {{ .Values.delegatedAgentDeployment.deployment.probes.initialDelay }}
             periodSeconds: {{ .Values.delegatedAgentDeployment.deployment.probes.periodDelay }}
+            failureThreshold: {{ .Values.delegatedAgentDeployment.deployment.probes.failureThreshold }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/charts/agent/tests/readiness_probe_test.yaml
+++ b/charts/agent/tests/readiness_probe_test.yaml
@@ -16,8 +16,8 @@ tests:
                path: /healthz
                port: 24483
              initialDelaySeconds: 90
-             periodSeconds: 3
-             failureThreshold: 3
+             periodSeconds: 10
+             failureThreshold: 9
     template: templates/daemonset.yaml
   - it: "[DaemonSet] Readiness Probe (agent == 12.18.0)"
     set:
@@ -32,8 +32,8 @@ tests:
               path: /healthz
               port: 24483
             initialDelaySeconds: 90
-            periodSeconds: 3
-            failureThreshold: 3
+            periodSeconds: 10
+            failureThreshold: 9
     template: templates/daemonset.yaml
   - it: "[DaemonSet] Readiness Probe (agent < 12.18.0)"
     set:
@@ -49,8 +49,8 @@ tests:
                 - -e
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
-            periodSeconds: 3
-            failureThreshold: 3
+            periodSeconds: 10
+            failureThreshold: 9
     template: templates/daemonset.yaml
   - it: "[DaemonSet] Readiness Probe (agent == dev)"
     set:
@@ -66,8 +66,8 @@ tests:
                 - -e
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
-            periodSeconds: 3
-            failureThreshold: 3
+            periodSeconds: 10
+            failureThreshold: 9
     template: templates/daemonset.yaml
   - it: "[DaemonSet] Readiness Probe (agent == latest)"
     set:
@@ -83,8 +83,8 @@ tests:
                 - -e
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
-            periodSeconds: 3
-            failureThreshold: 3
+            periodSeconds: 10
+            failureThreshold: 9
     template: templates/daemonset.yaml
   - it: "[DelegatedAgentDeployment] Readiness Probe (agent > 12.18.0)"
     set:
@@ -101,8 +101,8 @@ tests:
               path: /healthz
               port: 24483
             initialDelaySeconds: 90
-            periodSeconds: 3
-            failureThreshold: 3
+            periodSeconds: 10
+            failureThreshold: 9
 
   - it: "[DelegatedAgentDeployment] Readiness Probe (agent == 12.18.0)"
     set:
@@ -119,8 +119,8 @@ tests:
               path: /healthz
               port: 24483
             initialDelaySeconds: 90
-            periodSeconds: 3
-            failureThreshold: 3
+            periodSeconds: 10
+            failureThreshold: 9
 
   - it: "[DelegatedAgentDeployment] Readiness Probe (agent < 12.18.0)"
     set:
@@ -138,8 +138,8 @@ tests:
                 - -e
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
-            periodSeconds: 3
-            failureThreshold: 3
+            periodSeconds: 10
+            failureThreshold: 9
 
   - it: "[DelegatedAgentDeployment] Readiness Probe (agent == dev)"
     set:
@@ -157,8 +157,8 @@ tests:
                 - -e
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
-            periodSeconds: 3
-            failureThreshold: 3
+            periodSeconds: 10
+            failureThreshold: 9
 
   - it: "[DelegatedAgentDeployment] Readiness Probe (agent == latest)"
     set:
@@ -176,8 +176,8 @@ tests:
                 - -e
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
-            periodSeconds: 3
-            failureThreshold: 3
+            periodSeconds: 10
+            failureThreshold: 9
 
   - it: Test setting probe delays
     set:
@@ -220,8 +220,8 @@ tests:
                 - -e
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
-            periodSeconds: 3
-            failureThreshold: 3
+            periodSeconds: 10
+            failureThreshold: 9
 
   - it: "Do not use the HTTP Readiness Probe on GKE Autopilot"
     set:
@@ -238,5 +238,5 @@ tests:
                 - -e
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
-            periodSeconds: 3
-            failureThreshold: 3
+            periodSeconds: 10
+            failureThreshold: 9

--- a/charts/agent/tests/readiness_probe_test.yaml
+++ b/charts/agent/tests/readiness_probe_test.yaml
@@ -17,6 +17,7 @@ tests:
                port: 24483
              initialDelaySeconds: 90
              periodSeconds: 3
+             failureThreshold: 3
     template: templates/daemonset.yaml
   - it: "[DaemonSet] Readiness Probe (agent == 12.18.0)"
     set:
@@ -32,6 +33,7 @@ tests:
               port: 24483
             initialDelaySeconds: 90
             periodSeconds: 3
+            failureThreshold: 3
     template: templates/daemonset.yaml
   - it: "[DaemonSet] Readiness Probe (agent < 12.18.0)"
     set:
@@ -48,6 +50,7 @@ tests:
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
             periodSeconds: 3
+            failureThreshold: 3
     template: templates/daemonset.yaml
   - it: "[DaemonSet] Readiness Probe (agent == dev)"
     set:
@@ -64,6 +67,7 @@ tests:
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
             periodSeconds: 3
+            failureThreshold: 3
     template: templates/daemonset.yaml
   - it: "[DaemonSet] Readiness Probe (agent == latest)"
     set:
@@ -80,6 +84,7 @@ tests:
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
             periodSeconds: 3
+            failureThreshold: 3
     template: templates/daemonset.yaml
   - it: "[DelegatedAgentDeployment] Readiness Probe (agent > 12.18.0)"
     set:
@@ -97,6 +102,8 @@ tests:
               port: 24483
             initialDelaySeconds: 90
             periodSeconds: 3
+            failureThreshold: 3
+
   - it: "[DelegatedAgentDeployment] Readiness Probe (agent == 12.18.0)"
     set:
       delegatedAgentDeployment:
@@ -113,6 +120,8 @@ tests:
               port: 24483
             initialDelaySeconds: 90
             periodSeconds: 3
+            failureThreshold: 3
+
   - it: "[DelegatedAgentDeployment] Readiness Probe (agent < 12.18.0)"
     set:
       delegatedAgentDeployment:
@@ -130,6 +139,8 @@ tests:
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
             periodSeconds: 3
+            failureThreshold: 3
+
   - it: "[DelegatedAgentDeployment] Readiness Probe (agent == dev)"
     set:
       delegatedAgentDeployment:
@@ -147,6 +158,8 @@ tests:
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
             periodSeconds: 3
+            failureThreshold: 3
+
   - it: "[DelegatedAgentDeployment] Readiness Probe (agent == latest)"
     set:
       delegatedAgentDeployment:
@@ -164,17 +177,21 @@ tests:
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
             periodSeconds: 3
+            failureThreshold: 3
+
   - it: Test setting probe delays
     set:
       daemonset:
         probes:
           initialDelay: 5
           periodDelay: 3
+          failureThreshold: 10
       delegatedAgentDeployment:
         deployment:
           probes:
             initialDelay: 5
             periodDelay: 3
+            failureThreshold: 10
         enabled: true
     asserts:
       - equal:
@@ -183,6 +200,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.periodSeconds
           value: 3
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 10
 
   - it: "Do not use the HTTP Readiness Probe on GKE Autopilot"
     set:
@@ -201,6 +221,7 @@ tests:
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
             periodSeconds: 3
+            failureThreshold: 3
 
   - it: "Do not use the HTTP Readiness Probe on GKE Autopilot"
     set:
@@ -218,3 +239,4 @@ tests:
                 - /opt/draios/logs/running
             initialDelaySeconds: 90
             periodSeconds: 3
+            failureThreshold: 3

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -149,6 +149,7 @@ daemonset:
   probes:
     initialDelay: 90
     periodDelay: 3
+    failureThreshold: 3
   kmodule:
     env: {}
 # If is behind a proxy you can set the proxy server
@@ -314,6 +315,7 @@ delegatedAgentDeployment:
     probes:
       initialDelay: 90
       periodDelay: 3
+      failureThreshold: 3
     progressDeadlineSeconds: 600
     replicas: 1
     resources:

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -148,8 +148,8 @@ daemonset:
   # readiness probe delays
   probes:
     initialDelay: 90
-    periodDelay: 3
-    failureThreshold: 3
+    periodDelay: 10
+    failureThreshold: 9
   kmodule:
     env: {}
 # If is behind a proxy you can set the proxy server
@@ -314,8 +314,8 @@ delegatedAgentDeployment:
     # readiness probes delays
     probes:
       initialDelay: 90
-      periodDelay: 3
-      failureThreshold: 3
+      periodDelay: 10
+      failureThreshold: 9
     progressDeadlineSeconds: 600
     replicas: 1
     resources:


### PR DESCRIPTION
## What this PR does / why we need it:

- Allow to set the `failureThreshold` for the readiness probe
- Align the the results of `periodSeconds * failureThreshold` to the `initialDelaySeconds`
