### PR TITLE
fix(shield): allow accesskey to be null in case access_key_existing_secret is set

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "1.0.0"

--- a/charts/shield/values.schema.json
+++ b/charts/shield/values.schema.json
@@ -85,7 +85,7 @@
       "type": "object",
       "properties": {
         "access_key": {
-          "type": "string",
+          "type": [ "string", "null" ],
           "description": "Sysdig Agent Access Key",
           "examples": [
             "12345678-1234-1234-1234-123456789012"


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ x ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ x ] Chart Version bumped for the respective charts
- [ x ] Variables are documented in the README.md (or README.tpl in some charts)
- [ x ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ x ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
