### PR TITLE
feat(agent): create a clusterrolebinding if the clusterrole cluster-monitoring-view exists [SMAGENT-8031]

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.29.2
+version: 1.29.3

--- a/charts/agent/templates/clusterrolebinding-cluster-monitoring-view.yaml
+++ b/charts/agent/templates/clusterrolebinding-cluster-monitoring-view.yaml
@@ -1,0 +1,19 @@
+{{- if .Capabilities.APIVersions.Has "monitoring.openshift.io/v1" }}
+{{- $clusterRole := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "cluster-monitoring-view" -}}
+{{- if and .Values.rbac.create $clusterRole }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "agent.fullname" .}}-cluster-monitoring-view
+  labels:
+{{ include "agent.labels" . | indent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "agent.serviceAccountName" .}}
+    namespace: {{ include "agent.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-monitoring-view
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/charts/agent/tests/clusterrolebinding-cluster-monitoring-view-exist_test.yaml
+++ b/charts/agent/tests/clusterrolebinding-cluster-monitoring-view-exist_test.yaml
@@ -1,0 +1,54 @@
+suite: Agent Cluster Role Binding cluster-monitoring-view (exist)
+templates:
+  - templates/clusterrolebinding-cluster-monitoring-view.yaml
+kubernetesProvider:
+  scheme:
+    "rbac.authorization.k8s.io/v1/ClusterRole":
+      gvr:
+        group: "rbac.authorization.k8s.io"
+        version: "v1"
+        resource: "clusterroles"
+      namespaced: false
+  objects:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: cluster-monitoring-view
+
+tests:
+  - it: Does not create the ClusterRoleBinding if rbac.create is false
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Does not create the ClusterRoleBinding if the ClusterRole exists and monitoring.openshift.io/v1 is not supported
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Does create the ClusterRoleBinding if the ClusterRole exists and monitoring.openshift.io/v1 is supported
+    capabilities:
+      apiVersions:
+        - monitoring.openshift.io/v1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          name: RELEASE-NAME-agent-cluster-monitoring-view
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            namespace: NAMESPACE
+            name: RELEASE-NAME-agent
+      - equal:
+          path: roleRef
+          value:
+            kind: ClusterRole
+            name: cluster-monitoring-view
+            apiGroup: rbac.authorization.k8s.io

--- a/charts/agent/tests/clusterrolebinding-cluster-monitoring-view-not-exist_test.yaml
+++ b/charts/agent/tests/clusterrolebinding-cluster-monitoring-view-not-exist_test.yaml
@@ -1,0 +1,11 @@
+suite: Agent Cluster Role Binding cluster-monitoring-view (not exist)
+templates:
+  - templates/clusterrolebinding-cluster-monitoring-view.yaml
+tests:
+  - it: Does not create the ClusterRoleBinding if the ClusterRole does not exist and monitoring.openshift.io/v1 is supported
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## What this PR does / why we need it:

Create a `ClusterRoleBinding` if a `ClusterRole` named `cluster-monitoring-view` exists

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
