### PR TITLE
fix(node-analyzer): use correct values for custom CA envs generation

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.26.4
+version: 1.26.5
 appVersion: 12.9.0
 
 keywords:

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -282,7 +282,7 @@ spec:
           {{- end }}
           {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.nodeAnalyzer.ssl)) "true" }}
           - name: TLS_CA_PATHS
-            value: /ca-certs/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
+            value: /ca-certs/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.nodeAnalyzer.ssl) -}}
           {{- end }}
           {{- range $key, $value := .Values.nodeAnalyzer.kspmAnalyzer.env }}
           - name: "{{ $key }}"


### PR DESCRIPTION
## What this PR does / why we need it:

Use correct values for custom CA envs generation

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
