### PR TITLE
feat(agent): add /lib64 volume mount

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.27.1
+version: 1.27.2

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -298,9 +298,6 @@ spec:
               name: vardata-vol
             - mountPath: /host/var/run
               name: varrun-vol
-            - mountPath: /host/usr/lib64
-              name: lib64-vol
-              readOnly: true
             {{- if (include "agent.ebpfEnabled" .) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -321,9 +318,6 @@ spec:
               name: vardata-vol
             - mountPath: /host/var/run
               name: varrun-vol
-            - mountPath: /host/usr/lib64
-              name: lib64-vol
-              readOnly: true
             {{- if (include "agent.ebpfEnabled" .) }}
             - mountPath: /root/.sysdig
               name: bpf-probes

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -142,7 +142,7 @@ spec:
             - mountPath: /host/usr
               name: usr-vol
               readOnly: true
-            - path: /host/usr/lib64
+            - mountPath: /host/usr/lib64
               name: lib64-vol
               readOnly: true
             {{- if (include "agent.ebpfEnabled" .) }}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -142,6 +142,9 @@ spec:
             - mountPath: /host/usr
               name: usr-vol
               readOnly: true
+            - path: /host/usr/lib64
+              name: lib64-vol
+              readOnly: true
             {{- if (include "agent.ebpfEnabled" .) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -295,6 +298,9 @@ spec:
               name: vardata-vol
             - mountPath: /host/var/run
               name: varrun-vol
+            - mountPath: /host/usr/lib64
+              name: lib64-vol
+              readOnly: true
             {{- if (include "agent.ebpfEnabled" .) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -315,6 +321,9 @@ spec:
               name: vardata-vol
             - mountPath: /host/var/run
               name: varrun-vol
+            - mountPath: /host/usr/lib64
+              name: lib64-vol
+              readOnly: true
             {{- if (include "agent.ebpfEnabled" .) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -441,6 +450,9 @@ spec:
         - name: varrun-vol
           hostPath:
             path: /var/run
+        - name: lib64-vol
+          hostPath:
+            path: /lib64
         {{- if (include "agent.ebpfEnabled" .) }}
         - name: bpf-probes
           emptyDir: {}
@@ -473,6 +485,9 @@ spec:
         - name: vardata-vol
           hostPath:
             path: /var/data
+        - name: lib64-vol
+          hostPath:
+            path: /lib64
         {{- if (include "agent.ebpfEnabled" .) }}
         - name: bpf-probes
           emptyDir: {}

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -82,6 +82,42 @@ tests:
     templates:
       - daemonset.yaml
 
+  - it: Ensure /lib64 host volume is mounted as /host/usr/lib64 in container
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "lib64-vol")].mountPath
+          value: /host/usr/lib64
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "lib64-vol")].hostPath.path
+          value: /lib64
+    templates:
+      - daemonset.yaml
+
+  - it: Ensure /lib64 host volume is not mounted in container when running on gke.autopilot
+    set:
+      gke:
+        autopilot: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "lib64-vol")]
+      - isNull:
+          path: spec.template.spec.volumes[?(@.name == "lib64-vol")]
+    templates:
+      - daemonset.yaml
+
+  - it: Ensure /lib64 host volume is not mounted in container when running on global.gke.autopilot
+    set:
+      global:
+        gke:
+          autopilot: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "lib64-vol")]
+      - isNull:
+          path: spec.template.spec.volumes[?(@.name == "lib64-vol")]
+    templates:
+      - daemonset.yaml
+
   - it: Ensure agent http proxy volume is not mounted when http_proxy settings is not set
     set:
       sysdig:

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -85,7 +85,7 @@ tests:
   - it: Ensure /lib64 host volume is mounted as /host/usr/lib64 in container
     asserts:
       - equal:
-          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "lib64-vol")].mountPath
+          path: spec.template.spec.initContainers[*].volumeMounts[?(@.name == "lib64-vol")].mountPath
           value: /host/usr/lib64
       - equal:
           path: spec.template.spec.volumes[?(@.name == "lib64-vol")].hostPath.path
@@ -99,7 +99,7 @@ tests:
         autopilot: true
     asserts:
       - isNull:
-          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "lib64-vol")]
+          path: spec.template.spec.initContainers[*].volumeMounts[?(@.name == "lib64-vol")]
       - isNull:
           path: spec.template.spec.volumes[?(@.name == "lib64-vol")]
     templates:
@@ -112,7 +112,7 @@ tests:
           autopilot: true
     asserts:
       - isNull:
-          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "lib64-vol")]
+          path: spec.template.spec.initContainers[*].volumeMounts[?(@.name == "lib64-vol")]
       - isNull:
           path: spec.template.spec.volumes[?(@.name == "lib64-vol")]
     templates:


### PR DESCRIPTION
## What this PR does / why we need it:

Add optional host `/lib64` to `/host/usr/lib64` mount (except for gke autopilot), since in some environment the proper `ld-linux-*` is under `/lib64`

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
