### PR TITLE
fix(agent): [SMAGENT-7391] fix path of CA certificate to be used for proxy

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.24.3
+version: 1.24.4

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -476,7 +476,7 @@ ssl: {{ $ssl }}
 ssl_verify_certificate: {{ $sslVerifyCertificate }}
 {{- end }}
 {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
-ca_certificate: /etc/ca-certs/{{ include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) }}
+ca_certificate: etc/ca-certs/{{ include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) }}
 {{- end }}
 {{- end }}
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -476,7 +476,7 @@ ssl: {{ $ssl }}
 ssl_verify_certificate: {{ $sslVerifyCertificate }}
 {{- end }}
 {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
-ca_certificate: etc/ca-certs/{{ include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) }}
+ca_certificate: certificates/{{ include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) }}
 {{- end }}
 {{- end }}
 

--- a/charts/agent/templates/configmap-deployment.yaml
+++ b/charts/agent/templates/configmap-deployment.yaml
@@ -51,7 +51,7 @@ data:
 */}}
 {{- $baseSettings := .Values.sysdig.settings -}}
 {{- if and (eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") (.Values.sysdig.settings) (hasKey .Values.sysdig.settings "http_proxy") (hasKey .Values.sysdig.settings.http_proxy "ssl") (eq (get .Values.sysdig.settings.http_proxy "ssl") true) }}
-  {{- $caFilePath := printf "%s%s" "etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
+  {{- $caFilePath := printf "%s%s" "certificates/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
   {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}
   {{- $finalSettings := mergeOverwrite $mergedSettings $requiredOverrides -}}
   {{ toYaml $finalSettings | nindent 4 }}

--- a/charts/agent/templates/configmap-deployment.yaml
+++ b/charts/agent/templates/configmap-deployment.yaml
@@ -51,7 +51,7 @@ data:
 */}}
 {{- $baseSettings := .Values.sysdig.settings -}}
 {{- if and (eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") (.Values.sysdig.settings) (hasKey .Values.sysdig.settings "http_proxy") (hasKey .Values.sysdig.settings.http_proxy "ssl") (eq (get .Values.sysdig.settings.http_proxy "ssl") true) }}
-  {{- $caFilePath := printf "%s%s" "/etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
+  {{- $caFilePath := printf "%s%s" "etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
   {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}
   {{- $finalSettings := mergeOverwrite $mergedSettings $requiredOverrides -}}
   {{ toYaml $finalSettings | nindent 4 }}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -42,7 +42,7 @@ data:
   {{- $baseSettings := mergeOverwrite $baseSettings (dict "promscrape_web_address" "127.0.0.1:9991") -}}
 {{- end }}
 {{- if and (eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") (.Values.sysdig.settings) (hasKey .Values.sysdig.settings "http_proxy") (hasKey (default dict .Values.sysdig.settings.http_proxy) "ssl") (eq (get (default (dict "ssl" false) .Values.sysdig.settings.http_proxy) "ssl") true) }}
-  {{- $caFilePath := printf "%s%s" "/etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
+  {{- $caFilePath := printf "%s%s" "etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
   {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}
   {{ toYaml $mergedSettings | nindent 4 }}
 {{- else if .Values.sysdig.settings }}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -42,7 +42,7 @@ data:
   {{- $baseSettings := mergeOverwrite $baseSettings (dict "promscrape_web_address" "127.0.0.1:9991") -}}
 {{- end }}
 {{- if and (eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") (.Values.sysdig.settings) (hasKey .Values.sysdig.settings "http_proxy") (hasKey (default dict .Values.sysdig.settings.http_proxy) "ssl") (eq (get (default (dict "ssl" false) .Values.sysdig.settings.http_proxy) "ssl") true) }}
-  {{- $caFilePath := printf "%s%s" "etc/ca-certs/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
+  {{- $caFilePath := printf "%s%s" "certificates/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
   {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}
   {{ toYaml $mergedSettings | nindent 4 }}
 {{- else if .Values.sysdig.settings }}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -123,13 +123,13 @@ spec:
           {{- end }}
           {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
             - name: SSL_CERT_FILE
-              value: /opt/draios/etc/ca-certs/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
+              value: /opt/draios/certificates/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
           {{- end }}
           volumeMounts:
           {{- /* Always requested */}}
             {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
             - name: ca-cert
-              mountPath: /opt/draios/etc/ca-certs
+              mountPath: /opt/draios/certificates
               readOnly: true
             {{- end }}
 
@@ -221,7 +221,7 @@ spec:
             {{- end }}
             {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
             - name: SSL_CERT_FILE
-              value: /opt/draios/etc/ca-certs/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
+              value: /opt/draios/certificates/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
             {{- end }}
           readinessProbe:
             {{- if eq (include "agent.enableHttpProbes" .) "true" }}
@@ -268,7 +268,7 @@ spec:
 
           {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
             - name: ca-cert
-              mountPath: /opt/draios/etc/ca-certs
+              mountPath: /opt/draios/certificates
               readOnly: true
           {{- end }}
 

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
           {{- end }}
           {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
           - name: SSL_CERT_FILE
-            value: /opt/draios/etc/ca-certs/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
+            value: /opt/draios/certificates/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
           {{- end }}
           readinessProbe:
             {{- if eq (include "agent.enableHttpProbes" .) "true" }}
@@ -138,7 +138,7 @@ spec:
               name: podinfo
             {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
             - name: ca-cert
-              mountPath: /opt/draios/etc/ca-certs
+              mountPath: /opt/draios/certificates
               readOnly: true
             {{- end }}
 

--- a/charts/agent/tests/ca_cert_test.yaml
+++ b/charts/agent/tests/ca_cert_test.yaml
@@ -39,7 +39,7 @@ tests:
           path: spec.template.spec.initContainers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/root_ca.crt"
+            value: "/opt/draios/certificates/root_ca.crt"
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.volumes
@@ -52,12 +52,12 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/root_ca\.crt.*
+          pattern: certificates\/root_ca\.crt.*
         template: templates/configmap.yaml
   - it: Check Local CA Cert Delegated Agent Deployment
     set:
@@ -78,13 +78,13 @@ tests:
           path: spec.template.spec.initContainers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/root_ca.crt"
+            value: "/opt/draios/certificates/root_ca.crt"
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/root_ca.crt"
+            value: "/opt/draios/certificates/root_ca.crt"
         template: templates/deployment.yaml
       - contains:
           path: spec.template.spec.volumes
@@ -104,23 +104,23 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/deployment.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/root_ca\.crt.*
+          pattern: certificates\/root_ca\.crt.*
         template: templates/configmap.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/root_ca\.crt.*
+          pattern: certificates\/root_ca\.crt.*
         template: templates/configmap-deployment.yaml
   - it: Check Local CA Cert with SSL Proxy
     set:
@@ -142,7 +142,7 @@ tests:
           path: spec.template.spec.initContainers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/root_ca.crt"
+            value: "/opt/draios/certificates/root_ca.crt"
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.volumes
@@ -155,12 +155,12 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/root_ca\.crt.*
+          pattern: certificates\/root_ca\.crt.*
         template: templates/configmap.yaml
   - it: Check Local CA Cert with SSL Proxy Delegated Agent Deployment
     set:
@@ -184,13 +184,13 @@ tests:
           path: spec.template.spec.initContainers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/root_ca.crt"
+            value: "/opt/draios/certificates/root_ca.crt"
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/root_ca.crt"
+            value: "/opt/draios/certificates/root_ca.crt"
         template: templates/deployment.yaml
       - contains:
           path: spec.template.spec.volumes
@@ -210,23 +210,23 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/deployment.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/root_ca\.crt.*
+          pattern: certificates\/root_ca\.crt.*
         template: templates/configmap.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/root_ca\.crt.*
+          pattern: certificates\/root_ca\.crt.*
         template: templates/configmap-deployment.yaml
   - it: Check Global CA Cert with local CA cert override
     set:
@@ -254,7 +254,7 @@ tests:
           path: spec.template.spec.initContainers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/root_ca.crt"
+            value: "/opt/draios/certificates/root_ca.crt"
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.volumes
@@ -267,12 +267,12 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/root_ca\.crt.*
+          pattern: certificates\/root_ca\.crt.*
         template: templates/configmap.yaml
   - it: Check Global CA Cert with local CA cert override Delegated Agent Deployment
     set:
@@ -302,13 +302,13 @@ tests:
           path: spec.template.spec.initContainers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/root_ca.crt"
+            value: "/opt/draios/certificates/root_ca.crt"
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/root_ca.crt"
+            value: "/opt/draios/certificates/root_ca.crt"
         template: templates/deployment.yaml
       - contains:
           path: spec.template.spec.volumes
@@ -328,23 +328,23 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/deployment.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/root_ca\.crt.*
+          pattern: certificates\/root_ca\.crt.*
         template: templates/configmap.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/root_ca\.crt.*
+          pattern: certificates\/root_ca\.crt.*
         template: templates/configmap-deployment.yaml
   - it: Check Global CA Cert
     set:
@@ -364,7 +364,7 @@ tests:
           path: spec.template.spec.initContainers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/global_root_ca.crt"
+            value: "/opt/draios/certificates/global_root_ca.crt"
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.volumes
@@ -377,19 +377,19 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/global_root_ca\.crt.*
+          pattern: certificates\/global_root_ca\.crt.*
         template: templates/configmap.yaml
   - it: Check Global CA Cert Delegated Agent Deployment
     set:
@@ -411,13 +411,13 @@ tests:
           path: spec.template.spec.initContainers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/global_root_ca.crt"
+            value: "/opt/draios/certificates/global_root_ca.crt"
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/global_root_ca.crt"
+            value: "/opt/draios/certificates/global_root_ca.crt"
         template: templates/deployment.yaml
       - contains:
           path: spec.template.spec.volumes
@@ -437,30 +437,30 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/deployment.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/global_root_ca\.crt.*
+          pattern: certificates\/global_root_ca\.crt.*
         template: templates/configmap.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/global_root_ca\.crt.*
+          pattern: certificates\/global_root_ca\.crt.*
         template: templates/configmap-deployment.yaml
   - it: Check Global CA Cert with SSL Proxy
     set:
@@ -483,7 +483,7 @@ tests:
           path: spec.template.spec.initContainers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/global_root_ca.crt"
+            value: "/opt/draios/certificates/global_root_ca.crt"
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.volumes
@@ -496,19 +496,19 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/global_root_ca\.crt.*
+          pattern: certificates\/global_root_ca\.crt.*
         template: templates/configmap.yaml
   - it: Check Global CA Cert with SSL Proxy Delegated Agent Deployment
     set:
@@ -533,13 +533,13 @@ tests:
           path: spec.template.spec.initContainers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/global_root_ca.crt"
+            value: "/opt/draios/certificates/global_root_ca.crt"
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SSL_CERT_FILE
-            value: "/opt/draios/etc/ca-certs/global_root_ca.crt"
+            value: "/opt/draios/certificates/global_root_ca.crt"
         template: templates/deployment.yaml
       - contains:
           path: spec.template.spec.volumes
@@ -559,28 +559,28 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/deployment.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: ca-cert
-            mountPath: /opt/draios/etc/ca-certs
+            mountPath: /opt/draios/certificates
             readOnly: true
         template: templates/daemonset.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/global_root_ca\.crt.*
+          pattern: certificates\/global_root_ca\.crt.*
         template: templates/configmap.yaml
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*\/etc\/ca-certs\/global_root_ca\.crt.*
+          pattern: certificates\/global_root_ca\.crt.*
         template: templates/configmap-deployment.yaml


### PR DESCRIPTION
We're currently mounting the custom CA certificate under /opt/draios/etc/ca-certs as it is the location where the agent should normally look for it (i.e. the root install /opt/draios). However, the current agent implementation will always treat ca_certificate as a relative path and always prepend /opt/draios, whereas http_proxy.ca_certificate will honor an absolute path if such a path is specified.
So if we specify /etc/ca-certs/... for http_proxy.ca_certificate, any SSL connection to the proxy will fail because that path will not exist. It will however work for the CA certificate against the collector due to the reason explained above.

On the other hand, using a relative path etc/ca-certs (or in this case, certificates/ which is what the Windows agent will use) will work in both cases, so this is what we should be using instead.

## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
