### PR TITLE
fix(agent): Reorder volume list

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.27.18
+version: 1.27.19

--- a/charts/agent/templates/securitycontextconstraint.yaml
+++ b/charts/agent/templates/securitycontextconstraint.yaml
@@ -44,9 +44,9 @@ supplementalGroups:
 users:
 - system:serviceaccount:{{ include "agent.namespace" . }}:{{ template "agent.serviceAccountName" .}}
 volumes:
-- hostPath
-- emptyDir
-- secret
 - configMap
 - downwardAPI
+- emptyDir
+- hostPath
+- secret
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:
OpenShift stores the volume list in alphabetical order. To avoid unnecessary reconcile runs when using GitOps - align the order in helm chart with OpenShift expected order.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

<!-- Check Contribution guidelines in README.md for more insight. -->
