### PR TITLE
fix(shield): touch up custom port formatting

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.1.14
+version: 0.1.15
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/_config.tpl
+++ b/charts/shield/templates/cluster/_config.tpl
@@ -40,7 +40,7 @@
         {{- end -}}
     {{- end -}}
     {{- if and .Values.sysdig_endpoint.collector.host .Values.sysdig_endpoint.collector.port -}}
-      {{- $_ := set $sysdigEndpointConfig "collector" (printf "%s:%.0f" .Values.sysdig_endpoint.collector.host .Values.sysdig_endpoint.collector.port) -}}
+      {{- $_ := set $sysdigEndpointConfig "collector" (printf "%s:%d" .Values.sysdig_endpoint.collector.host (.Values.sysdig_endpoint.collector.port | int)) -}}
     {{- end -}}
     {{- $_ := set $config "sysdig_endpoint" $sysdigEndpointConfig -}}
     {{- $_ := set $config "cluster_config" (dict "name" .Values.cluster_config.name) -}}


### PR DESCRIPTION
## What this PR does / why we need it:
adjust the custom port formatting logic for cluster shield to prevent occasional formatting issues in the configmap.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
