### PR TITLE
fix(shield): add env var and port to host shield container

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -158,6 +158,17 @@ spec:
                   key: password
             {{- end }}
             {{- include "host.env" . | nindent 12 }}
+            {{ if or .Values.features.posture.host_posture.enabled (dig "kspm_analyzer" "enabled" false .Values.host.additional_settings) }}
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
+          ports:
+            {{- if or .Values.features.posture.host_posture.enabled (dig "kspm_analyzer" "enabled" false .Values.host.additional_settings) }}
+            - containerPort: {{ dig "kspm_analyzer" "port" 12000 .Values.host.additional_settings }}
+              name: kspm-analyzer
+            {{- end }}
           readinessProbe:
             httpGet:
               host: 127.0.0.1

--- a/charts/shield/tests/host/daemonset_test.yaml
+++ b/charts/shield/tests/host/daemonset_test.yaml
@@ -551,3 +551,35 @@ tests:
           content:
             name: my-cluster-volume
             mountPath: /host/my-cluster-mount-path
+
+  - it: Ensure port and env var set when host posture is enabled
+    set:
+      features:
+        posture:
+          host_posture:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].env
+          content:
+            name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                  fieldPath: metadata.namespace
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].ports
+          content:
+            containerPort: 12000
+            name: kspm-analyzer
+
+  - it: Ensure port and env var not set when host posture is disabled
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].env
+          content:
+            name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      - isNullOrEmpty:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].ports


### PR DESCRIPTION
## What this PR does / why we need it:
When the host posture feature is enabled, ensure that the POD_NAMESPACE env var is set on the Host Shield container and that the configured port is available (12000 by default).

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
