### PR TITLE
fix(node-analyzer): Reorder volume list

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.31.6
+version: 1.31.7
 appVersion: 12.9.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/securitycontextconstraint.yaml
+++ b/charts/node-analyzer/templates/securitycontextconstraint.yaml
@@ -35,9 +35,9 @@ supplementalGroups:
 users:
 - system:serviceaccount:{{ .Release.Namespace }}:{{ template "nodeAnalyzer.serviceAccountName" .}}
 volumes:
-- hostPath
-- emptyDir
-- secret
 - configMap
 - downwardAPI
+- emptyDir
+- hostPath
+- secret
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:
OpenShift stores the volume list in alphabetical order. To avoid unnecessary reconcile runs when using GitOps - align the order in helm chart with OpenShift expected order.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

<!-- Check Contribution guidelines in README.md for more insight. -->
