### PR TITLE
fix(shield): reconfigure host shield configmap mounts

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.2.9
+version: 0.2.10
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -173,7 +173,6 @@ spec:
             periodSeconds: 10
             failureThreshold: 9
           volumeMounts:
-          {{- /* TOOD: Local Forwarder config mount */}}
           {{- /* Custom CA */}}
           {{- include "common.custom_ca.volume_mount" (merge (dict) . (dict "CACertsPath" "/opt/draios/certificates/")) | nindent 12 }}
           {{- /* Always requested */}}
@@ -189,14 +188,10 @@ spec:
               name: run-vol
             - mountPath: /dev/shm
               name: dshm
-            - mountPath: /opt/draios/etc/kubernetes/config/dragent.yaml
-              name: dragent-config
-              subPath: dragent.yaml
-            - mountPath: /opt/draios/etc/kubernetes/config/host-shield.yaml
+            - mountPath: /opt/draios/etc/kubernetes/config
               name: host-shield-config
-              subPath: host-shield.yaml
             - mountPath: /opt/draios/etc/kubernetes/secrets
-              name: sysdig-agent-secrets
+              name: host-shield-secrets
             - mountPath: /etc/podinfo
               name: podinfo
           {{- /* Autopilot = false */}}
@@ -262,19 +257,10 @@ spec:
         - name: dshm
           emptyDir:
             medium: Memory
-        - name: dragent-config
-          configMap:
-            name: {{ include "host.fullname" . }}
-            items:
-              - key: dragent.yaml
-                path: dragent.yaml
         - name: host-shield-config
           configMap:
             name: {{ include "host.fullname" . }}
-            items:
-              - key: host-shield.yaml
-                path: host-shield.yaml
-        - name: sysdig-agent-secrets
+        - name: host-shield-secrets
           secret:
             secretName: {{ include "common.credentials.access_key_secret_name" . }}
         - name: podinfo
@@ -355,8 +341,6 @@ spec:
         - name: local-forwarder-config
           configMap:
             name: {{ include "host.fullname" . }}
-            items:
-              - key: local_forwarder_config.yaml
-                path: local_forwarder_config.yaml
+            optional: true
       {{- end }}
       {{- include "host.volumes" . | nindent 8 }}

--- a/charts/shield/tests/host/configmap-local-forwarder_test.yaml
+++ b/charts/shield/tests/host/configmap-local-forwarder_test.yaml
@@ -59,20 +59,3 @@ tests:
                   output: stdout
                 type: LOCAL
         template: host/configmap.yaml
-      - contains:
-          path: spec.template.spec.volumes
-          content:
-            configMap:
-              items:
-                - key: local_forwarder_config.yaml
-                  path: local_forwarder_config.yaml
-              name: release-name-shield-host
-            name: local-forwarder-config
-        template: host/daemonset.yaml
-      - contains:
-          path: spec.template.spec.containers[0].volumeMounts
-          content:
-            mountPath: /opt/draios/etc/local_forwarder_config.yaml
-            subPath: local_forwarder_config.yaml
-            name: local-forwarder-config
-        template: host/daemonset.yaml


### PR DESCRIPTION
## What this PR does / why we need it:
Mounting ConfigMaps while utilizing subPaths prevents the mounts from being updated when the ConfigMap is updated. See: https://github.com/kubernetes/kubernetes/issues/50345

Since all the files being mounted from the ConfigMap are located in the same directory, the use of subPaths can be removed and thus allow the configurations to be properly picked up by the host shield when they are made.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
