### PR TITLE
fix(shield): set /var/data type to DirectoryOrCreate

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -323,6 +323,7 @@ spec:
         - name: vardata-vol
           hostPath:
             path: /var/data
+            type: DirectoryOrCreate
         {{- if (include "host.driver.is_ebpf" .) }}
         - name: bpf-probes
           emptyDir: {}

--- a/charts/shield/tests/host/daemonset_test.yaml
+++ b/charts/shield/tests/host/daemonset_test.yaml
@@ -613,3 +613,9 @@ tests:
     asserts:
       - isNullOrEmpty:
           path: spec.template.spec.imagePullSecrets
+
+  - it: Test that /var/data is type DirectoryOrCreate
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "vardata-vol")].hostPath.type
+          value: DirectoryOrCreate


### PR DESCRIPTION
## What this PR does / why we need it:
Some hosts do not have a /var/data directory, which is mounted in to the host shield container. On those platforms, have the cluster create an empty directory to allow the installation to proceed.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
