### PR TITLE
fix(shield): configure the host securitycontextconstraint when running on openshift based clusters

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.2.8
+version: 0.2.9
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -139,12 +139,12 @@ true
 {{- end -}}
 
 {{- define "host.capabilities" -}}
-- SYS_ADMIN
-- SYS_RESOURCE
-- SYS_PTRACE
-- SYS_CHROOT
 - DAC_READ_SEARCH
 - KILL
-- SETUID
 - SETGID
+- SETUID
+- SYS_ADMIN
+- SYS_CHROOT
+- SYS_PTRACE
+- SYS_RESOURCE
 {{- end -}}

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -137,3 +137,14 @@ true
 {{- . | toYaml -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "host.capabilities" -}}
+- SYS_ADMIN
+- SYS_RESOURCE
+- SYS_PTRACE
+- SYS_CHROOT
+- DAC_READ_SEARCH
+- KILL
+- SETUID
+- SETGID
+{{- end -}}

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -119,14 +119,7 @@ spec:
               drop:
                 - ALL
               add:
-                - SYS_ADMIN
-                - SYS_RESOURCE
-                - SYS_PTRACE
-                - SYS_CHROOT
-                - DAC_READ_SEARCH
-                - KILL
-                - SETUID
-                - SETGID
+                {{- include "host.capabilities" . | nindent 16 }}
             {{- end }}
           env:
             - name: K8S_NODE

--- a/charts/shield/templates/host/openshift-securitycontextconstraint.yaml
+++ b/charts/shield/templates/host/openshift-securitycontextconstraint.yaml
@@ -12,10 +12,15 @@ allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: true
 allowHostPID: true
-allowHostPorts: false
+allowHostPorts: {{ or .Values.features.posture.host_posture.enabled (dig "kspm_analyzer" "enabled" false .Values.host.additional_settings) }}
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
+{{- if .Values.host.privileged }}
 allowedCapabilities: []
+{{- else }}
+allowedCapabilities:
+  {{- include "host.capabilities" . | nindent 2 }}
+{{- end }}
 allowedUnsafeSysctls: []
 defaultAddCapabilities: []
 fsGroup:

--- a/charts/shield/tests/host/daemonset_test.yaml
+++ b/charts/shield/tests/host/daemonset_test.yaml
@@ -100,14 +100,14 @@ tests:
               drop:
                 - ALL
               add:
-                - SYS_ADMIN
-                - SYS_RESOURCE
-                - SYS_PTRACE
-                - SYS_CHROOT
                 - DAC_READ_SEARCH
                 - KILL
-                - SETUID
                 - SETGID
+                - SETUID
+                - SYS_ADMIN
+                - SYS_CHROOT
+                - SYS_PTRACE
+                - SYS_RESOURCE
 
   - it: Test host.privileged=false
     set:
@@ -128,14 +128,14 @@ tests:
               drop:
                 - ALL
               add:
-                - SYS_ADMIN
-                - SYS_RESOURCE
-                - SYS_PTRACE
-                - SYS_CHROOT
                 - DAC_READ_SEARCH
                 - KILL
-                - SETUID
                 - SETGID
+                - SETUID
+                - SYS_ADMIN
+                - SYS_CHROOT
+                - SYS_PTRACE
+                - SYS_RESOURCE
       - isNotSubset:
           path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].securityContext
           content:

--- a/charts/shield/tests/host/openshift-securitycontextconstraint_test.yaml
+++ b/charts/shield/tests/host/openshift-securitycontextconstraint_test.yaml
@@ -26,3 +26,81 @@ tests:
       - contains:
           path: users
           content: "system:serviceaccount:shield-namespace:release-name-shield-host"
+
+  - it: SecurityContextConstraints allowedCapabilities is empty when host.privileged is true
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1
+    set:
+      host:
+        privileged: true
+    asserts:
+      - equal:
+          path: allowedCapabilities
+          value: []
+
+  - it: SecurityContextConstraints allowedCapabilities is not empty when host.privileged is false
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1
+    set:
+      host:
+        privileged: false
+    asserts:
+      - equal:
+          path: allowedCapabilities
+          value:
+            - SYS_ADMIN
+            - SYS_RESOURCE
+            - SYS_PTRACE
+            - SYS_CHROOT
+            - DAC_READ_SEARCH
+            - KILL
+            - SETUID
+            - SETGID
+
+  - it: SecurityContextConstraints allowHostPorts is true when features.posture.host_posture.enabled is true
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1
+    set:
+      features:
+        posture:
+          host_posture:
+            enabled: true
+    asserts:
+      - equal:
+          path: allowHostPorts
+          value: true
+
+  - it: SecurityContextConstraints allowHostPorts is true when host.additional_settings.kspm_analyzer.enabled is true
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1
+    set:
+      host:
+        additional_settings:
+          kspm_analyzer:
+            enabled: true
+    asserts:
+      - equal:
+          path: allowHostPorts
+          value: true
+
+  - it: SecurityContextConstraints allowHostPorts is false when features.posture.host_posture.enabled and host.additional_settings.kspm_analyzer.enabled are false
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1
+    set:
+      features:
+        posture:
+          host_posture:
+            enabled: false
+      host:
+        additional_settings:
+          kspm_analyzer:
+            enabled: false
+    asserts:
+      - equal:
+          path: allowHostPorts
+          value: false

--- a/charts/shield/tests/host/openshift-securitycontextconstraint_test.yaml
+++ b/charts/shield/tests/host/openshift-securitycontextconstraint_test.yaml
@@ -50,14 +50,14 @@ tests:
       - equal:
           path: allowedCapabilities
           value:
-            - SYS_ADMIN
-            - SYS_RESOURCE
-            - SYS_PTRACE
-            - SYS_CHROOT
             - DAC_READ_SEARCH
             - KILL
-            - SETUID
             - SETGID
+            - SETUID
+            - SYS_ADMIN
+            - SYS_CHROOT
+            - SYS_PTRACE
+            - SYS_RESOURCE
 
   - it: SecurityContextConstraints allowHostPorts is true when features.posture.host_posture.enabled is true
     capabilities:


### PR DESCRIPTION
## What this PR does / why we need it:

Currently the chart doesn't configure properly the openshift SecurityContextConstraint when the Host Posture feature is enabled or the user specify it doesn't want the host application to run as privileged.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
