### PR TITLE
feat(rh-shield-operator): prepare for v0.1.2

### DIFF
--- a/rh-shield-operator/Makefile
+++ b/rh-shield-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.1.1
+VERSION ?= 0.1.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/rh-shield-operator/bundle/manifests/rh-shield-operator.clusterserviceversion.yaml
+++ b/rh-shield-operator/bundle/manifests/rh-shield-operator.clusterserviceversion.yaml
@@ -368,16 +368,16 @@ metadata:
           }
         }
       ]
-    capabilities: SeamlessUpgrades
+    capabilities: Basic Install
     categories: Security, Monitoring
-    createdAt: "2024-11-07T18:47:53Z"
+    createdAt: "2024-11-08T14:23:41Z"
     description: |
       The Sysdig Shield Operator provides a way to deploy Sysdig Shield components on an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.36.1
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/sysdiglabs/charts
     support: https://sysdig.com
-  name: rh-shield-operator.v0.1.1
+  name: rh-shield-operator.v0.1.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -434,6 +434,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - '*'
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -525,7 +531,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=rh-shield-operator
-                image: quay.io/sysdig/rh-shield-operator:v0.1.1
+                image: quay.io/sysdig/rh-shield-operator:v0.1.2
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -542,7 +548,7 @@ spec:
                 resources:
                   limits:
                     cpu: 500m
-                    memory: 128Mi
+                    memory: 256Mi
                   requests:
                     cpu: 10m
                     memory: 64Mi
@@ -629,4 +635,4 @@ spec:
   provider:
     name: Sysdig
     url: https://sysdig.com
-  version: 0.1.1
+  version: 0.1.2

--- a/rh-shield-operator/config/manager/kustomization.yaml
+++ b/rh-shield-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/sysdig/rh-shield-operator
-  newTag: v0.1.1
+  newTag: v0.1.2

--- a/rh-shield-operator/config/manager/manager.yaml
+++ b/rh-shield-operator/config/manager/manager.yaml
@@ -85,7 +85,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 256Mi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/rh-shield-operator/config/manifests/bases/rh-shield-operator.clusterserviceversion.yaml
+++ b/rh-shield-operator/config/manifests/bases/rh-shield-operator.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[]'
-    capabilities: SeamlessUpgrades
+    capabilities: Basic Install
     categories: Security, Monitoring
     description: |
       The Sysdig Shield Operator provides a way to deploy Sysdig Shield components on an OpenShift cluster.

--- a/rh-shield-operator/config/rbac/role.yaml
+++ b/rh-shield-operator/config/rbac/role.yaml
@@ -48,6 +48,12 @@ rules:
 - verbs:
   - "*"
   apiGroups:
+  - "security.openshift.io"
+  resources:
+  - "securitycontextconstraints"
+- verbs:
+  - "*"
+  apiGroups:
   - "rbac.authorization.k8s.io"
   resources:
   - "clusterrolebindings"


### PR DESCRIPTION
## What this PR does / why we need it:
* Fix permissions issues around security context  constraints
* Update memory limit to 256Mi to prevent possible OOM kill of operator manager when processing CRDs

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)

<!-- Check Contribution guidelines in README.md for more insight. -->
