### PR TITLE
fix(cluster-shield):Change secureApiTokenSecret key name

### DIFF
--- a/charts/cluster-shield/Chart.yaml
+++ b/charts/cluster-shield/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-shield
 description: Cluster Shield Helm Chart for Kubernetes
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "1.0.1"
 maintainers:
   - name: AlbertoBarba

--- a/charts/cluster-shield/README.md
+++ b/charts/cluster-shield/README.md
@@ -23,7 +23,7 @@ $ pre-commit run -a
 $ helm repo add sysdig https://charts.sysdig.com
 $ helm repo update
 $ helm upgrade --install sysdig-sysdig-cluster-shield sysdig/cluster-shield \
-    --create-namespace -n sysdig-agent --version=1.0.2  \
+    --create-namespace -n sysdig-agent --version=1.0.3  \
     --set global.clusterConfig.name=CLUSTER_NAME \
     --set global.sysdig.region=SYSDIG_REGION \
     --set global.sysdig.accessKey=YOUR-KEY-HERE

--- a/charts/cluster-shield/templates/deployment.yaml
+++ b/charts/cluster-shield/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.sysdig.secureAPITokenSecret }}
-                  key: "secure-api-token"
+                  key: "SECURE_API_TOKEN"
             {{- end }}
             {{- if eq (include "cluster-shield.custom_ca.enabled" .) "true" }}
             - name: SSL_CERT_FILE

--- a/charts/cluster-shield/tests/deployment_test.yaml
+++ b/charts/cluster-shield/tests/deployment_test.yaml
@@ -91,7 +91,7 @@ tests:
           value: test-existing-secure-api-token-secret
       - equal:
           path: spec.template.spec.containers[?(@.name == "cluster-shield")].env[?(@.name == "SYSDIG_CLUSTER_SHIELD_SYSDIG_ENDPOINT__SECURE_API_TOKEN")].valueFrom.secretKeyRef.key
-          value: secure-api-token
+          value: SECURE_API_TOKEN
 
   - it: Test readinessProbe default values
     asserts:


### PR DESCRIPTION
Change secureApiTokenSecret key name to fix problem with deployment of cluster shield with existing secrets.

## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [X] Chart Version bumped for the respective charts
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
