### PR TITLE
feat(ci): add updatecli job to update bitnami/kubectl image tags

### DIFF
--- a/.github/updatecli.d/config-update-bitnami-kubectl-image.yaml
+++ b/.github/updatecli.d/config-update-bitnami-kubectl-image.yaml
@@ -1,0 +1,71 @@
+name: update bitnami/kubectl image tag for helm tests
+
+scms:
+  github:
+    kind: "github"
+    spec:
+      user: "updatecli"
+      email: "updatecli@sysdig.com"
+      owner: "sysdiglabs"
+      repository: "charts"
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: draios-jenkins
+      branch: "main"
+      hidecredit: true
+
+actions:
+  github:
+    kind: "github/pullrequest"
+    scmid: "github"
+    spec:
+      automerge: true
+      description: 'bump bitnami/kubectl image references'
+      labels:
+        - "automated PR"
+      mergemethod: squash
+      title: 'chore(ci): bump bitnami/kubectl image references'
+
+sources:
+  bitnamiKubectlImage:
+    kind: dockerimage
+    spec:
+      image: bitnami/kubectl
+      versionfilter:
+        kind: semver
+
+targets:
+  bumpAgentChart:
+    name: "bump the bitnami/kubectl image reference in the agent chart"
+    kind: helmchart
+    scmid: github
+    spec:
+      name: "charts/agent"
+      key: "$.tests.image.tag"
+      versionincrement: patch
+
+  bumpKspmCollectorChart:
+    name: "bump the bitnami/kubectl image reference in the kspm-collector chart"
+    kind: helmchart
+    scmid: github
+    spec:
+      name: "charts/kspm-collector"
+      key: "$.tests.image.tag"
+      versionincrement: patch
+
+  bumpNodeAnalyzerChart:
+    name: "bump the bitnami/kubectl image reference in the node-analyzer chart"
+    kind: helmchart
+    scmid: github
+    spec:
+      name: "charts/node-analyzer"
+      key: "$.tests.image.tag"
+      versionincrement: patch
+
+  bumpRapidResponseChart:
+    name: "bump the bitnami/kubectl image reference in the rapid-response chart"
+    kind: helmchart
+    scmid: github
+    spec:
+      name: "charts/rapid-response"
+      key: "$.tests.image.tag"
+      versionincrement: patch

--- a/.github/workflows/kubectl-update.yaml
+++ b/.github/workflows/kubectl-update.yaml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  agent-release:
+  kubectl-update:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/kubectl-update.yaml
+++ b/.github/workflows/kubectl-update.yaml
@@ -1,0 +1,25 @@
+---
+name: Update bitnami/kubectl image reference for Helm tests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  agent-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@v2.56.0
+
+      - name: Run Updatecli
+        run: "updatecli apply --config .github/updatecli.d/config-update-bitnami-kubectl-image.yaml"
+        env:
+          GITHUB_TOKEN: "${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}"


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds a nightly job that checks to make sure that the container image used by the `helm test` command is up to date in the charts that are configured to use it.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
