### PR TITLE
fix(shield): add lease rule for host shield role

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.1.16
+version: 0.1.17
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/role.yaml
+++ b/charts/shield/templates/host/role.yaml
@@ -10,5 +10,15 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-rules: []
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
 {{- end }}

--- a/charts/shield/tests/host/role_test.yaml
+++ b/charts/shield/tests/host/role_test.yaml
@@ -1,0 +1,68 @@
+suite: Host - Role
+templates:
+  - templates/host/role.yaml
+release:
+  name: release-name
+  namespace: shield-namespace
+values:
+  - ../values/base.yaml
+tests:
+  - it: Create the Role when requested
+    set:
+      host:
+        rbac:
+          create: true
+    asserts:
+      - isKind:
+          of: Role
+          count: 1
+      - equal:
+          path: metadata.name
+          value: release-name-shield-host
+      - equal:
+          path: metadata.namespace
+          value: shield-namespace
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - watch
+
+  - it: Ensure the Role is not created when not requested
+    set:
+      host:
+        rbac:
+          create: false
+    asserts:
+      - hasDocuments:
+        count: 0
+
+  - it: Check that labels and annotations are added
+    set:
+      host:
+        rbac:
+          create: true
+          labels:
+            app.kubernetes.io/name: shield
+            app.kubernetes.io/instance: release-name
+          annotations:
+            app.kubernetes.io/description: "This is a test"
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/name: shield
+            app.kubernetes.io/instance: release-name
+
+      - isSubset:
+          path: metadata.annotations
+          content:
+            app.kubernetes.io/description: "This is a test"


### PR DESCRIPTION
## What this PR does / why we need it:
required for cointerface component when configured for delegation process.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
