### PR TITLE
chore: exclude cluster-shield chart from ct install tests

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -71,4 +71,4 @@ jobs:
           k3s-version: v1.23.9+k3s1
 
       - name: Run chart-testing (install)
-        run: ct install --upgrade --target-branch=main --excluded-charts common,sysdig-stackdriver-bridge,sysdig-mcm-navmenu
+        run: ct install --upgrade --target-branch=main --excluded-charts cluster-shield,common,sysdig-stackdriver-bridge,sysdig-mcm-navmenu


### PR DESCRIPTION
## What this PR does / why we need it:

exclude cluster-shield chart from ct install tests

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
