### PR TITLE
fix(shield): add pull secrets to host shield daemonset

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -34,6 +34,8 @@ spec:
         {{- include "host.affinity" . | nindent 8 }}
       nodeSelector:
         {{- include "host.node_selector" . | nindent 8 }}
+      imagePullSecrets:
+        {{- toYaml .Values.host.image.pull_secrets | nindent 8 }}
       {{- if not (include "host.driver.is_universal_ebpf" .) }}
       initContainers:
         - name: sysdig-host-shield-kmodule

--- a/charts/shield/tests/host/daemonset_test.yaml
+++ b/charts/shield/tests/host/daemonset_test.yaml
@@ -583,3 +583,33 @@ tests:
                 fieldPath: metadata.namespace
       - isNullOrEmpty:
           path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].ports
+
+  - it: Image pull secrets are populated
+    set:
+      host:
+        image:
+          pull_secrets:
+            - name: my-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: my-secret
+
+  - it: Multiple pull secrets
+    set:
+      host:
+        image:
+          pull_secrets:
+            - name: my-secret
+            - name: my-other-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: my-secret
+            - name: my-other-secret
+
+  - it: Pull secrets are empty if none provided
+    asserts:
+      - isNullOrEmpty:
+          path: spec.template.spec.imagePullSecrets


### PR DESCRIPTION
## What this PR does / why we need it:
Image pull secrets were being inadvertently omitted from the host shield damonset.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
