### PR TITLE
fix(shield): shorten the service name used for container vulnerability management service

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/_helpers.tpl
+++ b/charts/shield/templates/cluster/_helpers.tpl
@@ -16,7 +16,7 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{- define "cluster.container_vulnerability_management_service_name" -}}
-  {{- include "cluster.fullname" . }}-container-vulnerability-management
+  {{- include "cluster.fullname" . | trunc 50 | trimSuffix "-" }}-container-vm
 {{- end }}
 
 {{- define "cluster.container_vulnerability_management_lease_name" -}}

--- a/charts/shield/tests/cluster/configmap_test.yaml
+++ b/charts/shield/tests/cluster/configmap_test.yaml
@@ -184,7 +184,7 @@ tests:
           pattern: |
             cluster_scanner:
               image_sbom_extractor:
-                nats_url: nats://release-name-shield-cluster-container-vulnerability-management:4222
+                nats_url: nats://release-name-shield-cluster-container-vm:4222
               leader_election_lock_name: release-name-shield-cluster-container-vulnerability-management
 
   - it: Sets the GRPC Endpoint when Admission Control is enabled with Container Vulnerability Management
@@ -220,13 +220,13 @@ tests:
           pattern: |
             cluster_scanner:
               image_sbom_extractor:
-                nats_url: nats://release-name-shield-cluster-container-vulnerability-management:4222
+                nats_url: nats://release-name-shield-cluster-container-vm:4222
               leader_election_lock_name: release-name-shield-cluster-container-vulnerability-management
       - matchRegex:
           path: data['cluster-shield.yaml']
           pattern: |
             admission_controller_secure:
-              rsi_grpc_endpoint: release-name-shield-cluster-container-vulnerability-management:9999
+              rsi_grpc_endpoint: release-name-shield-cluster-container-vm:9999
 
   - it: Secure API Token - Fail if kubernetes audit is enabled with On Premise Versions < 6.12.0 and Secure API Token is not set
     set:

--- a/charts/shield/tests/cluster/deployment_test.yaml
+++ b/charts/shield/tests/cluster/deployment_test.yaml
@@ -175,7 +175,7 @@ tests:
           path: spec.template.spec.containers[?(@.name == "cluster-shield")].env
           content:
             name: KUBE_SERVICE_NAME
-            value: release-name-shield-cluster-container-vulnerability-management
+            value: release-name-shield-cluster-container-vm
           any: true
     template: templates/cluster/deployment.yaml
 
@@ -1151,7 +1151,7 @@ tests:
           path: spec.template.spec.containers[?(@.name == "cluster-shield")].env
           content:
             name: KUBE_SERVICE_NAME
-            value: release-name-shield-cluster-container-vulnerability-management
+            value: release-name-shield-cluster-container-vm
       - contains:
           path: spec.template.spec.volumes
           content:

--- a/charts/shield/tests/cluster/role_test.yaml
+++ b/charts/shield/tests/cluster/role_test.yaml
@@ -64,7 +64,7 @@ tests:
               - "endpoints"
               - "endpoints/restricted"
             resourceNames:
-              - "release-name-shield-cluster-container-vulnerability-management"
+              - "release-name-shield-cluster-container-vm"
             verbs: ["*"]
 
   - it: Admission Control withContainer Vulnerability Management
@@ -114,5 +114,5 @@ tests:
               - "endpoints"
               - "endpoints/restricted"
             resourceNames:
-              - "release-name-shield-cluster-container-vulnerability-management"
+              - "release-name-shield-cluster-container-vm"
             verbs: ["*"]

--- a/charts/shield/tests/cluster/service-container-vulnerability-management_test.yaml
+++ b/charts/shield/tests/cluster/service-container-vulnerability-management_test.yaml
@@ -22,7 +22,7 @@ tests:
       - containsDocument:
           kind: Service
           apiVersion: v1
-          name: release-name-shield-cluster-container-vulnerability-management
+          name: release-name-shield-cluster-container-vm
       - equal:
           path: metadata.namespace
           value: shield-namespace
@@ -58,7 +58,7 @@ tests:
       - containsDocument:
           kind: Service
           apiVersion: v1
-          name: release-name-shield-cluster-container-vulnerability-management
+          name: release-name-shield-cluster-container-vm
       - equal:
           path: metadata.namespace
           value: shield-namespace


### PR DESCRIPTION
## What this PR does / why we need it:

Shorten the service name used for container vulnerability management service. It might happen that the helm release name is long enough to cause issues with the service creation which name needs to be max 63 characters.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
