### PR TITLE
chore(rh-shield-operator): prep for v0.1.5 release

### DIFF
--- a/rh-shield-operator/Makefile
+++ b/rh-shield-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.1.4
+VERSION ?= 0.1.5
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/rh-shield-operator/bundle/manifests/rh-shield-operator.clusterserviceversion.yaml
+++ b/rh-shield-operator/bundle/manifests/rh-shield-operator.clusterserviceversion.yaml
@@ -370,14 +370,14 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Security, Monitoring
-    createdAt: "2024-11-25T20:24:02Z"
+    createdAt: "2024-12-04T13:44:20Z"
     description: |
       The Sysdig Shield Operator provides a way to deploy Sysdig Shield components on an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.36.1
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/sysdiglabs/charts
     support: https://sysdig.com
-  name: rh-shield-operator.v0.1.4
+  name: rh-shield-operator.v0.1.5
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -531,7 +531,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=rh-shield-operator
-                image: quay.io/sysdig/rh-shield-operator:v0.1.4
+                image: quay.io/sysdig/rh-shield-operator:v0.1.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -635,4 +635,4 @@ spec:
   provider:
     name: Sysdig
     url: https://sysdig.com
-  version: 0.1.4
+  version: 0.1.5

--- a/rh-shield-operator/config/manager/kustomization.yaml
+++ b/rh-shield-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/sysdig/rh-shield-operator
-  newTag: v0.1.4
+  newTag: v0.1.5


### PR DESCRIPTION
## What this PR does / why we need it:
Prepping for the release that will contain the fix in https://github.com/sysdiglabs/charts/pull/2063

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)

<!-- Check Contribution guidelines in README.md for more insight. -->
