### PR TITLE
chore(agent): bump the Windows Agent release to 1.0.1

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.27.0
+version: 1.27.1

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -68,7 +68,7 @@ windows:
   image:
     registry: quay.io
     repository: sysdig/agent-windows
-    tag: 1.0.0
+    tag: 1.0.1
     # Specify an imagePullPolicy
     # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
