### PR TITLE
fix(rh-shield-operator): remove '*' from actions/checkout param

### DIFF
--- a/.github/workflows/release-rh-shield-operator.yaml
+++ b/.github/workflows/release-rh-shield-operator.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: '1'
-          sparse-checkout: 'rh-shield-operator/*'
+          sparse-checkout: 'rh-shield-operator/'
 
       - name: Login to Docker registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## What this PR does / why we need it:
the 'sparse-checkout' field does not accept wildcard characters. resolves the following issue:

```
/usr/bin/git sparse-checkout set rh-shield-operator/*
Error: fatal: specify directories rather than patterns.  If your directory really has any of '*?[]\' in it, pass --skip-checks
Error: The process '/usr/bin/git' failed with exit code 128
```
## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)

<!-- Check Contribution guidelines in README.md for more insight. -->
