### PR TITLE
 feat(node-analyzer): Added replication controllers to the list of inspected resources

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.31.0
+version: 1.31.1
 appVersion: 12.9.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/clusterrole-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/clusterrole-node-analyzer.yaml
@@ -42,6 +42,7 @@ rules:
     - pods/log
     - secrets
     - serviceaccounts
+    - replicationcontrollers
   verbs:
     - get
     - list


### PR DESCRIPTION
## What this PR does / why we need it:

Adds the replication controllers resource under the set of resources that can be get/list/watch-ed by the node-analyzer

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
