### PR TITLE
feat(shield): add metrics port when promex is enabled

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -153,6 +153,10 @@ spec:
             - containerPort: {{ dig "kspm_analyzer" "port" 12000 .Values.host.additional_settings }}
               name: kspm-analyzer
             {{- end }}
+            {{- if (dig "prometheus_exporter" "enabled" false .Values.host.additional_settings) }}
+            - containerPort: {{ regexFind "[0-9]+$" (dig "prometheus_exporter" "listen_url" "0.0.0.0:9544" .Values.host.additional_settings) }}
+              name: metrics
+            {{- end }}
           readinessProbe:
             httpGet:
               host: 127.0.0.1

--- a/charts/shield/tests/host/daemonset_test.yaml
+++ b/charts/shield/tests/host/daemonset_test.yaml
@@ -619,3 +619,35 @@ tests:
       - equal:
           path: spec.template.spec.volumes[?(@.name == "vardata-vol")].hostPath.type
           value: DirectoryOrCreate
+
+  - it: No metrics port if promex is not enabled
+    asserts:
+      - isNullOrEmpty:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].ports
+
+  - it: Enabling promex creates the metrics port
+    set:
+      host:
+        additional_settings:
+          prometheus_exporter:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].ports
+          content:
+            containerPort: 9544
+            name: metrics
+
+  - it: Setting custom metrics port values works as expected
+    set:
+      host:
+        additional_settings:
+          prometheus_exporter:
+            enabled: true
+            listen_url: 0.0.0.0:1234
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].ports
+          content:
+            containerPort: 1234
+            name: metrics


### PR DESCRIPTION
When the prometheus exporter is enabled, ensure the metrics port has been created so that the exporter can be accessed.

## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
