### PR TITLE
fix(cluster-shield): add missing CHANGELOG file and bump version

### DIFF
--- a/charts/cluster-shield/CHANGELOG.md
+++ b/charts/cluster-shield/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Chart: Cluster Shield
+
+All notable changes to this chart will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please note that it's automatically updated vía github actions.
+Manual edits are supported only below '## Change Log' and should be used
+exclusively to fix incorrect entries and not to add new ones.
+
+## Change Log
+# v0.10.1
+### Chores
+* **cluster-shield** [ccde92b](https://github.com/sysdiglabs/charts/commit/ccde92b3a672445f065d3612772e4105b9331049): Automatic bump to version 0.10.1 ([#1726](https://github.com/sysdiglabs/charts/issues/1726))

--- a/charts/cluster-shield/Chart.yaml
+++ b/charts/cluster-shield/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-shield
 description: Cluster Shield Helm Chart for Kubernetes
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: "0.10.1"
 maintainers:
   - name: AlbertoBarba

--- a/charts/cluster-shield/README.md
+++ b/charts/cluster-shield/README.md
@@ -25,7 +25,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-sysdig-cluster-shield sysdig/cluster-shield \
-    --create-namespace -n sysdig-agent --version=0.10.1  \
+    --create-namespace -n sysdig-agent --version=0.10.2  \
     --set global.clusterConfig.name=CLUSTER_NAME \
     --set global.sysdig.region=SYSDIG_REGION \
     --set global.sysdig.accessKey=YOUR-KEY-HERE


### PR DESCRIPTION
## What this PR does / why we need it:

Add missing `CHANGELOG.md` file in `cluster-shield` chart

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
