### PR TITLE
chore(rh-shield-operator): add dependabot config to bump helm-operator base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
       - "draios/team-tools-agent"
     labels:
       - "dependencies"
+  - package-ecosystem: docker
+    directory: "/rh-shield-operator"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "draios/team-tools-agent"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## What this PR does / why we need it:
Automate the process of updating the base image of the `rh-shield-operator` container image.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)

<!-- Check Contribution guidelines in README.md for more insight. -->
