### PR TITLE
chore(agent,sysdig-deploy): mount /host/dev volume readonly on ebpf mode

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.27.18
+version: 1.27.19

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.27.19
+version: 1.28.0

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -269,6 +269,7 @@ spec:
           {{- /* Always requested */}}
             - mountPath: /host/dev
               name: dev-vol
+              readOnly: {{ (include "agent.ebpfEnabled" .) | default false }}
             - mountPath: /host/usr
               name: usr-vol
               readOnly: true

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -121,6 +121,7 @@ spec:
           {{- /* Always requested */}}
             - mountPath: /host/dev
               name: dev-vol
+              readOnly: {{ (include "agent.ebpfEnabled" .) | default false }}
             - mountPath: /host/proc
               name: proc-vol
               readOnly: true

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -29,6 +29,36 @@ tests:
     templates:
       - daemonset.yaml
 
+  - it: Ensure /host/dev host volume is NOT mounted readonly by default
+    set:
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+      delegatedAgentDeployment:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "dev-vol")].readOnly
+          value: false
+    templates:
+      - daemonset.yaml
+      - deployment.yaml
+
+  - it: Ensure /host/dev host volume is mounted readonly on epbf mode
+    set:
+      ebpf:
+        enabled: true
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+      delegatedAgentDeployment:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "dev-vol")].readOnly
+          value: true
+    templates:
+      - daemonset.yaml
+      - deployment.yaml
+
   - it: Ensure /var/data host volume is mounted as /host/var/data in container
     set:
       sysdig:

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.27.18
+    version: ~1.28.0
     alias: agent
     condition: agent.enabled
   - name: common

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.62.4
+version: 1.63.0
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com


### PR DESCRIPTION
## What this PR does / why we need it:

We want to mount the `dev-vol` (`/host/dev`) volume as readonly when eBPF is enabled.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
