### PR TITLE
chore(rh-shield-operator): prep for v0.1.6 release

### DIFF
--- a/rh-shield-operator/Makefile
+++ b/rh-shield-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.1.5
+VERSION ?= 0.1.6
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/rh-shield-operator/bundle/manifests/rh-shield-operator.clusterserviceversion.yaml
+++ b/rh-shield-operator/bundle/manifests/rh-shield-operator.clusterserviceversion.yaml
@@ -370,14 +370,14 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Security, Monitoring
-    createdAt: "2024-12-04T13:44:20Z"
+    createdAt: "2024-12-09T17:08:58Z"
     description: |
       The Sysdig Shield Operator provides a way to deploy Sysdig Shield components on an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.36.1
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/sysdiglabs/charts
     support: https://sysdig.com
-  name: rh-shield-operator.v0.1.5
+  name: rh-shield-operator.v0.1.6
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -471,6 +471,24 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - '*'
+        - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - '*'
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews
@@ -531,7 +549,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=rh-shield-operator
-                image: quay.io/sysdig/rh-shield-operator:v0.1.5
+                image: quay.io/sysdig/rh-shield-operator:v0.1.6
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -635,4 +653,4 @@ spec:
   provider:
     name: Sysdig
     url: https://sysdig.com
-  version: 0.1.5
+  version: 0.1.6

--- a/rh-shield-operator/config/manager/kustomization.yaml
+++ b/rh-shield-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/sysdig/rh-shield-operator
-  newTag: v0.1.5
+  newTag: v0.1.6


### PR DESCRIPTION
## What this PR does / why we need it:
contains shield-0.3.1

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
