### PR TITLE
fix(agent): set allowHostPorts when needed

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.27.17
+version: 1.27.18

--- a/charts/agent/templates/securitycontextconstraint.yaml
+++ b/charts/agent/templates/securitycontextconstraint.yaml
@@ -12,7 +12,11 @@ allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: true
 allowHostPID: true
+{{- if or (dig "kspm_analyzer" "enabled" false .Values.sysdig.settings) (dig "prometheus_exporter" "enabled" false .Values.sysdig.settings) }}
+allowHostPorts: true
+{{- else }}
 allowHostPorts: false
+{{- end }}
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 {{- if eq "true" (include "agent.privileged" .) }}

--- a/charts/agent/tests/security_context_constraints_test.yaml
+++ b/charts/agent/tests/security_context_constraints_test.yaml
@@ -74,3 +74,68 @@ tests:
     asserts:
       - isNotEmpty:
           path: allowedCapabilities
+
+  - it: Test that we allow hostPorts when prometheus_exporter is enabled
+    set:
+      scc:
+        create: true
+      sysdig:
+        settings:
+          prometheus_exporter:
+            enabled: true
+    asserts:
+      - equal:
+          path: allowHostPorts
+          value: true
+
+  - it: Test that we allow hostPorts when kspm_analyzer is enabled
+    set:
+      scc:
+        create: true
+      sysdig:
+        settings:
+          kspm_analyzer:
+            enabled: true
+    asserts:
+      - equal:
+          path: allowHostPorts
+          value: true
+
+  - it: Test that we do not allow hostPorts when neither prometheus_exporter nor kspm_analyzer are enabled
+    set:
+      scc:
+        create: true
+      sysdig:
+        settings:
+          prometheus_exporter:
+            enabled: false
+          kspm_analyzer:
+            enabled: false
+    asserts:
+      - equal:
+          path: allowHostPorts
+          value: false
+
+  - it: Test that we do not allow hostPorts in the default case
+    set:
+      scc:
+        create: true
+    asserts:
+      - equal:
+          path: allowHostPorts
+          value: false
+
+  - it: Test that we allow hostPorts when prometheus_exporter and kspm_analyzer are enabled
+    set:
+      scc:
+        create: true
+      sysdig:
+        settings:
+          prometheus_exporter:
+            enabled: true
+          kspm_analyzer:
+            enabled: true
+    asserts:
+      - equal:
+          path: allowHostPorts
+          value: true


### PR DESCRIPTION
## What this PR does / why we need it:
When either the kspm-analyzer or the prometheus exporter are enabled in the agent container we require the ability for the agent container to utilize host ports.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
