### PR TITLE
feat(shield): validate proxy protocols via values schema

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.2.2
+version: 0.2.4
 appVersion: "1.0.0"

--- a/charts/shield/values.schema.json
+++ b/charts/shield/values.schema.json
@@ -29,6 +29,9 @@
     },
     "volume_mounts": {
       "$ref": "#/$defs/VolumeMounts"
+    },
+    "proxy": {
+      "$ref": "#/$defs/Proxy"
     }
   },
   "required": [
@@ -1015,6 +1018,38 @@
           "mountPath"
         ]
       }
+    },
+    "Proxy": {
+      "type": "object",
+      "properties": {
+        "http_proxy": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "HTTP Proxy URL"
+        },
+        "http_proxy_existing_secret": {
+          "type": ["string", "null"],
+          "description": "The name of the secret containing the HTTP Proxy URL"
+        },
+        "https_proxy": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "HTTPS Proxy URL"
+        },
+        "https_proxy_existing_secret": {
+          "type": ["string", "null"],
+          "description": "The name of the secret containing the HTTPS Proxy URL"
+        },
+        "no_proxy": {
+          "type": ["string", "null"],
+          "description": "No Proxy URL"
+        },
+        "no_proxy_existing_secret": {
+          "type": ["string", "null"],
+          "description": "The name of the secret containing the No Proxy URL"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }


### PR DESCRIPTION
## What this PR does / why we need it:
Enforce that when proxy configurations are given, the protocol type is present in the url.

Additionally ensure that 'null' is allowed for the situations where the chart default values are provided.

Ex.
```
proxy:
  https_proxy: https://example.com
  http_proxy: http://example.com
```

```
proxy:
  http_proxy: null
```

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

<!-- Check Contribution guidelines in README.md for more insight. -->
