### PR TITLE
fix(rh-shield-operator): add missing permissions to Operator role

### DIFF
--- a/rh-shield-operator/config/rbac/role.yaml
+++ b/rh-shield-operator/config/rbac/role.yaml
@@ -86,13 +86,13 @@ rules:
   apiGroups:
   - "admissionregistration.k8s.io"
   resources:
-    - "validatingwebhookconfigurations"
+  - "validatingwebhookconfigurations"
 - verbs:
   - "*"
   apiGroups:
   - "coordination.k8s.io"
   resources:
-    - "leases"
+  - "leases"
 - verbs:
   - "*"
   apiGroups:

--- a/rh-shield-operator/config/rbac/role.yaml
+++ b/rh-shield-operator/config/rbac/role.yaml
@@ -81,5 +81,22 @@ rules:
   resources:
   - "daemonsets"
   - "deployments"
-
+- verbs:
+  - "*"
+  apiGroups:
+  - "admissionregistration.k8s.io"
+  resources:
+    - "validatingwebhookconfigurations"
+- verbs:
+  - "*"
+  apiGroups:
+  - "coordination.k8s.io"
+  resources:
+    - "leases"
+- verbs:
+  - "*"
+  apiGroups:
+  - "scheduling.k8s.io"
+  resources:
+  - "priorityclasses"
 #+kubebuilder:scaffold:rules


### PR DESCRIPTION
## What this PR does / why we need it:
The Operator did not have sufficient permissions in its Role
to operate on the following resources:
* priorityclass
* validatingwebhookconfigurations

The Operator also requires the use of leases, and was getting that permission already from the leader election role used for Operator leader elections.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers

<!-- Check Contribution guidelines in README.md for more insight. -->
