### PR TITLE
chore(shield): remove other as accepted value for cluster_type

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: "1.0.0"

--- a/charts/shield/values.schema.json
+++ b/charts/shield/values.schema.json
@@ -61,7 +61,6 @@
           "description": "Type of Kubernetes cluster",
           "enum": [
             "generic",
-            "other",
             "gke-autopilot"
           ],
           "examples": [


### PR DESCRIPTION
## What this PR does / why we need it:

Remove `other` as accepted value for cluster_type

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
