### PR TITLE
feat(agent): explicitly naming the prometheus metrics port in the agent daemonset

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.27.13
+version: 1.27.14

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -230,6 +230,11 @@ spec:
             - name: SSL_CERT_FILE
               value: /opt/draios/certificates/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
             {{- end }}
+          {{- if and (hasKey .Values.sysdig.settings "prometheus_exporter") (.Values.sysdig.settings.prometheus_exporter.enabled) }}
+          ports:
+            - containerPort: {{ regexFind "[0-9]+$" (default "0.0.0.0:9544" .Values.sysdig.settings.prometheus_exporter.listen_url) }}
+              name: metrics
+          {{- end }}
           readinessProbe:
             {{- if eq (include "agent.enableHttpProbes" .) "true" }}
             httpGet:

--- a/charts/agent/tests/daemonset_metrics_ports_test.yaml
+++ b/charts/agent/tests/daemonset_metrics_ports_test.yaml
@@ -1,0 +1,68 @@
+suite: Test Daemonset Metrics Port
+templates:
+  - templates/daemonset.yaml
+kubernetesProvider:
+  scheme:
+    "v1/Node":
+      gvr:
+        version: "v1"
+        resource: "nodes"
+      namespaced: false
+  objects:
+  - apiVersion: v1
+    kind: Node
+    metadata:
+      name: fakenode
+    status:
+      nodeInfo:
+        osImage: fake-os-image
+tests:
+  - it: test default behavior with no port
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].ports
+    templates:
+      - templates/daemonset.yaml
+
+  - it: test behavior with prometheus_exporter enabled
+    set:
+      sysdig:
+        settings:
+          prometheus_exporter:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value:
+            - containerPort: 9544
+              name: metrics
+    templates:
+      - templates/daemonset.yaml
+
+  - it: test behavior with prometheus_exporter explicitly disabled
+    set:
+      sysdig:
+        settings:
+          prometheus_exporter:
+            enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].ports
+    templates:
+      - templates/daemonset.yaml
+
+  - it: test behavior with prometheus_exporter enabled and non-default port
+    set:
+      sysdig:
+        settings:
+          prometheus_exporter:
+            enabled: true
+            listen_url: 127.0.0.1:1234
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value:
+            - containerPort: 1234
+              name: metrics
+    templates:
+      - templates/daemonset.yaml


### PR DESCRIPTION
## What this PR does / why we need it:

Changes imported from https://github.com/sysdiglabs/charts/pull/1865