### PR TITLE
chore: update helm-unittest plugin to version 0.6.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ lint:
 	docker run --rm -e CT_VALIDATE_MAINTAINERS=false -u $(shell id -u) -v $(PWD):/charts quay.io/helmpack/chart-testing:latest sh -c "cd /charts; ct lint --target-branch=main --all"
 
 deps-unittest:
-	@helm plugin install https://github.com/helm-unittest/helm-unittest --version=0.5.1 || true
+	@helm plugin install https://github.com/helm-unittest/helm-unittest --version=0.6.1 || true
 
 unittest: deps-unittest
 	find ./charts -name "Chart.yaml" | \
 		xargs -L1 dirname | \
 		xargs -I% sh -c \
-			"helm dependency build % ; helm unittest --strict %"
+			"helm dependency build % ; helm unittest --strict -f "tests/**/*_test.yaml" %"
 
 unit-test-rs: deps-unittest
 	find ./charts/registry-scanner -name "Chart.yaml" | \


### PR DESCRIPTION
## What this PR does / why we need it:

 - update helm-unittest plugin to version 0.6.1

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
