### PR TITLE
feat(agent,node-analyzer,kspm-collector): Allow to skip test execution via config file

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.29.6
+version: 1.29.7

--- a/charts/agent/templates/tests/test-rollout.yaml
+++ b/charts/agent/templates/tests/test-rollout.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.tests.skip }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -27,3 +28,4 @@ spec:
       - -w
       - --timeout={{ .Values.tests.timeout }}
   restartPolicy: Never
+{{- end }}

--- a/charts/agent/tests/test_test.yaml
+++ b/charts/agent/tests/test_test.yaml
@@ -1,0 +1,19 @@
+suite: Test Agent tests
+templates:
+  - tests/test-rollout.yaml
+
+tests:
+  - it: "Check that test are executed by deafult"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Pod
+
+  - it: "Check that test are not included when skip is set"
+    set:
+      tests:
+        skip: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -397,6 +397,7 @@ ssl:
     # Provide the filename that is defined inside the existing ConfigMap
     existingCaConfigMapKeyName: null
 tests:
+  skip: false
   timeout: 300s
   image:
     repo: bitnami/kubectl

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
-version: 0.16.3
+version: 0.16.4
 appVersion: 1.39.4
 keywords:
   - monitoring

--- a/charts/kspm-collector/templates/tests/test-rollout.yaml
+++ b/charts/kspm-collector/templates/tests/test-rollout.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.tests.skip }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -27,3 +28,4 @@ spec:
       - -w
       - --timeout={{ .Values.tests.timeout }}
   restartPolicy: Never
+{{- end }}

--- a/charts/kspm-collector/tests/test_test.yaml
+++ b/charts/kspm-collector/tests/test_test.yaml
@@ -1,0 +1,19 @@
+suite: Test KSPM Collector tests
+templates:
+  - tests/test-rollout.yaml
+
+tests:
+  - it: "Check that test are executed by deafult"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Pod
+
+  - it: "Check that test are not included when skip is set"
+    set:
+      tests:
+        skip: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/kspm-collector/values.yaml
+++ b/charts/kspm-collector/values.yaml
@@ -213,6 +213,7 @@ ssl:
     existingCaConfigMapKeyName:
 
 tests:
+  skip: false
   timeout: 300s
   image:
     repo: bitnami/kubectl

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.32.7
+version: 1.32.8
 appVersion: 12.9.0
 keywords:
   - monitoring

--- a/charts/node-analyzer/templates/tests/test-rollout.yaml
+++ b/charts/node-analyzer/templates/tests/test-rollout.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.tests.skip }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -27,3 +28,4 @@ spec:
       - -w
       - --timeout={{ .Values.tests.timeout }}
   restartPolicy: Never
+{{- end }}

--- a/charts/node-analyzer/tests/test_test.yaml
+++ b/charts/node-analyzer/tests/test_test.yaml
@@ -1,0 +1,21 @@
+suite: Test RuntimeScanner configuration
+templates:
+  - tests/test-rollout.yaml
+values:
+  - ./default_required_values.yaml
+
+tests:
+  - it: "Check that test are executed by deafult"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Pod
+
+  - it: "Check that test are not included when skip is set"
+    set:
+      tests:
+        skip: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -529,6 +529,7 @@ nodeAnalyzer:
     apiServerSocketPath: /run/api.sock
 
 tests:
+  skip: false
   timeout: 300s
   image:
     repo: bitnami/kubectl


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
