### PR TITLE
feat(cluster-shield): add logic to load OpenShift ca cert to cluster shield

### DIFF
--- a/charts/cluster-shield/Chart.yaml
+++ b/charts/cluster-shield/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-shield
 description: Cluster Shield Helm Chart for Kubernetes
 type: application
-version: 1.7.1
+version: 1.7.2
 appVersion: "1.7.1"
 maintainers:
   - name: AlbertoBarba

--- a/charts/cluster-shield/templates/deployment.yaml
+++ b/charts/cluster-shield/templates/deployment.yaml
@@ -105,6 +105,11 @@ spec:
               mountPath: /ca-certs
               readOnly: true
             {{- end }}
+            {{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+            - name: openshift-ca-cert
+              mountPath: /ca-certs
+              readOnly: true
+            {{- end }}
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -172,6 +177,14 @@ spec:
         - name: ca-cert
           configMap:
             name:  {{ .Values.ca.existingCaConfigMap | default .Values.global.ssl.ca.existingCaConfigMap }}
+        {{- end }}
+        {{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+        - name: openshift-ca-cert
+          configMap:
+            name: openshift-service-ca.crt
+            items:
+            - key: service-ca.crt
+              path: service-ca.crt
         {{- end }}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/cluster-shield/tests/deployment_test.yaml
+++ b/charts/cluster-shield/tests/deployment_test.yaml
@@ -553,3 +553,25 @@ tests:
           path: spec.template.metadata.annotations.hello
           value: world
     template: templates/deployment.yaml
+
+  - it: Test adding CA certificate of OpenShift
+    template: templates/deployment.yaml
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].volumeMounts
+          content:
+            name: openshift-ca-cert
+            mountPath: /ca-certs
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: openshift-ca-cert
+            configMap:
+              name: openshift-service-ca.crt
+              items:
+              - key: service-ca.crt
+                path: service-ca.crt


### PR DESCRIPTION
add logic to load OpenShift ca cert to be able to use it when communicate to internal registry without using registry_ssl.verify=false to avoid error like below:

```
failed to load image with remote analyzer: Get "https://image-registry.openshift-image-registry.svc:5000/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [X] Chart Version bumped for the respective charts
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
