### PR TITLE
chore(rh-shield-operator): add 'maintainer' label

### DIFF
--- a/rh-shield-operator/Dockerfile
+++ b/rh-shield-operator/Dockerfile
@@ -5,6 +5,7 @@ ARG RELEASE_VERSION
 
 LABEL name="rh-shield-operator" \
       vendor="Sysdig" \
+      maintainer="Sysdig" \
       version="${RELEASE_VERSION}" \
       release="1" \
       summary="Operator based on the shield chart by Sysdig" \


### PR DESCRIPTION
## What this PR does / why we need it:
Release 1.11.0 of the `preflight` utility used to certify the Operator images updated the `HasRequiredLabels` test and the test now fails if the `maintainer` label has not been set on the Operator image.

For the curious, the relevant upstream PR can be found [here](https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/1219).

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)

<!-- Check Contribution guidelines in README.md for more insight. -->
