### PR TITLE
fix(registry-scanner): avoid duplicated fips suffix

### DIFF
--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://www.sysdig.com/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
-version: 1.6.6
+version: 1.6.7
 appVersion: 0.7.3
 maintainers:
   - name: sysdiglabs

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -136,7 +136,7 @@ Use the following command to deploy:
 helm upgrade --install registry-scanner \
    --namespace sysdig-agent \
    --create-namespace \
-   --version=1.6.6 \
+   --version=1.6.7 \
    --set config.secureBaseURL=<SYSDIG_SECURE_URL> \
    --set config.secureAPIToken=<SYSDIG_SECURE_API_TOKEN> \
    --set config.secureSkipTLS=true \

--- a/charts/registry-scanner/templates/_helpers.tpl
+++ b/charts/registry-scanner/templates/_helpers.tpl
@@ -115,7 +115,11 @@ Allow overriding registry and repository for air-gapped environments
 
 {{- define "registry-scanner.inlineScanImage" -}}
 {{- if .Values.image.fips -}}
-    {{- .Values.config.scan.inlineScanImage -}} -fips
+    {{- if hasSuffix "-fips" .Values.config.scan.inlineScanImage -}}
+        {{- .Values.config.scan.inlineScanImage -}}
+    {{- else -}}
+        {{- .Values.config.scan.inlineScanImage -}}-fips
+    {{- end -}}
 {{- else -}}
     {{- .Values.config.scan.inlineScanImage -}}
 {{- end -}}

--- a/charts/registry-scanner/templates/_helpers.tpl
+++ b/charts/registry-scanner/templates/_helpers.tpl
@@ -106,7 +106,9 @@ Allow overriding registry and repository for air-gapped environments
     {{- $imageTag = (printf "job-%s" .Chart.AppVersion) -}}
     {{- end -}}
     {{- if .Values.image.fips -}}
-    {{- $imageTag = (printf "%s-fips" $imageTag) -}}
+      {{- if not (hasSuffix "-fips" $imageTag) -}}
+        {{- $imageTag = (printf "%s-fips" $imageTag) -}}
+      {{- end -}}
     {{- end -}}
     {{- $globalRegistry := (default .Values.global dict).imageRegistry -}}
     {{- $globalRegistry | default $imageRegistry | default "quay.io" -}} / {{- $imageRepository -}} : {{- $imageTag -}}

--- a/charts/registry-scanner/tests/configmap_test.yaml
+++ b/charts/registry-scanner/tests/configmap_test.yaml
@@ -199,7 +199,19 @@ tests:
     asserts:
       - matchRegex:
           path: data['config.yaml']
-          pattern: "scan:((.|\n)*)inlineScanImage:.foo:bar-fips"
+          pattern: "scan:((.|\n)*)inlineScanImage:.foo:bar-fips\n"
+  - it: fips is requested with inlineScanImage already including fips suffix
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        tag: "bananas"
+        fips: true
+      config.scan.inlineScanImage: foo:bar-fips
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: "scan:((.|\n)*)inlineScanImage:.foo:bar-fips\n"
   - it: fips is NOT requested with inlineScanImage set
     set:
       scanOnStart:
@@ -210,7 +222,7 @@ tests:
     asserts:
       - matchRegex:
           path: data['config.yaml']
-          pattern: "scan:((.|\n)*)inlineScanImage: foo:bar"
+          pattern: "scan:((.|\n)*)inlineScanImage: foo:bar\n"
       - matchRegex:
           path: data['config.yaml']
-          pattern: "scan:((.|\n)*)inlineScanImage: foo:bar"
+          pattern: "scan:((.|\n)*)inlineScanImage: foo:bar\n"

--- a/charts/registry-scanner/tests/job_test.yaml
+++ b/charts/registry-scanner/tests/job_test.yaml
@@ -89,6 +89,19 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: ".*:bananas-fips$"
+
+  - it: fips is requested along with a custom tag that already includes fips
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        tag: "bananas-fips"
+        fips: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ".*:bananas-fips$"
+
   - it: fips is NOT requested but custom tag is
     set:
       scanOnStart:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
