### PR TITLE
feat(ci): extend agent update pipeline for shield chart

### DIFF
--- a/.github/updatecli.d/config-agent-release.yaml
+++ b/.github/updatecli.d/config-agent-release.yaml
@@ -1,4 +1,4 @@
-name: update sysdig and agent charts for new agent release
+name: update shield and agent charts for new host-shield release
 
 scms:
   github:
@@ -18,11 +18,11 @@ actions:
     scmid: "github"
     spec:
       automerge: true
-      description: 'bump agent image tags for `agent` and `sysdig` charts to {{ requiredEnv "AGENT_RELEASE" }}'
+      description: 'bump agent image tags for `agent` and `shield` charts to {{ requiredEnv "AGENT_RELEASE" }}'
       labels:
         - "automated PR"
       mergemethod: squash
-      title: 'feat: release agent {{ requiredEnv "AGENT_RELEASE" }}'
+      title: 'feat(agent,shield): release agent {{ requiredEnv "AGENT_RELEASE" }}'
 
 sources:
   agentRelease:
@@ -35,22 +35,23 @@ sources:
         pattern: '[0-9]+\.[0-9]+\.[0-9]+$'
 
 targets:
-  updateAgentChartValues:
-    name: "update agent tag in agent chart"
-    kind: yaml
-    scmid: github
-    spec:
-      file: "charts/agent/values.yaml"
-      key: "$.image.tag"
-
-  bumpAgentChart:
-    name: "bump the chart version of the agent chart"
+  updateAgentChart:
+    name: "update the agent chart"
     kind: helmchart
     scmid: github
-    dependson:
-      - updateAgentChartValues
     spec:
       name: "charts/agent"
-      file: Chart.yaml
-      key: "$.appVersion"
-      versionincrement: patch
+      file: values.yaml
+      key: "$.image.tag"
+      appVersion: true
+      versionincrement: auto
+
+  updateShieldChart:
+    name: "update the the shield chart"
+    kind: helmchart
+    scmid: github
+    spec:
+      name: "charts/shield"
+      file: values.yaml
+      key: "$.host.image.tag"
+      versionincrement: auto


### PR DESCRIPTION
## What this PR does / why we need it:
* The shield chart will now be updated when a new agent release occurs
* Resolve issue where agent chart updates did not update the chart version

#### updatecli target output for simulated 13.6.0 release
```
TARGETS
========

updateShieldChart
------------------------

**Dry Run enabled**

⚠ - change detected:
	* key "$.host.image.tag" should be updated from "13.5.0" to "13.6.0", in file "charts/shield/values.yaml"
change detected:
	* key "$.version" should be updated from "0.1.13" to "0.2.0", in file "charts/shield/Chart.yaml"

updateAgentChart
--------------

**Dry Run enabled**

⚠ - change detected:
	* key "$.image.tag" should be updated from "13.5.0" to "13.6.0", in file "charts/agent/values.yaml"
change detected:
	* key "$.appVersion" should be updated from "13.5.0" to "13.6.0", in file "charts/agent/Chart.yaml"
change detected:
	* key "$.version" should be updated from "1.30.0" to "1.31.0", in file "charts/agent/Chart.yaml"
```

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)

<!-- Check Contribution guidelines in README.md for more insight. -->
