### PR TITLE
feat(agent): add "sysdig_api_endpoint" in dragent.yaml based on the region

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.34.8
+version: 1.35.0

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -526,6 +526,11 @@ ssl_verify_certificate: {{ $sslVerifyCertificate }}
 {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
 ca_certificate: certificates/{{ include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) }}
 {{- end }}
+
+{{- $sysdigApiEndpoint := include "sysdig.secureApiEndpoint" }}
+{{- if $sysdigApiEndpoint }}
+sysdig_api_endpoint: {{- $sysdigApiEndpoint }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -527,9 +527,9 @@ ssl_verify_certificate: {{ $sslVerifyCertificate }}
 ca_certificate: certificates/{{ include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) }}
 {{- end }}
 
-{{- $sysdigApiEndpoint := include "sysdig.secureApiEndpoint" }}
+{{- $sysdigApiEndpoint := include "sysdig.secureApiEndpoint" . }}
 {{- if $sysdigApiEndpoint }}
-sysdig_api_endpoint: {{- $sysdigApiEndpoint }}
+sysdig_api_endpoint: {{ $sysdigApiEndpoint }}
 {{- end }}
 {{- end }}
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -359,6 +359,15 @@ Determine sysdig secure endpoint based on provided region
 {{- end -}}
 
 {{/*
+Determine api endpoint based on provided region
+*/}}
+{{- define "agent.secureApiEndpoint" -}}
+    {{- if hasKey ((include "sysdig.regions" .) | fromYaml) .Values.global.sysdig.region }}
+        {{- include "sysdig.secureApiEndpoint" . }}
+    {{- end -}}
+{{- end -}}
+
+{{/*
 Agent agentConfigmapName
 */}}
 {{- define "agent.configmapName" -}}
@@ -526,10 +535,9 @@ ssl_verify_certificate: {{ $sslVerifyCertificate }}
 {{- if eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true" }}
 ca_certificate: certificates/{{ include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl) }}
 {{- end }}
-
-{{- $sysdigApiEndpoint := include "sysdig.secureApiEndpoint" . }}
-{{- if $sysdigApiEndpoint }}
-sysdig_api_endpoint: {{ $sysdigApiEndpoint }}
+{{- $secureApiEndpoint := include "get_if_not_in_settings" (dict "root" . "default" (include "sysdig.secureApiEndpoint" .) "setting" "sysdig_api_endpoint") }}
+{{- if $secureApiEndpoint }}
+sysdig_api_endpoint: {{ $secureApiEndpoint }}
 {{- end }}
 {{- end }}
 

--- a/charts/agent/tests/api_endpoint_region_test.yaml
+++ b/charts/agent/tests/api_endpoint_region_test.yaml
@@ -20,7 +20,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*ingest\-us2\.app\.sysdig\.com.*
+          pattern: .*collector:.*ingest\-us2\.app\.sysdig\.com.*
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*us2\.app\.sysdig\.com.*
 
   - it: Checking region 'us3'
     set:
@@ -32,7 +35,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*ingest\.us3\.sysdig\.com.*
+          pattern: .*collector:.*ingest\.us3\.sysdig\.com.*
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*app\.us3\.sysdig\.com.*
 
   - it: Checking region 'us4'
     set:
@@ -44,7 +50,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*ingest\.us4\.sysdig\.com.*
+          pattern: .*collector:.*ingest\.us4\.sysdig\.com.*
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*app\.us4\.sysdig\.com.*
 
   - it: Checking region 'eu1'
     set:
@@ -56,7 +65,10 @@ tests:
             of: ConfigMap
         - matchRegex:
             path: data['dragent.yaml']
-            pattern: .*ingest\-eu1\.app\.sysdig\.com.*
+            pattern: .*collector:.*ingest\-eu1\.app\.sysdig\.com.*
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*eu1\.app\.sysdig\.com.*
 
   - it: Checking region 'au1'
     set:
@@ -68,7 +80,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*ingest\.au1\.sysdig\.com.*
+          pattern: .*collector:.*ingest\.au1\.sysdig\.com.*
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*app\.au1\.sysdig\.com.*
 
   - it: Checking region 'me2'
     set:
@@ -80,7 +95,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: .*ingest\.me2\.sysdig\.com.*
+          pattern: .*collector:.*ingest\.me2\.sysdig\.com.*
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*app\.me2\.sysdig\.com.*
 
   - it: Checking region 'au-syd-monitor'
     set:
@@ -92,7 +110,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.au-syd.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.au-syd.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*au-syd\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'br-sao-monitor'
     set:
@@ -104,7 +125,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.br-sao.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.br-sao.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*br-sao\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'ca-tor-monitor'
     set:
@@ -116,7 +140,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.ca-tor.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.ca-tor.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*ca-tor\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'eu-de-monitor'
     set:
@@ -128,7 +155,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.eu-de.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.eu-de.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*eu-de\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'eu-gb-monitor'
     set:
@@ -140,7 +170,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.eu-gb.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.eu-gb.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*eu-gb\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'jp-osa-monitor'
     set:
@@ -152,7 +185,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.jp-osa.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.jp-osa.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*jp-osa\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'jp-tok-monitor'
     set:
@@ -164,7 +200,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.jp-tok.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.jp-tok.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*jp-tok\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'us-east-monitor'
     set:
@@ -176,7 +215,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.us-east.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.us-east.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*us-east\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'us-south-monitor'
     set:
@@ -188,7 +230,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.us-south.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.us-south.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*us-south\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'au-syd-private-monitor'
     set:
@@ -200,7 +245,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.au-syd.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.private.au-syd.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.au-syd\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'br-sao-private-monitor'
     set:
@@ -212,7 +260,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.br-sao.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.private.br-sao.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.br-sao\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'ca-tor-private-monitor'
     set:
@@ -224,7 +275,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.ca-tor.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.private.ca-tor.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.ca-tor\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'eu-de-private-monitor'
     set:
@@ -236,7 +290,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.eu-de.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.private.eu-de.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.eu-de\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'eu-gb-private-monitor'
     set:
@@ -248,7 +305,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.eu-gb.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.private.eu-gb.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.eu-gb\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'jp-osa-private-monitor'
     set:
@@ -260,7 +320,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.jp-osa.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.private.jp-osa.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.jp-osa\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'jp-tok-private-monitor'
     set:
@@ -272,7 +335,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.jp-tok.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.private.jp-tok.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.jp-tok\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'us-east-private-monitor'
     set:
@@ -284,7 +350,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.us-east.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.private.us-east.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.us-east\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'us-south-private-monitor'
     set:
@@ -296,7 +365,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.us-south.monitoring.cloud.ibm.com
+          pattern: collector:.*ingest.private.us-south.monitoring.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.us-south\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'au-syd-secure'
     set:
@@ -308,7 +380,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.au-syd.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.au-syd.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*au-syd\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'br-sao-secure'
     set:
@@ -320,7 +395,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.br-sao.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.br-sao.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*br-sao\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'ca-tor-secure'
     set:
@@ -332,7 +410,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.ca-tor.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.ca-tor.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*ca-tor\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'eu-de-secure'
     set:
@@ -344,7 +425,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.eu-de.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.eu-de.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*eu-de\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'eu-gb-secure'
     set:
@@ -356,7 +440,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.eu-gb.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.eu-gb.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*eu-gb\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'jp-osa-secure'
     set:
@@ -368,7 +455,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.jp-osa.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.jp-osa.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*jp-osa\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'jp-tok-secure'
     set:
@@ -380,7 +470,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.jp-tok.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.jp-tok.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*jp-tok\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'us-east-secure'
     set:
@@ -392,7 +485,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.us-east.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.us-east.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*us-east\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'us-south-secure'
     set:
@@ -404,7 +500,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.us-south.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.us-south.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*us-south\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'au-syd-private-secure'
     set:
@@ -416,7 +515,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.au-syd.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.private.au-syd.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.au-syd\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'br-sao-private-secure'
     set:
@@ -428,7 +530,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.br-sao.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.private.br-sao.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.br-sao\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'ca-tor-private-secure'
     set:
@@ -440,7 +545,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.ca-tor.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.private.ca-tor.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.ca-tor\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'eu-de-private-secure'
     set:
@@ -452,7 +560,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.eu-de.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.private.eu-de.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.eu-de\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'eu-gb-private-secure'
     set:
@@ -464,7 +575,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.eu-gb.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.private.eu-gb.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.eu-gb\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'jp-osa-private-secure'
     set:
@@ -476,7 +590,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.jp-osa.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.private.jp-osa.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.jp-osa\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'jp-tok-private-secure'
     set:
@@ -488,7 +605,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.jp-tok.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.private.jp-tok.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.jp-tok\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'us-east-private-secure'
     set:
@@ -500,7 +620,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.us-east.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.private.us-east.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.us-east\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking region 'us-south-private-secure'
     set:
@@ -512,7 +635,10 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data['dragent.yaml']
-          pattern: ingest.private.us-south.security-compliance-secure.cloud.ibm.com
+          pattern: collector:.*ingest.private.us-south.security-compliance-secure.cloud.ibm.com
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*private\.us-south\.security-compliance-secure\.cloud\.ibm\.com
 
   - it: Checking wrong region input
     set:

--- a/charts/agent/tests/api_endpoint_region_test.yaml
+++ b/charts/agent/tests/api_endpoint_region_test.yaml
@@ -61,11 +61,11 @@ tests:
         sysdig:
           region: eu1
     asserts:
-        - isKind:
-            of: ConfigMap
-        - matchRegex:
-            path: data['dragent.yaml']
-            pattern: .*collector:.*ingest\-eu1\.app\.sysdig\.com.*
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*collector:.*ingest\-eu1\.app\.sysdig\.com.*
       - matchRegex:
           path: data['dragent.yaml']
           pattern: .*sysdig_api_endpoint:.*eu1\.app\.sysdig\.com.*

--- a/charts/agent/tests/custom_settings_test.yaml
+++ b/charts/agent/tests/custom_settings_test.yaml
@@ -118,3 +118,16 @@ tests:
             second: example
             .*
     template: configmap-deployment.yaml
+
+  - it: Testing custom API Endpoint take precedence over default
+    set:
+      sysdig:
+        accessKey: AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+        settings:
+          region: us2
+          sysdig_api_endpoint: test.sysdig-example.com
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: .*sysdig_api_endpoint:.*test\.sysdig-example\.com.*
+    template: configmap.yaml

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.74.4
+version: 1.75.0
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -26,7 +26,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.34.8
+    version: ~1.35.0
     alias: agent
     condition: agent.enabled
   - name: common


### PR DESCRIPTION
## What this PR does / why we need it:

Making life easier when setting up the response actions feature (More [here](https://docs.google.com/document/d/1WmiSd5Lg-6UZanrxEpmJ7caFRkS6OptNlVauGhI_ZOE/edit?tab=t.0#heading=h.d38hhgu083pq))

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
