### PR TITLE
fix(registry-scanner): handle error for fips image

### DIFF
--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://www.sysdig.com/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
-version: 1.6.8
+version: 1.6.9
 appVersion: 0.7.4
 maintainers:
   - name: sysdiglabs

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -136,7 +136,7 @@ Use the following command to deploy:
 helm upgrade --install registry-scanner \
    --namespace sysdig-agent \
    --create-namespace \
-   --version=1.6.8 \
+   --version=1.6.9 \
    --set config.secureBaseURL=<SYSDIG_SECURE_URL> \
    --set config.secureAPIToken=<SYSDIG_SECURE_API_TOKEN> \
    --set config.secureSkipTLS=true \

--- a/charts/registry-scanner/templates/_helpers.tpl
+++ b/charts/registry-scanner/templates/_helpers.tpl
@@ -118,7 +118,10 @@ Allow overriding registry and repository for air-gapped environments
 {{- define "registry-scanner.inlineScanImage" -}}
 {{- if .Values.image.fips -}}
     {{- if hasSuffix "-fips" .Values.config.scan.inlineScanImage -}}
-        {{- .Values.config.scan.inlineScanImage -}}
+        {{ fail "use `image.fips: true` instead of manually setting fips tag" }}
+    {{- end -}}
+    {{- if not .Values.config.scan.inlineScanImage -}}
+        {{- (include "registry-scanner.image" .) -}}
     {{- else -}}
         {{- .Values.config.scan.inlineScanImage -}}-fips
     {{- end -}}

--- a/charts/registry-scanner/templates/configmap.yaml
+++ b/charts/registry-scanner/templates/configmap.yaml
@@ -82,7 +82,7 @@ data:
           limits:
             memory: {{ .Values.config.scan.jobs.resources.limits.memory }}
         temporaryVolumeSizeLimit: {{ .Values.config.scan.jobs.temporaryVolumeSizeLimit }}
-      {{- if .Values.config.scan.inlineScanImage }}
+      {{- if  or .Values.config.scan.inlineScanImage .Values.image.fips }}
       inlineScanImage: {{ include "registry-scanner.inlineScanImage" . }}
       {{- end }}
       {{- if .Values.imagePullSecrets }}

--- a/charts/registry-scanner/tests/configmap_job_test.yaml
+++ b/charts/registry-scanner/tests/configmap_job_test.yaml
@@ -1,0 +1,123 @@
+suite: Registry Scanner - configmap and job
+templates:
+  - templates/configmap.yaml
+  - templates/job.yaml
+tests:
+  - it: fips is requested without inlineScanImage set
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        fips: true
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: "scan:((.|\n)*)inlineScanImage:.quay.io/sysdig/registry-scanner:job-0.7.4-fips\n"
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "quay.io/sysdig/registry-scanner:job-0.7.4-fips$"
+        template: templates/job.yaml
+  - it: fips is requested with inlineScanImage set
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        fips: true
+      config.scan.inlineScanImage: bananas/foo:bar
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: "scan:((.|\n)*)inlineScanImage:.bananas/foo:bar-fips\n"
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "quay.io/sysdig/registry-scanner:job-0.7.4-fips$"
+        template: templates/job.yaml
+  - it: fips is requested with inlineScanImage set and custom image repo
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        registry: bananas
+        repository: foo
+        tag: bar
+        fips: true
+      config.scan.inlineScanImage: something/different:boo
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: "scan:((.|\n)*)inlineScanImage:.something/different:boo-fips\n"
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "bananas/foo:bar-fips$"
+        template: templates/job.yaml
+  - it: fips is requested with inlineScanImage already including fips, fails
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        registry: bananas
+        repository: foo
+        tag: bar
+        fips: true
+      config.scan.inlineScanImage: something/different:boo-fips
+    asserts:
+      - failedTemplate:
+          errorMessage: "use `image.fips: true` instead of manually setting fips tag"
+        template: templates/configmap.yaml
+  - it: fips is requested without inlineScanImage set and custom image repo
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        registry: bananas
+        repository: foo
+        tag: bar
+        fips: true
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: "scan:((.|\n)*)inlineScanImage:.bananas/foo:bar-fips\n"
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "bananas/foo:bar-fips$"
+        template: templates/job.yaml
+  - it: custom repo and it does not set inlineScanImage
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        registry: bananas
+        repository: foo
+        tag: bar
+    asserts:
+      - notMatchRegex:
+          path: data['config.yaml']
+          pattern: "scan:((.|\n)*)inlineScanImage"
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "bananas/foo:bar$"
+        template: templates/job.yaml
+
+  - it: custom repo and custom inlineScanImage
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        registry: bananas
+        repository: foo
+        tag: bar
+      config.scan.inlineScanImage: something/different:boo-fips
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: "scan:((.|\n)*)inlineScanImage:.something/different:boo-fips"
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "bananas/foo:bar$"
+        template: templates/job.yaml

--- a/charts/registry-scanner/tests/configmap_test.yaml
+++ b/charts/registry-scanner/tests/configmap_test.yaml
@@ -209,9 +209,8 @@ tests:
         fips: true
       config.scan.inlineScanImage: foo:bar-fips
     asserts:
-      - matchRegex:
-          path: data['config.yaml']
-          pattern: "scan:((.|\n)*)inlineScanImage:.foo:bar-fips\n"
+      - failedTemplate:
+          errorMessage: "use `image.fips: true` instead of manually setting fips tag"
   - it: fips is NOT requested with inlineScanImage set
     set:
       scanOnStart:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
