### PR TITLE
feat(agent): allow gke autopilot user to select universal ebpf driver

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.29.8
+version: 1.29.9

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -597,14 +597,6 @@ true
 {{- include "agent.configmapName" . | trunc 46 | trimSuffix "-" | printf "%s-local-forwarder" }}
 {{- end }}
 
-{{- define "agent.enableHttpProbes" }}
-{{- if not (include "agent.gke.autopilot" .) }}
-{{- if and (include "agent.isSemVer" .Values.image.tag) (semverCompare ">= 12.18.0-0" .Values.image.tag) }}
-{{- printf "true" -}}
-{{- end }}
-{{- end }}
-{{- end }}
-
 {{- define "agent.enableFalcoBaselineSecureLight" }}
 {{- if and (include "agent.isSemVer" .Values.image.tag) (semverCompare ">= 12.19.0-0" .Values.image.tag) }}
 {{- printf "true" -}}

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -280,7 +280,7 @@ Check for all COS nodes or a flag to enable eBPF. If false, return nothing so
 it can act like a boolean
 */}}
 {{- define "agent.ebpfEnabled" -}}
-  {{- if (or (eq "true" (include "agent.isAllCos" .)) .Values.ebpf.enabled) -}}
+  {{- if (or (eq "true" (include "agent.isAllCos" .)) (include "agent.gke.autopilot" .) .Values.ebpf.enabled) -}}
     true
   {{- end -}}
 {{- end -}}
@@ -635,7 +635,7 @@ annotations:
       - image tag not semver: go on at user's risk
 */}}
 {{- define "agent.privileged" }}
-  {{- if or .Values.privileged (include "agent.gke.autopilot" .) }}
+  {{- if .Values.privileged }}
     {{- /* OK */ -}}
     {{- print "true" }}
   {{- else }}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -29,7 +29,7 @@ data:
 {{/*
   Unset proxy_user and proxy_password if present and gke autopilot is disabled.
 */}}
-{{- if and (hasKey .Values.sysdig.settings "http_proxy") (not (include "agent.gke.autopilot" .)) }}
+{{- if hasKey .Values.sysdig.settings "http_proxy" }}
   {{- $_ := unset .Values.sysdig.settings.http_proxy "proxy_user" -}}
   {{- $_ := unset .Values.sysdig.settings.http_proxy "proxy_password" -}}
 {{- end }}

--- a/charts/agent/templates/daemonset-windows.yaml
+++ b/charts/agent/templates/daemonset-windows.yaml
@@ -65,10 +65,8 @@ spec:
             mountPath: Sysdig/Agent/certificates
             readOnly: true
           {{- end }}
-          {{- if (include "agent.httpProxyCredentials" .) }}
           - mountPath: Sysdig/Agent/Secrets/http_proxy
             name: sysdig-agent-http-proxy-secrets
-          {{- end }}
       terminationGracePeriodSeconds: 0
       volumes:
       - name: config
@@ -81,11 +79,10 @@ spec:
           {{- else }}
           secretName: {{ include "agent.accessKeySecret" . }}
           {{- end }}
-      {{- if (include "agent.httpProxyCredentials" .) }}
       - name: sysdig-agent-http-proxy-secrets
         secret:
           secretName: {{ template "agent.fullname" . }}-proxy
-      {{- end }}
+          optional: true
       {{- if eq (include "sysdig.custom_ca.useValues"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
       - name: ca-cert
         secret:

--- a/charts/agent/templates/daemonset-windows.yaml
+++ b/charts/agent/templates/daemonset-windows.yaml
@@ -65,7 +65,7 @@ spec:
             mountPath: Sysdig/Agent/certificates
             readOnly: true
           {{- end }}
-          {{- if and (include "agent.httpProxyCredentials" .) (not (include "agent.gke.autopilot" .)) }}
+          {{- if (include "agent.httpProxyCredentials" .) }}
           - mountPath: Sysdig/Agent/Secrets/http_proxy
             name: sysdig-agent-http-proxy-secrets
           {{- end }}
@@ -81,7 +81,7 @@ spec:
           {{- else }}
           secretName: {{ include "agent.accessKeySecret" . }}
           {{- end }}
-      {{- if and (include "agent.httpProxyCredentials" .) (not (include "agent.gke.autopilot" .)) }}
+      {{- if (include "agent.httpProxyCredentials" .) }}
       - name: sysdig-agent-http-proxy-secrets
         secret:
           secretName: {{ template "agent.fullname" . }}-proxy

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -248,15 +248,10 @@ spec:
           {{- end }}
           {{- end }}
           readinessProbe:
-            {{- if eq (include "agent.enableHttpProbes" .) "true" }}
             httpGet:
               host: 127.0.0.1
               path: /healthz
               port: 24483
-            {{- else }}
-            exec:
-              command: [ "test", "-e", "/opt/draios/logs/running" ]
-            {{- end }}
             initialDelaySeconds: {{ .Values.daemonset.probes.initialDelay }}
             periodSeconds: {{ .Values.daemonset.probes.periodDelay }}
             failureThreshold: {{ .Values.daemonset.probes.failureThreshold }}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -279,10 +279,8 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
-            {{- if (include "agent.httpProxyCredentials" .) }}
             - mountPath: /opt/draios/etc/secrets/http_proxy
               name: sysdig-agent-http-proxy-secrets
-            {{- end }}
             - mountPath: /etc/podinfo
               name: podinfo
 
@@ -391,6 +389,10 @@ spec:
           configMap:
             name: {{ include "agent.configmapName" . }}
             optional: true
+        - name: sysdig-agent-http-proxy-secrets
+          secret:
+            secretName: {{ template "agent.fullname" . }}-proxy
+            optional: true
         {{- if .Values.localForwarder.enabled }}
         - name: local-forwarder-config
           configMap:
@@ -404,11 +406,6 @@ spec:
             {{- else }}
             secretName: {{ include "agent.accessKeySecret" . }}
             {{- end }}
-        {{- if (include "agent.httpProxyCredentials" .) }}
-        - name: sysdig-agent-http-proxy-secrets
-          secret:
-            secretName: {{ template "agent.fullname" . }}-proxy
-        {{- end }}
         - name: podinfo
           downwardAPI:
             defaultMode: 420

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -89,7 +89,7 @@ spec:
               {{ toYaml .Values.slim.resources | nindent 12 }}
             {{- end }}
           env:
-          {{- if or (include "agent.ebpfEnabled" .) (include "agent.gke.autopilot" .) }}
+          {{- if (include "agent.ebpfEnabled" .) }}
             - name: SYSDIG_BPF_PROBE
               value:
           {{- end }}
@@ -195,14 +195,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            {{- if and (or (include "agent.ebpfEnabled" .) (include "agent.gke.autopilot" .)) (not (include "agent.universalEbpfEnforced" . )) }}
+            {{- if and (include "agent.ebpfEnabled" .) (not (include "agent.universalEbpfEnforced" . )) }}
             - name: SYSDIG_BPF_PROBE
               value:
             {{- end }}
-            {{- if and (include "agent.universalEbpfEnforced" .) (not (include "agent.gke.autopilot" .)) }}
+            {{- if (include "agent.universalEbpfEnforced" .) }}
             - name: SYSDIG_AGENT_DRIVER
               value: universal_ebpf
-            {{- else if and (include "agent.legacyEbpfEnforced" .) (not (include "agent.gke.autopilot" .)) }}
+            {{- else if (include "agent.legacyEbpfEnforced" .) }}
             - name: SYSDIG_AGENT_DRIVER
               value: legacy_ebpf
             {{- end }}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -279,7 +279,7 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
-            {{- if and (include "agent.httpProxyCredentials" .) (not (include "agent.gke.autopilot" .)) }}
+            {{- if (include "agent.httpProxyCredentials" .) }}
             - mountPath: /opt/draios/etc/secrets/http_proxy
               name: sysdig-agent-http-proxy-secrets
             {{- end }}
@@ -404,7 +404,7 @@ spec:
             {{- else }}
             secretName: {{ include "agent.accessKeySecret" . }}
             {{- end }}
-        {{- if and (include "agent.httpProxyCredentials" .) (not (include "agent.gke.autopilot" .)) }}
+        {{- if (include "agent.httpProxyCredentials" .) }}
         - name: sysdig-agent-http-proxy-secrets
           secret:
             secretName: {{ template "agent.fullname" . }}-proxy

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -103,15 +103,10 @@ spec:
             value: /opt/draios/certificates/{{- include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) -}}
           {{- end }}
           readinessProbe:
-            {{- if eq (include "agent.enableHttpProbes" .) "true" }}
             httpGet:
               host: 127.0.0.1
               path: /healthz
               port: 24483
-            {{- else }}
-            exec:
-              command: [ "test", "-e", "/opt/draios/logs/running" ]
-            {{- end }}
             initialDelaySeconds: {{ .Values.delegatedAgentDeployment.deployment.probes.initialDelay }}
             periodSeconds: {{ .Values.delegatedAgentDeployment.deployment.probes.periodDelay }}
             failureThreshold: {{ .Values.delegatedAgentDeployment.deployment.probes.failureThreshold }}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -126,10 +126,8 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
-            {{- if and (include "agent.httpProxyCredentials" .) }}
             - mountPath: /opt/draios/etc/secrets/http_proxy
               name: sysdig-agent-http-proxy-secrets
-            {{- end }}
             - mountPath: /etc/podinfo
               name: podinfo
             {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
@@ -258,11 +256,10 @@ spec:
             {{- else }}
             secretName: {{ include "agent.accessKeySecret" . }}
             {{- end }}
-        {{- if and (include "agent.httpProxyCredentials" .) }}
         - name: sysdig-agent-http-proxy-secrets
           secret:
             secretName: {{ template "agent.fullname" . }}-proxy
-        {{- end }}
+            optional: true
         - name: podinfo
           downwardAPI:
             defaultMode: 420

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -126,7 +126,7 @@ spec:
               name: sysdig-agent-config
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
-            {{- if and (include "agent.httpProxyCredentials" .) (not (include "agent.gke.autopilot" .)) }}
+            {{- if and (include "agent.httpProxyCredentials" .) }}
             - mountPath: /opt/draios/etc/secrets/http_proxy
               name: sysdig-agent-http-proxy-secrets
             {{- end }}
@@ -258,7 +258,7 @@ spec:
             {{- else }}
             secretName: {{ include "agent.accessKeySecret" . }}
             {{- end }}
-        {{- if and (include "agent.httpProxyCredentials" .) (not (include "agent.gke.autopilot" .)) }}
+        {{- if and (include "agent.httpProxyCredentials" .) }}
         - name: sysdig-agent-http-proxy-secrets
           secret:
             secretName: {{ template "agent.fullname" . }}-proxy

--- a/charts/agent/templates/secrets.yaml
+++ b/charts/agent/templates/secrets.yaml
@@ -36,7 +36,7 @@ metadata:
 data:
   {{ include "sysdig.custom_ca.keyName" (dict "global" .Values.global.ssl "component" .Values.ssl) }}: {{ include "sysdig.custom_ca.cert" (dict "global" .Values.global.ssl "component" .Values.ssl "Files" .Subcharts.common.Files) | b64enc | quote }}
 {{- end }}
-{{- if and (include "agent.httpProxyCredentials" .) (not (include "agent.gke.autopilot" .)) }}
+{{- if (include "agent.httpProxyCredentials" .) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/agent/tests/gke_autopilot_volumes_test.yaml
+++ b/charts/agent/tests/gke_autopilot_volumes_test.yaml
@@ -141,13 +141,34 @@ tests:
       - isNull:
           path: spec.template.spec.volumes[?(@.hostPath.path =~ /\/.*/ && @.hostPath.path != "/usr" && @.hostPath.path != "/run" && @.hostPath.path != "/dev" && @.hostPath.path != "/proc" && @.hostPath.path != "/etc/os-release" && @.hostPath.path != "/boot" && @.hostPath.path != "/var/run/containerd/containerd.sock")]
 
-  - it: Ensure the SYSDIG_AGENT_DRIVER env var is not set
+  - it: Ensure the SYSDIG_AGENT_DRIVER env var is set to legacy_ebpf when running on GKE Autopilot (default)
     set:
       gke:
         autopilot:
           enabled: true
     asserts:
-      - isNull:
-          path: spec.template.spec.initContainer[0].env[?(@.name != "SYSDIG_BPF_PROBE")]
-      - isNull:
-          path: spec.template.spec.containers[0].env[?(@.name != "SYSDIG_BPF_PROBE" && @.name != "K8S_NODE")]
+      - exists:
+          path: spec.template.spec.containers[0].env[?(@.name == "SYSDIG_BPF_PROBE")]
+      - isNullOrEmpty:
+          path: spec.template.spec.containers[0].env[?(@.name == "SYSDIG_BPF_PROBE")].value
+      - exists:
+          path: spec.template.spec.containers[0].env[?(@.name == "SYSDIG_AGENT_DRIVER")]
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
+          value: legacy_ebpf
+
+  - it: Ensure the SYSDIG_AGENT_DRIVER env var is set to universal_ebpf when running on GKE Autopilot (user defined)
+    set:
+      gke:
+        autopilot:
+          enabled: true
+      ebpf:
+        kind: universal_ebpf
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].env[?(@.name == "SYSDIG_BPF_PROBE")].value
+      - exists:
+          path: spec.template.spec.containers[0].env[?(@.name == "SYSDIG_AGENT_DRIVER")]
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "SYSDIG_AGENT_DRIVER")].value
+          value: universal_ebpf

--- a/charts/agent/tests/readiness_probe_test.yaml
+++ b/charts/agent/tests/readiness_probe_test.yaml
@@ -18,10 +18,7 @@ kubernetesProvider:
       nodeInfo:
         osImage: fake-os-image
 tests:
-  - it: "[DaemonSet] Readiness Probe (agent > 12.18.0)"
-    set:
-      image:
-        tag: 12.18.1
+  - it: "[DaemonSet] Readiness Probe"
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe
@@ -34,10 +31,11 @@ tests:
              periodSeconds: 10
              failureThreshold: 9
     template: templates/daemonset.yaml
-  - it: "[DaemonSet] Readiness Probe (agent == 12.18.0)"
+
+  - it: "[DelegatedAgentDeployment] Readiness Probe"
     set:
-      image:
-        tag: 12.18.0
+      delegatedAgentDeployment:
+        enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe
@@ -46,150 +44,6 @@ tests:
               host: 127.0.0.1
               path: /healthz
               port: 24483
-            initialDelaySeconds: 90
-            periodSeconds: 10
-            failureThreshold: 9
-    template: templates/daemonset.yaml
-  - it: "[DaemonSet] Readiness Probe (agent < 12.18.0)"
-    set:
-      image:
-        tag: 12.16.3
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe
-          value:
-            exec:
-              command:
-                - test
-                - -e
-                - /opt/draios/logs/running
-            initialDelaySeconds: 90
-            periodSeconds: 10
-            failureThreshold: 9
-    template: templates/daemonset.yaml
-  - it: "[DaemonSet] Readiness Probe (agent == dev)"
-    set:
-      image:
-        tag: dev
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe
-          value:
-            exec:
-              command:
-                - test
-                - -e
-                - /opt/draios/logs/running
-            initialDelaySeconds: 90
-            periodSeconds: 10
-            failureThreshold: 9
-    template: templates/daemonset.yaml
-  - it: "[DaemonSet] Readiness Probe (agent == latest)"
-    set:
-      image:
-        tag: latest
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe
-          value:
-            exec:
-              command:
-                - test
-                - -e
-                - /opt/draios/logs/running
-            initialDelaySeconds: 90
-            periodSeconds: 10
-            failureThreshold: 9
-    template: templates/daemonset.yaml
-  - it: "[DelegatedAgentDeployment] Readiness Probe (agent > 12.18.0)"
-    set:
-      delegatedAgentDeployment:
-        enabled: true
-      image:
-        tag: 12.18.1
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe
-          value:
-            httpGet:
-              host: 127.0.0.1
-              path: /healthz
-              port: 24483
-            initialDelaySeconds: 90
-            periodSeconds: 10
-            failureThreshold: 9
-
-  - it: "[DelegatedAgentDeployment] Readiness Probe (agent == 12.18.0)"
-    set:
-      delegatedAgentDeployment:
-        enabled: true
-      image:
-        tag: 12.18.0
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe
-          value:
-            httpGet:
-              host: 127.0.0.1
-              path: /healthz
-              port: 24483
-            initialDelaySeconds: 90
-            periodSeconds: 10
-            failureThreshold: 9
-
-  - it: "[DelegatedAgentDeployment] Readiness Probe (agent < 12.18.0)"
-    set:
-      delegatedAgentDeployment:
-        enabled: true
-      image:
-        tag: 12.16.3
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe
-          value:
-            exec:
-              command:
-                - test
-                - -e
-                - /opt/draios/logs/running
-            initialDelaySeconds: 90
-            periodSeconds: 10
-            failureThreshold: 9
-
-  - it: "[DelegatedAgentDeployment] Readiness Probe (agent == dev)"
-    set:
-      delegatedAgentDeployment:
-        enabled: true
-      image:
-        tag: dev
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe
-          value:
-            exec:
-              command:
-                - test
-                - -e
-                - /opt/draios/logs/running
-            initialDelaySeconds: 90
-            periodSeconds: 10
-            failureThreshold: 9
-
-  - it: "[DelegatedAgentDeployment] Readiness Probe (agent == latest)"
-    set:
-      delegatedAgentDeployment:
-        enabled: true
-      image:
-        tag: latest
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe
-          value:
-            exec:
-              command:
-                - test
-                - -e
-                - /opt/draios/logs/running
             initialDelaySeconds: 90
             periodSeconds: 10
             failureThreshold: 9
@@ -218,40 +72,3 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.failureThreshold
           value: 10
-
-  - it: "Do not use the HTTP Readiness Probe on GKE Autopilot"
-    set:
-      global:
-        gke:
-          autopilot: true
-    template: templates/daemonset.yaml
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[*].readinessProbe
-          value:
-            exec:
-              command:
-                - test
-                - -e
-                - /opt/draios/logs/running
-            initialDelaySeconds: 90
-            periodSeconds: 10
-            failureThreshold: 9
-
-  - it: "Do not use the HTTP Readiness Probe on GKE Autopilot"
-    set:
-      gke:
-        autopilot: true
-    template: templates/daemonset.yaml
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[*].readinessProbe
-          value:
-            exec:
-              command:
-                - test
-                - -e
-                - /opt/draios/logs/running
-            initialDelaySeconds: 90
-            periodSeconds: 10
-            failureThreshold: 9

--- a/charts/agent/tests/secrets_test.yaml
+++ b/charts/agent/tests/secrets_test.yaml
@@ -73,19 +73,3 @@ tests:
           path: data.proxy_password
           value: cGFzc3dvcmQ=
         documentIndex: 1
-
-  - it: Should not create proxy secret with http_proxy settings and autopilot enabled
-    set:
-      sysdig:
-        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
-        settings:
-          http_proxy:
-            proxy_user: username
-            proxy_password: password
-      gke:
-        autopilot: true
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Secret

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -112,17 +112,21 @@ tests:
     templates:
       - daemonset.yaml
 
-  - it: Ensure agent http proxy volume is not mounted when http_proxy settings is not set
+  - it: Ensure agent http proxy volume is mounted as optional
     set:
       sysdig:
         accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
       delegatedAgentDeployment:
         enabled: true
     asserts:
-      - isNull:
-          path: spec.template.spec.volumes[?(@.name == "sysdig-agent-http-proxy-secrets")]
-      - isNull:
-          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "sysdig-agent-http-proxy-secrets")]
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "sysdig-agent-http-proxy-secrets")].secret
+          value:
+            secretName: RELEASE-NAME-agent-proxy
+            optional: true
+      - equal:
+          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "sysdig-agent-http-proxy-secrets")].mountPath
+          value: /opt/draios/etc/secrets/http_proxy
     templates:
       - deployment.yaml
       - daemonset.yaml
@@ -142,6 +146,7 @@ tests:
           path: spec.template.spec.volumes[?(@.name == "sysdig-agent-http-proxy-secrets")].secret
           value:
             secretName: RELEASE-NAME-agent-proxy
+            optional: true
       - equal:
           path: spec.template.spec.containers[*].volumeMounts[?(@.name == "sysdig-agent-http-proxy-secrets")].mountPath
           value: /opt/draios/etc/secrets/http_proxy

--- a/charts/agent/tests/volumes_test.yaml
+++ b/charts/agent/tests/volumes_test.yaml
@@ -127,27 +127,6 @@ tests:
       - deployment.yaml
       - daemonset.yaml
 
-  - it: Ensure agent http proxy volume is not mounted when http_proxy settings is set and autopilot is enabled
-    set:
-      sysdig:
-        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
-        settings:
-          http_proxy:
-            proxy_user: username
-            proxy_password: password
-      delegatedAgentDeployment:
-        enabled: true
-      gke:
-        autopilot: true
-    asserts:
-      - isNull:
-          path: spec.template.spec.volumes[?(@.name == "sysdig-agent-http-proxy-secrets")]
-      - isNull:
-          path: spec.template.spec.containers[*].volumeMounts[?(@.name == "sysdig-agent-http-proxy-secrets")]
-    templates:
-      - deployment.yaml
-      - daemonset.yaml
-
   - it: Ensure agent http proxy volume is mounted when http_proxy settings is set
     set:
       delegatedAgentDeployment:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
