### PR TITLE
fix(shield): apply kspm_analyzer agent app name

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_configmap_helpers.tpl
@@ -89,7 +89,7 @@
   {{- end }}
 {{- end }}
 {{- if or .Values.features.posture.host_posture.enabled (dig "kspm_analyzer" "enabled" false .Values.host.additional_settings) }}
-  {{- $config = merge $config (dict "kspm_analyzer" (dict "agent_app_name" "shield")) }}
+  {{- $config = merge $config (dict "kspm_analyzer" (dict "agent_app_name" (include "shield.name" .)) }}
 {{- end }}
 {{- if .Values.cluster_config.tags -}}
   {{- $tagList := list }}

--- a/charts/shield/templates/host/_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_configmap_helpers.tpl
@@ -88,6 +88,9 @@
     {{- $config = merge $config (dict "host_scanner" (dict "host_fs_mount_path" "/host")) }}
   {{- end }}
 {{- end }}
+{{- if or .Values.features.posture.host_posture.enabled (dig "kspm_analyzer" "enabled" false .Values.host.additional_settings) }}
+  {{- $config = merge $config (dict "kspm_analyzer" (dict "agent_app_name" "shield")) }}
+{{- end }}
 {{- if .Values.cluster_config.tags -}}
   {{- $tagList := list }}
   {{- range $k, $v := .Values.cluster_config.tags }}

--- a/charts/shield/templates/host/_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_configmap_helpers.tpl
@@ -89,7 +89,7 @@
   {{- end }}
 {{- end }}
 {{- if or .Values.features.posture.host_posture.enabled (dig "kspm_analyzer" "enabled" false .Values.host.additional_settings) }}
-  {{- $config = merge $config (dict "kspm_analyzer" (dict "agent_app_name" (include "shield.name" .)) }}
+  {{- $config = merge $config (dict "kspm_analyzer" (dict "agent_app_name" (include "shield.name" .))) }}
 {{- end }}
 {{- if .Values.cluster_config.tags -}}
   {{- $tagList := list }}

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -886,3 +886,37 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             tags: AgentTag3:AgentTagValue3,agentTag1:agentTagValue1,agentTag2:agentTagValue2
+
+  - it: Enabling Host Posture sets the agent app version setting
+    set:
+      features:
+        posture:
+          host_posture:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            kspm_analyzer:
+              agent_app_name: shield
+
+  - it: Enabling Host Posture via additional_settings sets the agent app version setting
+    set:
+      host:
+        additional_settings:
+          kspm_analyzer :
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            kspm_analyzer:
+              agent_app_name: shield
+
+  - it: The agent_app_setting field is not present if host posture is not enabled
+    asserts:
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            kspm_analyzer:
+              agent_app_name: shield


### PR DESCRIPTION
## What this PR does / why we need it:
The kspm analyzer requires the `agent_app_name` parameter to be set to the value given to the `app.kubernetes.io/name` label on the host shield pod, which is `shield` when installed via the shield chart.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
