### PR TITLE
fix(sysdig-deploy): cluster-shield check for posture does not properly check the global kspm flag

### DIFF
--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.64.5
+version: 1.64.6
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com

--- a/charts/sysdig-deploy/templates/cluster-shield-check.yaml
+++ b/charts/sysdig-deploy/templates/cluster-shield-check.yaml
@@ -58,7 +58,7 @@
       {{- end -}}
     {{- end -}}
 
-    {{- if and $postureEnabled .Values.global.kspm $kspmCollectorEnabled -}}
+    {{- if and $postureEnabled .Values.global.kspm.deploy $kspmCollectorEnabled -}}
       {{ fail "Cannot enable both cluster_shield.features.posture and kspmCollector" }}
     {{- end -}}
   {{- end -}}

--- a/charts/sysdig-deploy/tests/cluster_shield_constraint_test.yaml
+++ b/charts/sysdig-deploy/tests/cluster_shield_constraint_test.yaml
@@ -206,6 +206,30 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: Should not fail fail when both posture and kspmCollector are enabled but global kspm deploy is disabled
+    set:
+      global:
+        kspm:
+          deploy: false
+      admissionController:
+        enabled: true
+        features:
+          kspmAdmissionController: true
+          k8sAuditDetections: true
+      clusterScanner:
+        enabled: true
+      kspmCollector:
+        enabled: true
+      clusterShield:
+        enabled: true
+        cluster_shield:
+          features:
+            posture:
+              enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: Should fail when both container vulnerability management and clusterScanner are enabled
     set:
       global:


### PR DESCRIPTION
## What this PR does / why we need it:

A check required by cluster-shield for posture does not properly check the global kspm flag.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
