### PR TITLE
fix(agent): update windows agent ds template to remove not needed security context

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.35.0
+version: 1.35.1

--- a/charts/agent/templates/daemonset-windows.yaml
+++ b/charts/agent/templates/daemonset-windows.yaml
@@ -30,16 +30,6 @@ spec:
         {{ toYaml .Values.global.image.pullSecrets | nindent 8 }}
       {{- end }}
       securityContext:
-        privileged: true
-        {{- if ( semverCompare ">= 1.31.0" (.Capabilities.KubeVersion.GitVersion )) }}
-        runAsNonRoot: false
-        runAsGroup: 0
-        {{- end }}
-        readOnlyRootFilesystem: false
-        allowPrivilegeEscalation: true
-        capabilities:
-          add:
-            - ALL
         windowsOptions:
           hostProcess: true
           runAsUserName: "NT AUTHORITY\\SYSTEM"


### PR DESCRIPTION
## What this PR does / why we need it:
update windows agent ds template to remove not needed security context. Windows agent DaemonSet manifest is always out of sync for customers that are using Argo CD. This change is removing linux related security context from the ds manifest.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
