### PR TITLE
chore(sysdig-deploy): bump cluster-shield to 1.0.1

### DIFF
--- a/.github/workflows/update-sysdig-deploy-chart.yaml
+++ b/.github/workflows/update-sysdig-deploy-chart.yaml
@@ -21,6 +21,7 @@ jobs:
             charts/admission-controller/*
             charts/agent/*
             charts/cluster-scanner/*
+            charts/cluster-shield/*
             charts/common/*
             charts/kspm-collector/*
             charts/node-analyzer/*

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.56.7
+version: 1.56.8
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -60,6 +60,6 @@ dependencies:
   - name: cluster-shield
     # repository: https://charts.sysdig.com
     repository: file://../cluster-shield
-    version: ~1.0.0
+    version: ~1.0.1
     alias: clusterShield
     condition: clusterShield.enabled

--- a/scripts/sysdig-deploy/update-sysdig-deploy.sh
+++ b/scripts/sysdig-deploy/update-sysdig-deploy.sh
@@ -7,6 +7,7 @@ sysdig_deploy_path="sysdig-deploy"
 admission_controller_chart_path="admission-controller"
 agent_chart_path="agent"
 cluster_scanner_chart_path="cluster-scanner"
+cluster_shield_chart_path="cluster-shield"
 common_chart_path="common"
 kspm_collector_chart_path="kspm-collector"
 node_analyzer_chart_path="node-analyzer"
@@ -69,7 +70,7 @@ check_update_needed () {
     fi
 }
 
-charts=( "$node_analyzer_chart_path" "$agent_chart_path" "$kspm_collector_chart_path" "$rapid_response_chart_path" "$admission_controller_chart_path" "$common_chart_path" "$cluster_scanner_chart_path")
+charts=( "$node_analyzer_chart_path" "$agent_chart_path" "$kspm_collector_chart_path" "$rapid_response_chart_path" "$admission_controller_chart_path" "$common_chart_path" "$cluster_scanner_chart_path" "$cluster_shield_chart_path")
 for chart in "${charts[@]}"
 do
     check_update_needed "$chart"


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
