### PR TITLE
fix(agent): use dig function for prometheus_exporter settings check

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.27.14
+version: 1.27.15

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -230,9 +230,9 @@ spec:
             - name: SSL_CERT_FILE
               value: /opt/draios/certificates/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
             {{- end }}
-          {{- if and (hasKey .Values.sysdig.settings "prometheus_exporter") (.Values.sysdig.settings.prometheus_exporter.enabled) }}
+          {{- if dig "prometheus_exporter" "enabled" false .Values.sysdig.settings }}
           ports:
-            - containerPort: {{ regexFind "[0-9]+$" (default "0.0.0.0:9544" .Values.sysdig.settings.prometheus_exporter.listen_url) }}
+            - containerPort: {{ regexFind "[0-9]+$" (dig "prometheus_exporter" "listen_url" "0.0.0.0:9544" .Values.sysdig.settings) }}
               name: metrics
           {{- end }}
           readinessProbe:


### PR DESCRIPTION
## What this PR does / why we need it:
Migrate the new prometheus_exporter port creation logic to use Helm's '[dig](https://helm.sh/docs/chart_template_guide/function_list/#dig)' function to protect against cases where the values may not be present.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

<!-- Check Contribution guidelines in README.md for more insight. -->
