### PR TITLE
feat(agent): [SMAGENT-8138][SMAGENT-8501] add full securityContext to agent charts

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.34.5
+version: 1.34.6

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -690,8 +690,14 @@ annotations:
 privileged: true
 runAsNonRoot: false
 runAsUser: 0
+runAsGroup: 0
 readOnlyRootFilesystem: false
 allowPrivilegeEscalation: true
+capabilities:
+  drop:
+    - ALL
+  add:
+    - ALL
 {{- else }}
 allowPrivilegeEscalation: false
 seccompProfile:

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -694,6 +694,8 @@ runAsGroup: 0
 readOnlyRootFilesystem: false
 allowPrivilegeEscalation: true
 capabilities:
+  drop:
+    - ALL
   add:
     - CHOWN
     - DAC_OVERRIDE

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -696,48 +696,6 @@ allowPrivilegeEscalation: true
 capabilities:
   drop:
     - ALL
-  add:
-    - CHOWN
-    - DAC_OVERRIDE
-    - DAC_READ_SEARCH
-    - FOWNER
-    - FSETID
-    - KILL
-    - SETGID
-    - SETUID
-    - SETPCAP
-    - LINUX_IMMUTABLE
-    - NET_BIND_SERVICE
-    - NET_BROADCAST
-    - NET_ADMIN
-    - NET_RAW
-    - IPC_LOCK
-    - IPC_OWNER
-    - SYS_MODULE
-    - SYS_RAWIO
-    - SYS_CHROOT
-    - SYS_PTRACE
-    - SYS_PACCT
-    - SYS_ADMIN
-    - SYS_BOOT
-    - SYS_NICE
-    - SYS_RESOURCE
-    - SYS_TIME
-    - SYS_TTY_CONFIG
-    - MKNOD
-    - LEASE
-    - AUDIT_WRITE
-    - AUDIT_CONTROL
-    - SETFCAP
-    - MAC_OVERRIDE
-    - MAC_ADMIN
-    - SYSLOG
-    - WAKE_ALARM
-    - BLOCK_SUSPEND
-    - AUDIT_READ
-    - PERFMON
-    - BPF
-    - CHECKPOINT_RESTORE
 {{- else }}
 allowPrivilegeEscalation: false
 seccompProfile:

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -696,8 +696,6 @@ allowPrivilegeEscalation: true
 capabilities:
   drop:
     - ALL
-  add:
-    - ALL
 {{- else }}
 allowPrivilegeEscalation: false
 seccompProfile:

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -696,6 +696,48 @@ allowPrivilegeEscalation: true
 capabilities:
   drop:
     - ALL
+  add:
+    - CHOWN
+    - DAC_OVERRIDE
+    - DAC_READ_SEARCH
+    - FOWNER
+    - FSETID
+    - KILL
+    - SETGID
+    - SETUID
+    - SETPCAP
+    - LINUX_IMMUTABLE
+    - NET_BIND_SERVICE
+    - NET_BROADCAST
+    - NET_ADMIN
+    - NET_RAW
+    - IPC_LOCK
+    - IPC_OWNER
+    - SYS_MODULE
+    - SYS_RAWIO
+    - SYS_CHROOT
+    - SYS_PTRACE
+    - SYS_PACCT
+    - SYS_ADMIN
+    - SYS_BOOT
+    - SYS_NICE
+    - SYS_RESOURCE
+    - SYS_TIME
+    - SYS_TTY_CONFIG
+    - MKNOD
+    - LEASE
+    - AUDIT_WRITE
+    - AUDIT_CONTROL
+    - SETFCAP
+    - MAC_OVERRIDE
+    - MAC_ADMIN
+    - SYSLOG
+    - WAKE_ALARM
+    - BLOCK_SUSPEND
+    - AUDIT_READ
+    - PERFMON
+    - BPF
+    - CHECKPOINT_RESTORE
 {{- else }}
 allowPrivilegeEscalation: false
 seccompProfile:

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -694,8 +694,6 @@ runAsGroup: 0
 readOnlyRootFilesystem: false
 allowPrivilegeEscalation: true
 capabilities:
-  drop:
-    - ALL
   add:
     - CHOWN
     - DAC_OVERRIDE

--- a/charts/agent/templates/daemonset-windows.yaml
+++ b/charts/agent/templates/daemonset-windows.yaml
@@ -30,6 +30,16 @@ spec:
         {{ toYaml .Values.global.image.pullSecrets | nindent 8 }}
       {{- end }}
       securityContext:
+        privileged: true
+        {{- if ( semverCompare ">= 1.31.0" (.Capabilities.KubeVersion.GitVersion )) }}
+        runAsNonRoot: false
+        runAsGroup: 0
+        {{- end }}
+        readOnlyRootFilesystem: false
+        allowPrivilegeEscalation: true
+        capabilities:
+          add:
+            - ALL
         windowsOptions:
           hostProcess: true
           runAsUserName: "NT AUTHORITY\\SYSTEM"

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -78,9 +78,15 @@ spec:
           securityContext:
             privileged: true
             runAsNonRoot: false
+            runAsGroup: 0
             runAsUser: 0
             readOnlyRootFilesystem: false
             allowPrivilegeEscalation: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - ALL
           resources:
             {{- if (include "agent.gke.autopilot" .) }}
               {{- $resources := merge .Values.slim.resources (dict "requests" (dict "ephemeral-storage" .Values.gke.ephemeralStorage))}}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -85,6 +85,48 @@ spec:
             capabilities:
               drop:
                 - ALL
+              add:
+                - CHOWN
+                - DAC_OVERRIDE
+                - DAC_READ_SEARCH
+                - FOWNER
+                - FSETID
+                - KILL
+                - SETGID
+                - SETUID
+                - SETPCAP
+                - LINUX_IMMUTABLE
+                - NET_BIND_SERVICE
+                - NET_BROADCAST
+                - NET_ADMIN
+                - NET_RAW
+                - IPC_LOCK
+                - IPC_OWNER
+                - SYS_MODULE
+                - SYS_RAWIO
+                - SYS_CHROOT
+                - SYS_PTRACE
+                - SYS_PACCT
+                - SYS_ADMIN
+                - SYS_BOOT
+                - SYS_NICE
+                - SYS_RESOURCE
+                - SYS_TIME
+                - SYS_TTY_CONFIG
+                - MKNOD
+                - LEASE
+                - AUDIT_WRITE
+                - AUDIT_CONTROL
+                - SETFCAP
+                - MAC_OVERRIDE
+                - MAC_ADMIN
+                - SYSLOG
+                - WAKE_ALARM
+                - BLOCK_SUSPEND
+                - AUDIT_READ
+                - PERFMON
+                - BPF
+                - CHECKPOINT_RESTORE
           resources:
             {{- if (include "agent.gke.autopilot" .) }}
               {{- $resources := merge .Values.slim.resources (dict "requests" (dict "ephemeral-storage" .Values.gke.ephemeralStorage))}}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -83,8 +83,6 @@ spec:
             readOnlyRootFilesystem: false
             allowPrivilegeEscalation: true
             capabilities:
-              drop:
-                - ALL
               add:
                 - CHOWN
                 - DAC_OVERRIDE

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -85,8 +85,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-              add:
-                - ALL
           resources:
             {{- if (include "agent.gke.autopilot" .) }}
               {{- $resources := merge .Values.slim.resources (dict "requests" (dict "ephemeral-storage" .Values.gke.ephemeralStorage))}}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -85,48 +85,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-              add:
-                - CHOWN
-                - DAC_OVERRIDE
-                - DAC_READ_SEARCH
-                - FOWNER
-                - FSETID
-                - KILL
-                - SETGID
-                - SETUID
-                - SETPCAP
-                - LINUX_IMMUTABLE
-                - NET_BIND_SERVICE
-                - NET_BROADCAST
-                - NET_ADMIN
-                - NET_RAW
-                - IPC_LOCK
-                - IPC_OWNER
-                - SYS_MODULE
-                - SYS_RAWIO
-                - SYS_CHROOT
-                - SYS_PTRACE
-                - SYS_PACCT
-                - SYS_ADMIN
-                - SYS_BOOT
-                - SYS_NICE
-                - SYS_RESOURCE
-                - SYS_TIME
-                - SYS_TTY_CONFIG
-                - MKNOD
-                - LEASE
-                - AUDIT_WRITE
-                - AUDIT_CONTROL
-                - SETFCAP
-                - MAC_OVERRIDE
-                - MAC_ADMIN
-                - SYSLOG
-                - WAKE_ALARM
-                - BLOCK_SUSPEND
-                - AUDIT_READ
-                - PERFMON
-                - BPF
-                - CHECKPOINT_RESTORE
           resources:
             {{- if (include "agent.gke.autopilot" .) }}
               {{- $resources := merge .Values.slim.resources (dict "requests" (dict "ephemeral-storage" .Values.gke.ephemeralStorage))}}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -83,6 +83,8 @@ spec:
             readOnlyRootFilesystem: false
             allowPrivilegeEscalation: true
             capabilities:
+              drop:
+                - ALL
               add:
                 - CHOWN
                 - DAC_OVERRIDE

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -69,8 +69,12 @@ spec:
             privileged: true
             runAsNonRoot: false
             runAsUser: 0
+            runAsGroup: 0
             readOnlyRootFilesystem: false
             allowPrivilegeEscalation: true
+            capabilities:
+              add:
+                - ALL
           env:
           - name: RUN_MODE
             value: nodriver

--- a/charts/agent/tests/readiness_probe_windows_test.yaml
+++ b/charts/agent/tests/readiness_probe_windows_test.yaml
@@ -19,6 +19,9 @@ kubernetesProvider:
 tests:
 
   - it: "Windows Agent Probes (agent < 1.3.0)"
+    capabilities:
+      majorVersion: 1
+      minorVersion: 31
     set:
       windows:
         enabled: true

--- a/charts/agent/tests/security_context_test.yaml
+++ b/charts/agent/tests/security_context_test.yaml
@@ -29,6 +29,12 @@ tests:
             readOnlyRootFilesystem: false
             runAsNonRoot: false
             runAsUser: 0
+            runAsGroup: 0
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - ALL
 
   - it: Ensure the securityContext for a non-privileged agent contains the keys defined
     set:
@@ -125,3 +131,35 @@ tests:
                 - SYS_TIME
                 - SYS_TTY_CONFIG
                 - WAKE_ALARM
+
+  - it: Ensure the securityContext contains the mandatory keys
+    asserts:
+      - isSubset:
+          path: spec.template.spec['initContainers','containers'][:].securityContext.capabilities
+          content:
+            drop:
+              - ALL
+      - exists:
+          path: spec.template.spec.initContainers[:].securityContext.runAsNonRoot
+      - exists:
+          path: spec.template.spec.containers[:].securityContext.runAsNonRoot
+      - exists:
+          path: spec.template.spec.initContainers[:].securityContext.runAsUser
+      - exists:
+          path: spec.template.spec.containers[:].securityContext.runAsUser
+      - exists:
+          path: spec.template.spec.initContainers[:].securityContext.runAsGroup
+      - exists:
+          path: spec.template.spec.containers[:].securityContext.runAsGroup
+      - exists:
+          path: spec.template.spec.initContainers[:].securityContext.privileged
+      - exists:
+          path: spec.template.spec.containers[:].securityContext.privileged
+      - exists:
+          path: spec.template.spec.initContainers[:].securityContext.allowPrivilegeEscalation
+      - exists:
+          path: spec.template.spec.containers[:].securityContext.allowPrivilegeEscalation
+      - exists:
+          path: spec.template.spec.initContainers[:].securityContext.readOnlyRootFilesystem
+      - exists:
+          path: spec.template.spec.containers[:].securityContext.readOnlyRootFilesystem

--- a/charts/agent/tests/security_context_test.yaml
+++ b/charts/agent/tests/security_context_test.yaml
@@ -33,8 +33,6 @@ tests:
             capabilities:
               drop:
                 - ALL
-              add:
-                - ALL
 
   - it: Ensure the securityContext for a non-privileged agent contains the keys defined
     set:

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.73.0
+version: 1.73.1
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -26,7 +26,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.34.5
+    version: ~1.34.6
     alias: agent
     condition: agent.enabled
   - name: common


### PR DESCRIPTION
Update the agent charts so to include a full securityContext. Beware of https://github.com/kubernetes/kubernetes/issues/125012 affecting Windows kubelet.

Compared to #2017, just removed the "add: -ALL" part which was breaking some systems like ROKS and probably also Azure, which seemed unnecessary (probably redundant given we have `privileged: true`).

## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
