### PR TITLE
feat(agent): remove liveness probe in sysdig-agent-windows daemonset due to binaries unification.

### DIFF
--- a/charts/agent/templates/daemonset-windows.yaml
+++ b/charts/agent/templates/daemonset-windows.yaml
@@ -38,11 +38,19 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.windows.image.registry }}/{{ .Values.windows.image.repository }}:{{ .Values.windows.image.tag }}"
           imagePullPolicy: {{ .Values.windows.image.pullPolicy | default .Values.global.image.pullPolicy }}
+          livenessProbe:
+            httpGet:
+              host: 127.0.0.1
+              path: /healthz
+              port: 24483
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               host: 127.0.0.1
               path: /healthz
-              port: 24484
+              port: 24483
             initialDelaySeconds: 60
             timeoutSeconds: 10
           resources:

--- a/charts/agent/templates/daemonset-windows.yaml
+++ b/charts/agent/templates/daemonset-windows.yaml
@@ -38,14 +38,6 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.windows.image.registry }}/{{ .Values.windows.image.repository }}:{{ .Values.windows.image.tag }}"
           imagePullPolicy: {{ .Values.windows.image.pullPolicy | default .Values.global.image.pullPolicy }}
-          livenessProbe:
-            httpGet:
-              host: 127.0.0.1
-              path: /healthz
-              port: 24484
-            initialDelaySeconds: 60
-            periodSeconds: 30
-            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               host: 127.0.0.1


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
