### PR TITLE
feat(shield): add host support (universal_ebpf) on gke-autopilot

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -83,7 +83,7 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{- define "host.driver.is_ebpf" }}
-{{- if or (include "host.driver.is_legacy_ebpf" .) (include "common.cluster_type.is_gke_autopilot" .) }}
+{{- if or (include "host.driver.is_legacy_ebpf" .) (include "host.driver.is_universal_ebpf" .) }}
 true
 {{- else }}
 {{- end }}

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -83,21 +83,21 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{- define "host.driver.is_ebpf" }}
-{{- if or (include "host.driver.is_legacy_ebpf" .) (include "host.driver.is_universal_ebpf" .) }}
+{{- if or (include "host.driver.is_legacy_ebpf" .) (include "common.cluster_type.is_gke_autopilot" .) }}
 true
 {{- else }}
 {{- end }}
 {{- end }}
 
 {{- define "host.driver.is_legacy_ebpf" }}
-{{- if eq "legacy_ebpf" .Values.host.driver }}
+{{- if and (eq "legacy_ebpf" .Values.host.driver) (not (include "common.cluster_type.is_gke_autopilot" .)) }}
 true
 {{- else }}
 {{- end }}
 {{- end }}
 
 {{- define "host.driver.is_universal_ebpf" }}
-{{- if eq "universal_ebpf" .Values.host.driver }}
+{{- if or (eq "universal_ebpf" .Values.host.driver) (include "common.cluster_type.is_gke_autopilot" .) }}
 true
 {{- else }}
 {{- end }}

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -98,8 +98,6 @@ spec:
             - mountPath: /host/etc/os-release
               name: osrel
               readOnly: true
-            - mountPath: /root/.sysdig
-              name: bpf-probes
           {{- end }}
       {{- end }}
       containers:
@@ -126,7 +124,7 @@ spec:
             {{- if (include "host.driver.is_universal_ebpf" .) }}
             - name: SYSDIG_AGENT_DRIVER
               value: universal_ebpf
-            {{- else if (include "host.driver.is_legacy_ebpf" .) }}
+            {{- else if and (include "host.driver.is_legacy_ebpf" .) (not (include "common.cluster_type.is_gke_autopilot" .)) }}
             - name: SYSDIG_AGENT_DRIVER
               value: legacy_ebpf
             {{- end }}
@@ -214,8 +212,6 @@ spec:
               readOnly: true
             - mountPath: /host/var/run/containerd/containerd.sock
               name: containerdsock-vol
-            - mountPath: /root/.sysdig
-              name: bpf-probes
           {{- end }}
 
           {{- if (include "host.need_host_root" .) }}
@@ -313,8 +309,6 @@ spec:
         - name: osrel
           hostPath:
             path: /etc/os-release
-        - name: bpf-probes
-          emptyDir: {}
         - name: containerdsock-vol
           hostPath:
             path: /var/run/containerd/containerd.sock

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -123,10 +123,10 @@ spec:
             - name: SYSDIG_BPF_PROBE
               value:
             {{- end }}
-            {{- if and (include "host.driver.is_universal_ebpf" .) (not (include "common.cluster_type.is_gke_autopilot" .)) }}
+            {{- if (include "host.driver.is_universal_ebpf" .) }}
             - name: SYSDIG_AGENT_DRIVER
               value: universal_ebpf
-            {{- else if and (include "host.driver.is_legacy_ebpf" .) (not (include "common.cluster_type.is_gke_autopilot" .)) }}
+            {{- else if (include "host.driver.is_legacy_ebpf" .) }}
             - name: SYSDIG_AGENT_DRIVER
               value: legacy_ebpf
             {{- end }}

--- a/charts/shield/templates/host/gke-allowlist-synchronizer.yaml
+++ b/charts/shield/templates/host/gke-allowlist-synchronizer.yaml
@@ -1,0 +1,14 @@
+{{- if (include "common.cluster_type.is_gke_autopilot" .) -}}
+apiVersion: auto.gke.io/v1
+kind: AllowlistSynchronizer
+metadata:
+  name: sysdig-agent-allowlist-synchronizer
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+  labels:
+    {{- include "host.labels" . | nindent 4 }}
+spec:
+  allowlistPaths:
+    - "Sysdig/agent/*"
+{{- end -}}

--- a/charts/shield/tests/host/gke-allowlist-synchronizer_test.yaml
+++ b/charts/shield/tests/host/gke-allowlist-synchronizer_test.yaml
@@ -1,0 +1,25 @@
+suite: Host - Service
+templates:
+  - templates/host/gke-allowlist-synchronizer.yaml
+release:
+  name: release-name
+  namespace: shield-namespace
+values:
+  - ../values/gke-autopilot.yaml
+tests:
+  - it: Contains the agent GKE AllowlistSynchronizer resource
+    asserts:
+      - containsDocument:
+          kind: AllowlistSynchronizer
+          apiVersion: auto.gke.io/v1
+          name: sysdig-agent-allowlist-synchronizer
+      - equal:
+          path: metadata.namespace
+          value: shield-namespace
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: spec.allowlistPaths
+          value:
+            - "Sysdig/agent/*"

--- a/charts/shield/tests/values/gke-autopilot.yaml
+++ b/charts/shield/tests/values/gke-autopilot.yaml
@@ -1,0 +1,11 @@
+cluster_config:
+  name: test-cluster
+  cluster_type: gke-autopilot
+
+sysdig_endpoint:
+  region: custom
+  access_key: 12345678-1234-1234-1234-123456789012
+  api_url: https://www.example.com
+  collector:
+    host: example.com
+    port: 6443


### PR DESCRIPTION
## What this PR does / why we need it:

- GKE Autopilot support for version >= `1.32.2-gke.1652000`;
- No custom images supported: only the default `quay.io/sysdig/agent-slim` is supported;
- No `proxy` configuration supported at the moment;
- `rapid_response` feature is not supported at the moment.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
