### PR TITLE
chore(rapid-response): bump rapid-response version to 0.4.1

### DIFF
--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.2
+version: 0.9.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.0
+appVersion: 0.4.1
 
 keywords:
   - monitoring

--- a/charts/rapid-response/README.md
+++ b/charts/rapid-response/README.md
@@ -65,7 +65,7 @@ The following table lists the configurable parameters of the Sysdig Rapid Respon
 | `rapidResponse.existingServiceAccount`     | (Optional) Sets the ServiceAccount name to provide additional capabilities to Rapid Response pod. | ` `                                                          |
 | `rapidResponse.image.registry`             | Specifies the Rapid Response image registry.                 | `quay.io`                                                    |
 | `rapidResponse.image.repository`           | Specifies the  image repository to pull from.                | `sysdig/rapid-response-host-component`                       |
-| `rapidResponse.image.tag`                  | Specifies the  image tag to pull.                            | `"0.4.0"`                                                    |
+| `rapidResponse.image.tag`                  | Specifies the  image tag to pull.                            | `"${IMAGE_TAG}"`                                                    |
 | `rapidResponse.image.pullPolicy`           | Specifies the image pull policy.                             | `""`                                                         |
 | `rapidResponse.imagePullSecrets`           | Specifies the image pull secret.                             | ` `                                                          |
 | `rapidResponse.apiEndpoint`                | Specifies the Rapid Response `apiEndpoint`.                  | ` `                                                          |


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
