### PR TITLE
feat(shield): only specify collector port if given in config

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_configmap_helpers.tpl
@@ -100,12 +100,14 @@ true
 {{- $config := dict
   "k8s_cluster_name" .Values.cluster_config.name
   "collector" (include "common.collector_endpoint" .)
-  "collector_port" .Values.sysdig_endpoint.collector.port
 }}
 {{- if .Values.features.kubernetes_metadata.enabled }}
   {{- $_ := set $config "k8s_delegated_nodes" (dig "k8s_delegated_nodes" 0 .Values.host.additional_settings) -}}
 {{- else if hasKey .Values.host.additional_settings "k8s_delegated_nodes" }}
   {{- $_ := set $config "k8s_delegated_nodes" (get $config "k8s_delegated_nodes") }}
+{{- end }}
+{{- if .Values.sysdig_endpoint.collector.port }}
+{{- $config = merge $config (dict "collector_port" .Values.sysdig_endpoint.collector.port) }}
 {{- end }}
 {{- $config = merge $config (dict "sysdig_api_endpoint" (include "common.secure_api_endpoint" .)) }}
 {{- if (include "common.proxy.enabled" . ) }}

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -1070,3 +1070,39 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             k8s_delegated_nodes: 1
+
+  - it: Ensure collector_port is set when given
+    set:
+      sysdig_endpoint:
+        collector:
+          url: example.com
+          port: 1234
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            collector_port: 1234
+
+  - it: Ensure collector_port is not set when a region is provided
+    set:
+      sysdig_endpoint:
+        region: us1
+        collector:
+          port: null
+    asserts:
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            collector_port: .*
+
+  - it: Validate port can be overridden for region if provided
+    set:
+      sysdig_endpoint:
+        region: us1
+        collector:
+          port: 1234
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            collector_port: 1234


### PR DESCRIPTION
## What this PR does / why we need it:
Only write the `collector_port` field into the Host Shield configuration if it has been provided by the user. This approach has two main benefits:

1) Allows the Host Shield to run with the default port
   it defines out of the box.
2) Allows simpler configurations when using the region codes
   the SaaS regions all support the Host Shield's default port,
   thus making the specification of this field to the chart
   redundant.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
