### PR TITLE
fix(ci): use strict semver for test pod image tag update

### DIFF
--- a/.github/updatecli.d/config-update-bitnami-kubectl-image.yaml
+++ b/.github/updatecli.d/config-update-bitnami-kubectl-image.yaml
@@ -32,6 +32,7 @@ sources:
       image: bitnami/kubectl
       versionfilter:
         kind: semver
+        strict: true
 
 targets:
   bumpAgentChart:


### PR DESCRIPTION
## What this PR does / why we need it:
without the use of 'strict: true' in the versionfilter, updatecli could end up using just `major.minor` for the image tag and omitting any patch version (if present). by setting `strict: true` the tool will always search for, and use, an image tag which includes the patch number (ie. my-image:1.2.3).

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
