### PR TITLE
fix(rh-shield-operator): remove duplicate '$' in variable dereference

### DIFF
--- a/.github/workflows/release-rh-shield-operator.yaml
+++ b/.github/workflows/release-rh-shield-operator.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build and Push Operator and Bundle Images
         env:
-          IMAGE_TAG_BASE: $${{ secrets.QUAY_RH_SHIELD_OPERATOR_IMAGE_TAG_BASE }}
+          IMAGE_TAG_BASE: ${{ secrets.QUAY_RH_SHIELD_OPERATOR_IMAGE_TAG_BASE }}
           VERSION: ${{ github.event.inputs.release_version }}
         run: |
           make docker-build docker-push bundle-build bundle-push


### PR DESCRIPTION
## What this PR does / why we need it:
Remove the duplicate $ in the `IMAGE_TAG_BASE` variable pass through. This was causing the leading character of the container image name to be dropped during the push phase.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)

<!-- Check Contribution guidelines in README.md for more insight. -->
