### PR TITLE
fix(shield): Fix wrong config file name

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/configmap.yaml
+++ b/charts/shield/templates/host/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "host.labels" . | nindent 4 }}
 data:
-  host_shield_config.yaml: |
+  host-shield.yaml: |
     {{- include "host.host_shield_config" . | nindent 4 }}
   dragent.yaml: |
     {{- include "host.configmap" . | nindent 4 }}

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -186,9 +186,9 @@ spec:
             - mountPath: /opt/draios/etc/kubernetes/config/dragent.yaml
               name: dragent-config
               subPath: dragent.yaml
-            - mountPath: /opt/draios/etc/kubernetes/config/host_shield_config.yaml
+            - mountPath: /opt/draios/etc/kubernetes/config/host-shield.yaml
               name: host-shield-config
-              subPath: host_shield_config.yaml
+              subPath: host-shield.yaml
             - mountPath: /opt/draios/etc/kubernetes/secrets
               name: sysdig-agent-secrets
             - mountPath: /etc/podinfo
@@ -266,8 +266,8 @@ spec:
           configMap:
             name: {{ include "host.fullname" . }}
             items:
-              - key: host_shield_config.yaml
-                path: host_shield_config.yaml
+              - key: host-shield.yaml
+                path: host-shield.yaml
         - name: sysdig-agent-secrets
           secret:
             secretName: {{ include "common.credentials.access_key_secret_name" . }}

--- a/charts/shield/tests/host/configmap-host-shield-config_test.yaml
+++ b/charts/shield/tests/host/configmap-host-shield-config_test.yaml
@@ -1,4 +1,4 @@
-suite: Host - Configmap [host_shield_config.yaml]
+suite: Host - Configmap [host-shield.yaml]
 templates:
   - templates/host/configmap.yaml
 release:
@@ -17,7 +17,7 @@ tests:
   - it: Everything is disabled by default
     asserts:
       - matchRegex:
-          path: data['host_shield_config.yaml']
+          path: data['host-shield.yaml']
           pattern: |
             features:
               detections:
@@ -44,7 +44,7 @@ tests:
             enabled: true
     asserts:
       - matchRegex:
-          path: data['host_shield_config.yaml']
+          path: data['host-shield.yaml']
           pattern: |
             features:
               detections:
@@ -71,7 +71,7 @@ tests:
             enabled: false
     asserts:
       - matchRegex:
-          path: data['host_shield_config.yaml']
+          path: data['host-shield.yaml']
           pattern: |
             features:
               detections:
@@ -98,7 +98,7 @@ tests:
             enabled: true
     asserts:
       - matchRegex:
-          path: data['host_shield_config.yaml']
+          path: data['host-shield.yaml']
           pattern: |
             features:
               detections:
@@ -125,7 +125,7 @@ tests:
             enabled: false
     asserts:
       - matchRegex:
-          path: data['host_shield_config.yaml']
+          path: data['host-shield.yaml']
           pattern: |
             features:
               detections:
@@ -147,7 +147,7 @@ tests:
   - it: Host Vulnerability Management is disabled by default
     asserts:
       - matchRegex:
-          path: data['host_shield_config.yaml']
+          path: data['host-shield.yaml']
           pattern: |
             features:
               detections:
@@ -177,7 +177,7 @@ tests:
             enabled: true
     asserts:
       - matchRegex:
-          path: data['host_shield_config.yaml']
+          path: data['host-shield.yaml']
           pattern: |-
             features:
               detections:
@@ -206,7 +206,7 @@ tests:
             enabled: true
     asserts:
       - matchRegex:
-          path: data['host_shield_config.yaml']
+          path: data['host-shield.yaml']
           pattern: |-
             features:
               detections:
@@ -233,7 +233,7 @@ tests:
             enabled: true
     asserts:
       - matchRegex:
-          path: data['host_shield_config.yaml']
+          path: data['host-shield.yaml']
           pattern: |-
             features:
               detections:
@@ -260,7 +260,7 @@ tests:
             enabled: true
     asserts:
       - matchRegex:
-          path: data['host_shield_config.yaml']
+          path: data['host-shield.yaml']
           pattern: |-
             features:
               detections:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
