### PR TITLE
chore(agent,shield): disable remotefs_stats by default

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.34.3
+version: 1.34.4

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -41,15 +41,18 @@ data:
 {{- if and (include "agent.gke.autopilot" .) (or (not (hasKey $baseSettings "promscrape_web_address")) (eq (get $baseSettings "promscrape_web_address") "127.0.0.1:9990") ) }}
   {{- $baseSettings := mergeOverwrite $baseSettings (dict "promscrape_web_address" "127.0.0.1:9991") -}}
 {{- end }}
+{{- if not (dig "remotefs_stats" "enabled" false $baseSettings)}}
+  {{- $merged := mergeOverwrite $baseSettings (dict "remotefs_stats" (dict "enabled" false)) -}}
+{{- end }}
 {{- if and (eq (include "sysdig.custom_ca.enabled"  (dict "global" .Values.global.ssl "component" .Values.ssl)) "true") (.Values.sysdig.settings) (hasKey .Values.sysdig.settings "http_proxy") (hasKey (default dict .Values.sysdig.settings.http_proxy) "ssl") (eq (get (default (dict "ssl" false) .Values.sysdig.settings.http_proxy) "ssl") true) }}
   {{- $caFilePath := printf "%s%s" "certificates/" (include "sysdig.custom_ca.keyName"  (dict "global" .Values.global.ssl "component" .Values.ssl)) }}
-  {{- $mergedSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}
-  {{ toYaml $mergedSettings | nindent 4 }}
-{{- else if (dig "kspm_analyzer" "enabled" false $baseSettings) }}
-  {{- $mergedSettings := mergeOverwrite $baseSettings (dict "kspm_analyzer" (dict "agent_app_name" "agent" "pod_namespace" .Release.Namespace)) -}}
-  {{ toYaml $mergedSettings | nindent 4 }}
-{{- else if .Values.sysdig.settings }}
-  {{ toYaml .Values.sysdig.settings | nindent 4 }}
+  {{- $baseSettings := mergeOverwrite $baseSettings (dict "http_proxy" (dict "ca_certificate" $caFilePath)) -}}
+{{- end }}
+{{- if (dig "kspm_analyzer" "enabled" false $baseSettings) }}
+  {{- $baseSettings := mergeOverwrite $baseSettings (dict "kspm_analyzer" (dict "agent_app_name" "agent" "pod_namespace" .Release.Namespace)) -}}
+{{- end }}
+{{- if $baseSettings}}
+  {{ toYaml $baseSettings | nindent 4 }}
 {{- end }}
 {{- if .Values.leaderelection.enable }}
     k8s_delegation_election: true

--- a/charts/agent/tests/remotefs_stats_test.yaml
+++ b/charts/agent/tests/remotefs_stats_test.yaml
@@ -1,0 +1,24 @@
+suite: Test remotefs_stats is disabled by default
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: remotefs_stats should be disabled by default
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: |
+            remotefs_stats:
+              enabled: false
+
+  - it: remotefs_stats can be enabled if desired
+    set:
+      sysdig:
+        settings:
+          remotefs_stats:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: |
+            remotefs_stats:
+              enabled: true

--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_configmap_helpers.tpl
@@ -143,6 +143,9 @@ true
 {{- $config = merge $config (dict "local_forwarder" (dict "enabled" .enabled "transmit_message_types" .transmit_message_types)) }}
 {{- end }}
 {{- end }}
+{{- if not (dig "remotefs_stats" "enabled" false .Values.host.additional_settings) }}
+{{- $config = merge $config (dict "remotefs_stats" (dict "enabled" false)) }}
+{{- end }}
 {{- $config = merge $config (include "host.configmap.agent_mode" . | fromYaml) }}
 {{- if .Values.host.additional_settings }}
 {{- $config = mergeOverwrite $config (include "host.config_override" . | fromYaml) }}

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -1146,3 +1146,24 @@ tests:
     asserts:
       - notExists:
           path: data["prometheus.yaml"]
+
+  - it: remotefs_stats should be disabled by default
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: |
+            remotefs_stats:
+              enabled: false
+
+  - it: remotefs_stats can be enabled if desired
+    set:
+      host:
+        additional_settings:
+          remotefs_stats:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: |
+            remotefs_stats:
+              enabled: true


### PR DESCRIPTION
## What this PR does / why we need it:
The `remotefs_stats` feature should be disabled by default.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
