### PR TITLE
feat(shield): set host shield to secure_light by default

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.1.19
+version: 0.1.20
 appVersion: "1.0.0"

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -951,3 +951,79 @@ tests:
           pattern: |
             http_proxy:
               ca_certificate: certificates/custom-ca-from-secret.crt
+
+  - it: Test secure_light by default
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            feature:
+              mode: secure_light
+
+  - it: Test manual override of feature mode
+    set:
+      features:
+        monitoring:
+          app_checks:
+            enabled: true
+      host:
+        additional_settings:
+          feature:
+            mode: troubleshooting
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            feature:
+              mode: troubleshooting
+
+  - it: Test enabling NetSec flips agent to secure mode
+    set:
+      features:
+        investigations:
+          network_security:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            feature:
+              mode: secure
+
+  - it: Test enabling NetSec in additional_settings flips agent to secure mode
+    set:
+      host:
+        additional_settings:
+          network_topology:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            feature:
+              mode: secure
+
+  - it: Test enabling a monitor feature forces agent mode to monitor
+    set:
+      features:
+        monitoring:
+          app_checks:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            feature:
+              mode: monitor
+
+  - it: Test enabling a monitor feature in additional_settings forces agent mode to monitor
+    set:
+      host:
+        additional_settings:
+          app_checks_enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            feature:
+              mode: monitor


### PR DESCRIPTION
## What this PR does / why we need it:
The host shield feature mode will now default to `secure_light`. This can be overridden in one of three ways.

1) Explicitly overriding the value by setting `host.additional_settings.feature.mode`
   to something else.
2) Enabling `features.investigations.network_security.enabled` will change the mode
   to `secure`.
3) Enabling any feature under `features.monitoring` will set the mode to `monitor`
   regardless of the secure features enabled.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
