### PR TITLE
feat(node-analyzer): added option to disable platform scanning

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.29.0
+version: 1.29.1
 appVersion: 12.9.0
 
 keywords:

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.29.1
+version: 1.30.0
 appVersion: 12.9.0
 
 keywords:

--- a/charts/node-analyzer/templates/configmap-host-scanner.yaml
+++ b/charts/node-analyzer/templates/configmap-host-scanner.yaml
@@ -39,6 +39,9 @@ data:
   {{- if .Values.nodeAnalyzer.hostScanner.vulnerabilityDBVersion }}
   vuln_db_version: {{ .Values.nodeAnalyzer.hostScanner.vulnerabilityDBVersion | quote }}
   {{- end }}
+  {{- if .Values.nodeAnalyzer.hostScanner.disablePlatformScanning }}
+  disable_platform_scanning: {{ .Values.nodeAnalyzer.hostScanner.disablePlatformScanning | quote }}
+  {{- end }}
   {{- if .Values.nodeAnalyzer.hostScanner.scanContainers.enabled }}
   {{- if .Values.nodeAnalyzer.hostScanner.scanContainers.dockerSocketPath }}
   docker_socket_path: {{ .Values.nodeAnalyzer.hostScanner.scanContainers.dockerSocketPath | quote}}

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -912,6 +912,12 @@ spec:
                 name: {{ .Release.Name }}-host-scanner
                 key: vuln_db_version
                 optional: true
+          - name: DISABLE_PLATFORM_SCANNING
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}-host-scanner
+                key: disable_platform_scanning
+                optional: true
           - name: TMPDIR
             value: "/tmp"
           - name: PROBES_ENABLED

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -387,6 +387,8 @@ nodeAnalyzer:
     # additionalDirsToScan is a optional comma-separated list of directories that
     # should be analyzer in addition to default ones.
     # additionalDirsToScan: "/foo/bar/baz,/my/other/folder"
+    #
+    # disablePlatformScanning: false
 
     # probesPort is the port where readiness and liveness probes are exposed
     probesPort: 7001

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.55.1
+version: 1.56.0
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -36,7 +36,7 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.29.1
+    version: ~1.30.0
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: cluster-scanner

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.55.0
+version: 1.55.1
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -36,7 +36,7 @@ dependencies:
   - name: node-analyzer
     # repository: https://charts.sysdig.com
     repository: file://../node-analyzer
-    version: ~1.29.0
+    version: ~1.29.1
     alias: nodeAnalyzer
     condition: nodeAnalyzer.enabled
   - name: cluster-scanner


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
