### PR TITLE
feat(node-analyzer): Allow setting parameters for all probes in DaemonSet

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.31.6
+version: 1.32.0
 appVersion: 12.9.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
+++ b/charts/node-analyzer/templates/daemonset-node-analyzer.yaml
@@ -661,14 +661,14 @@ spec:
           httpGet:
             port: {{ .Values.nodeAnalyzer.runtimeScanner.probesPort }}
             path: /probes/liveness
-          initialDelaySeconds: 90
-          periodSeconds: 3
+          initialDelaySeconds: {{ .Values.nodeAnalyzer.runtimeScanner.livenessProbe.probe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.nodeAnalyzer.runtimeScanner.livenessProbe.probe.periodSeconds }}
         readinessProbe:
           httpGet:
             port: {{ .Values.nodeAnalyzer.runtimeScanner.probesPort }}
             path: /probes/readiness
-          initialDelaySeconds: 90
-          periodSeconds: 3
+          initialDelaySeconds: {{ .Values.nodeAnalyzer.runtimeScanner.readinessProbe.probe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.nodeAnalyzer.runtimeScanner.readinessProbe.probe.periodSeconds }}
         securityContext:
             privileged: true
         resources:
@@ -808,14 +808,14 @@ spec:
           httpGet:
             port: {{ .Values.nodeAnalyzer.hostScanner.probesPort }}
             path: /probes/liveness
-          initialDelaySeconds: 90
-          periodSeconds: 3
+          initialDelaySeconds: {{ .Values.nodeAnalyzer.hostScanner.livenessProbe.probe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.nodeAnalyzer.hostScanner.livenessProbe.probe.periodSeconds }}
         readinessProbe:
           httpGet:
             port: {{ .Values.nodeAnalyzer.hostScanner.probesPort }}
             path: /probes/readiness
-          initialDelaySeconds: 90
-          periodSeconds: 3
+          initialDelaySeconds: {{ .Values.nodeAnalyzer.hostScanner.readinessProbe.probe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.nodeAnalyzer.hostScanner.readinessProbe.probe.periodSeconds }}
         securityContext:
           # The privileged flag is necessary for OCP 4.x and other Kubernetes setups that deny host filesystem access to
           # running containers by default regardless of volume mounts.

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -339,6 +339,15 @@ nodeAnalyzer:
         memory: 2Gi
         ephemeral-storage: "4Gi"
 
+    readinessProbe:
+      probe:
+        initialDelaySeconds: 90
+        periodSeconds: 3
+    livenessProbe:
+      probe:
+        initialDelaySeconds: 90
+        periodSeconds: 3
+
     env: {}
 
     settings:
@@ -421,6 +430,15 @@ nodeAnalyzer:
         cpu: 150m
         memory: 150Mi
         ephemeral-storage: 250Mi
+
+    readinessProbe:
+      probe:
+        initialDelaySeconds: 90
+        periodSeconds: 3
+    livenessProbe:
+      probe:
+        initialDelaySeconds: 90
+        periodSeconds: 3
 
     env: {}
 


### PR DESCRIPTION
## What this PR does / why we need it:

It takes ages to deploy right now, because the probes are waiting an excessively long time - and we'd like to be able to make this time shorter.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
