### PR TITLE
fix(shield): update custom CA path in host shield config

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.1.15
+version: 0.1.16
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -24,6 +24,9 @@ If release name contains chart name it will be used as a full name.
     {{- $host := split ":" $parsedProxyConfig.host -}}
     {{- $_ := set $proxyConfig "proxy_host" $host._0 -}}
     {{- $_ := set $proxyConfig "proxy_port" $host._1 -}}
+    {{- if or .Values.ssl.ca.key_name .Values.ssl.ca.existing_ca_secret_key_name }}
+      {{- $_ = set $proxyConfig "ca_certificate" (printf "certificates/%s" (include "common.custom_ca.key_name" .)) }}
+    {{- end }}
     {{- $proxyConfig | toYaml -}}
 {{- end -}}
 {{- end -}}

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -24,8 +24,8 @@ If release name contains chart name it will be used as a full name.
     {{- $host := split ":" $parsedProxyConfig.host -}}
     {{- $_ := set $proxyConfig "proxy_host" $host._0 -}}
     {{- $_ := set $proxyConfig "proxy_port" $host._1 -}}
-    {{- if or .Values.ssl.ca.key_name .Values.ssl.ca.existing_ca_secret_key_name }}
-      {{- $_ = set $proxyConfig "ca_certificate" (printf "certificates/%s" (include "common.custom_ca.key_name" .)) }}
+    {{- if (include "common.custom_ca.enabled" .) }}
+      {{- $_ = set $proxyConfig "ca_certificate" (include "common.custom_ca.path" (mergeOverwrite . (dict "CACertsPath" "certificates/"))) }}
     {{- end }}
     {{- $proxyConfig | toYaml -}}
 {{- end -}}

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -920,3 +920,34 @@ tests:
           pattern: |
             kspm_analyzer:
               agent_app_name: shield
+
+  - it: Test with Custom CA In Values
+    set:
+      proxy:
+        https_proxy: "https://proxy.example.com:8080"
+      ssl:
+        ca:
+          certs:
+            - "test certificate"
+          key_name: "custom-ca-from-values.crt"
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            http_proxy:
+              ca_certificate: certificates/custom-ca-from-values.crt
+
+  - it: Test with Custom CA In Existing Secret
+    set:
+      proxy:
+        https_proxy: "https://proxy.example.com:8080"
+      ssl:
+        ca:
+          existing_ca_secret: "fake-secret-name"
+          existing_ca_secret_key_name: "custom-ca-from-secret.crt"
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            http_proxy:
+              ca_certificate: certificates/custom-ca-from-secret.crt


### PR DESCRIPTION
## What this PR does / why we need it:
The shield chart places custom CA certificates in `/opt/draios/certificates` with a filename that matches either the `ssl.ca.key_name` or `ssl.ca.existing_ca_secret_key_name` values. This change causes the chart to set the host shield's `http_proxy.ca_certificate` setting to match the expected location.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
