### PR TITLE
fix(registry-scanner): do not set secrets when using an AWS Service Account 

### DIFF
--- a/charts/registry-scanner/Chart.yaml
+++ b/charts/registry-scanner/Chart.yaml
@@ -4,7 +4,7 @@ description: Sysdig Registry Scanner
 type: application
 home: https://www.sysdig.com/
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4
-version: 1.6.10
+version: 1.6.11
 appVersion: 0.7.5
 maintainers:
   - name: sysdiglabs

--- a/charts/registry-scanner/README.md
+++ b/charts/registry-scanner/README.md
@@ -136,7 +136,7 @@ Use the following command to deploy:
 helm upgrade --install registry-scanner \
    --namespace sysdig-agent \
    --create-namespace \
-   --version=1.6.10 \
+   --version=1.6.11 \
    --set config.secureBaseURL=<SYSDIG_SECURE_URL> \
    --set config.secureAPIToken=<SYSDIG_SECURE_API_TOKEN> \
    --set config.secureSkipTLS=true \

--- a/charts/registry-scanner/templates/_helpers.tpl
+++ b/charts/registry-scanner/templates/_helpers.tpl
@@ -180,3 +180,13 @@ Check cronjob value
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{/*
+{{/*
+EKS with AWS Service Account
+*/}}
+{{- define "registry-scanner.eksWithSA" -}}
+  {{- if hasKey .Values.serviceAccount.annotations "eks.amazonaws.com/role-arn" }}
+     true
+  {{- end }}
+{{- end }}

--- a/charts/registry-scanner/templates/_job.tpl
+++ b/charts/registry-scanner/templates/_job.tpl
@@ -74,6 +74,9 @@
           {{- end }}
           {{- if eq .Values.config.registryType "ecr" }}
           - name: AWS_ACCESS_KEY_ID
+            {{- if contains "true" (include "registry-scanner.eksWithSA" .)}}
+            value: ""
+            {{- else }}
             valueFrom:
               secretKeyRef:
                 {{- if not .Values.existingSecretName }}
@@ -82,7 +85,11 @@
                 name: {{ .Values.existingSecretName }}
                 {{- end }}
                 key: aws_access_key_id
+            {{- end }}
           - name: AWS_SECRET_ACCESS_KEY
+            {{- if contains "true" (include "registry-scanner.eksWithSA" .)}}
+            value: ""
+            {{- else }}
             valueFrom:
               secretKeyRef:
                 {{- if not .Values.existingSecretName }}
@@ -91,6 +98,7 @@
                 name: {{ .Values.existingSecretName }}
                 {{- end }}
                 key: aws_secret_access_key
+            {{- end }}
           - name: AWS_REGION
             valueFrom:
               secretKeyRef:

--- a/charts/registry-scanner/tests/job_test.yaml
+++ b/charts/registry-scanner/tests/job_test.yaml
@@ -112,3 +112,33 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: ".*:bananas$"
+  - it: uses generated secret name when existingSecretName is not set
+    set:
+      config.registryType: "ecr"
+      scanOnStart.enabled: true
+      existingSecretName: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-registry-scanner
+                key: aws_secret_access_key
+
+  - it: uses existingSecretName when set
+    set:
+      config.registryType: "ecr"
+      scanOnStart.enabled: true
+      existingSecretName: my-existing-secret
+      Release.Name: test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-existing-secret
+                key: aws_secret_access_key

--- a/charts/registry-scanner/tests/job_test.yaml
+++ b/charts/registry-scanner/tests/job_test.yaml
@@ -2,121 +2,120 @@ suite: Registry Scanner - scanOnStart Job
 templates:
   - templates/job.yaml
 tests:
-  - it: checks job manifest is available when scanOnStart is enabled
-    set:
-      scanOnStart:
-        enabled: true
-    asserts:
-      - containsDocument:
-          kind: Job
-          apiVersion: batch/v1
-  - it: checks job name is same as scanOnStart.jobName
-    set:
-      scanOnStart:
-        enabled: true
-        jobName: foo
-    asserts:
-      - equal:
-          path: metadata.name
-          value: foo
-  - it: sets extraEnvVars on job
-    set:
-      scanOnStart:
-        enabled: true
-      extraEnvVars:
-        - name: FOO
-          value: bar
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: FOO
-            value: bar
-  - it: sets default labels
-    set:
-      scanOnStart:
-        enabled: true
-    asserts:
-      - equal:
-          path: metadata.labels['app.kubernetes.io/component']
-          value: registry-scanner-orchestrator
-      - equal:
-          path: spec.template.metadata.labels['app.kubernetes.io/component']
-          value: registry-scanner-orchestrator
-  - it: ttlSecondsAfterFinished default value is set
-    set:
-      scanOnStart:
-        enabled: true
-    asserts:
-      - equal:
-          path: spec.ttlSecondsAfterFinished
-          value: 3600
-  - it: ttlSecondsAfterFinished is set
-    set:
-      config.scan.orchestrator.ttlSecondsAfterFinished: '0'
-      scanOnStart:
-        enabled: true
-    asserts:
-      - equal:
-          path: spec.ttlSecondsAfterFinished
-          value: 0
-  - it: ttlSecondsAfterFinished is unset
-    set:
-      config.scan.orchestrator.ttlSecondsAfterFinished: ''
-      scanOnStart:
-        enabled: true
-    asserts:
-      - isNull:
-          path: spec.ttlSecondsAfterFinished
-  - it: fips is requested
-    set:
-      scanOnStart:
-        enabled: true
-      image:
-        fips: true
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].image
-          pattern: ".*-fips$"
-  - it: fips is requested along with a custom tag
-    set:
-      scanOnStart:
-        enabled: true
-      image:
-        tag: "bananas"
-        fips: true
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].image
-          pattern: ".*:bananas-fips$"
-
-  - it: fips is requested along with a custom tag that already includes fips
-    set:
-      scanOnStart:
-        enabled: true
-      image:
-        tag: "bananas-fips"
-        fips: true
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].image
-          pattern: ".*:bananas-fips$"
-
-  - it: fips is NOT requested but custom tag is
-    set:
-      scanOnStart:
-        enabled: true
-      image:
-        tag: "bananas"
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].image
-          pattern: ".*:bananas$"
+#  - it: checks job manifest is available when scanOnStart is enabled
+#    set:
+#      scanOnStart:
+#        enabled: true
+#    asserts:
+#      - containsDocument:
+#          kind: Job
+#          apiVersion: batch/v1
+#  - it: checks job name is same as scanOnStart.jobName
+#    set:
+#      scanOnStart:
+#        enabled: true
+#        jobName: foo
+#    asserts:
+#      - equal:
+#          path: metadata.name
+#          value: foo
+#  - it: sets extraEnvVars on job
+#    set:
+#      scanOnStart:
+#        enabled: true
+#      extraEnvVars:
+#        - name: FOO
+#          value: bar
+#    asserts:
+#      - contains:
+#          path: spec.template.spec.containers[0].env
+#          content:
+#            name: FOO
+#            value: bar
+#  - it: sets default labels
+#    set:
+#      scanOnStart:
+#        enabled: true
+#    asserts:
+#      - equal:
+#          path: metadata.labels['app.kubernetes.io/component']
+#          value: registry-scanner-orchestrator
+#      - equal:
+#          path: spec.template.metadata.labels['app.kubernetes.io/component']
+#          value: registry-scanner-orchestrator
+#  - it: ttlSecondsAfterFinished default value is set
+#    set:
+#      scanOnStart:
+#        enabled: true
+#    asserts:
+#      - equal:
+#          path: spec.ttlSecondsAfterFinished
+#          value: 3600
+#  - it: ttlSecondsAfterFinished is set
+#    set:
+#      config.scan.orchestrator.ttlSecondsAfterFinished: '0'
+#      scanOnStart:
+#        enabled: true
+#    asserts:
+#      - equal:
+#          path: spec.ttlSecondsAfterFinished
+#          value: 0
+#  - it: ttlSecondsAfterFinished is unset
+#    set:
+#      config.scan.orchestrator.ttlSecondsAfterFinished: ''
+#      scanOnStart:
+#        enabled: true
+#    asserts:
+#      - isNull:
+#          path: spec.ttlSecondsAfterFinished
+#  - it: fips is requested
+#    set:
+#      scanOnStart:
+#        enabled: true
+#      image:
+#        fips: true
+#    asserts:
+#      - matchRegex:
+#          path: spec.template.spec.containers[0].image
+#          pattern: ".*-fips$"
+#  - it: fips is requested along with a custom tag
+#    set:
+#      scanOnStart:
+#        enabled: true
+#      image:
+#        tag: "bananas"
+#        fips: true
+#    asserts:
+#      - matchRegex:
+#          path: spec.template.spec.containers[0].image
+#          pattern: ".*:bananas-fips$"
+#
+#  - it: fips is requested along with a custom tag that already includes fips
+#    set:
+#      scanOnStart:
+#        enabled: true
+#      image:
+#        tag: "bananas-fips"
+#        fips: true
+#    asserts:
+#      - matchRegex:
+#          path: spec.template.spec.containers[0].image
+#          pattern: ".*:bananas-fips$"
+#
+#  - it: fips is NOT requested but custom tag is
+#    set:
+#      scanOnStart:
+#        enabled: true
+#      image:
+#        tag: "bananas"
+#    asserts:
+#      - matchRegex:
+#          path: spec.template.spec.containers[0].image
+#          pattern: ".*:bananas$"
   - it: uses generated secret name when existingSecretName is not set
     set:
       config.registryType: "ecr"
       scanOnStart.enabled: true
-      existingSecretName: ""
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -126,13 +125,19 @@ tests:
               secretKeyRef:
                 name: RELEASE-NAME-registry-scanner
                 key: aws_secret_access_key
-
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-registry-scanner
+                key: aws_region
   - it: uses existingSecretName when set
     set:
       config.registryType: "ecr"
       scanOnStart.enabled: true
       existingSecretName: my-existing-secret
-      Release.Name: test
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -142,3 +147,32 @@ tests:
               secretKeyRef:
                 name: my-existing-secret
                 key: aws_secret_access_key
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: my-existing-secret
+                key: aws_region
+  - it: does not set AWS_SECRET_ACCESS_KEY when serviceAccount.annotations are set
+    set:
+      config.registryType: "ecr"
+      serviceAccount:
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::123:role/MyRole
+      scanOnStart.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_SECRET_ACCESS_KEY
+            value: ""
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-registry-scanner
+                key: aws_region

--- a/charts/registry-scanner/tests/job_test.yaml
+++ b/charts/registry-scanner/tests/job_test.yaml
@@ -2,116 +2,116 @@ suite: Registry Scanner - scanOnStart Job
 templates:
   - templates/job.yaml
 tests:
-#  - it: checks job manifest is available when scanOnStart is enabled
-#    set:
-#      scanOnStart:
-#        enabled: true
-#    asserts:
-#      - containsDocument:
-#          kind: Job
-#          apiVersion: batch/v1
-#  - it: checks job name is same as scanOnStart.jobName
-#    set:
-#      scanOnStart:
-#        enabled: true
-#        jobName: foo
-#    asserts:
-#      - equal:
-#          path: metadata.name
-#          value: foo
-#  - it: sets extraEnvVars on job
-#    set:
-#      scanOnStart:
-#        enabled: true
-#      extraEnvVars:
-#        - name: FOO
-#          value: bar
-#    asserts:
-#      - contains:
-#          path: spec.template.spec.containers[0].env
-#          content:
-#            name: FOO
-#            value: bar
-#  - it: sets default labels
-#    set:
-#      scanOnStart:
-#        enabled: true
-#    asserts:
-#      - equal:
-#          path: metadata.labels['app.kubernetes.io/component']
-#          value: registry-scanner-orchestrator
-#      - equal:
-#          path: spec.template.metadata.labels['app.kubernetes.io/component']
-#          value: registry-scanner-orchestrator
-#  - it: ttlSecondsAfterFinished default value is set
-#    set:
-#      scanOnStart:
-#        enabled: true
-#    asserts:
-#      - equal:
-#          path: spec.ttlSecondsAfterFinished
-#          value: 3600
-#  - it: ttlSecondsAfterFinished is set
-#    set:
-#      config.scan.orchestrator.ttlSecondsAfterFinished: '0'
-#      scanOnStart:
-#        enabled: true
-#    asserts:
-#      - equal:
-#          path: spec.ttlSecondsAfterFinished
-#          value: 0
-#  - it: ttlSecondsAfterFinished is unset
-#    set:
-#      config.scan.orchestrator.ttlSecondsAfterFinished: ''
-#      scanOnStart:
-#        enabled: true
-#    asserts:
-#      - isNull:
-#          path: spec.ttlSecondsAfterFinished
-#  - it: fips is requested
-#    set:
-#      scanOnStart:
-#        enabled: true
-#      image:
-#        fips: true
-#    asserts:
-#      - matchRegex:
-#          path: spec.template.spec.containers[0].image
-#          pattern: ".*-fips$"
-#  - it: fips is requested along with a custom tag
-#    set:
-#      scanOnStart:
-#        enabled: true
-#      image:
-#        tag: "bananas"
-#        fips: true
-#    asserts:
-#      - matchRegex:
-#          path: spec.template.spec.containers[0].image
-#          pattern: ".*:bananas-fips$"
-#
-#  - it: fips is requested along with a custom tag that already includes fips
-#    set:
-#      scanOnStart:
-#        enabled: true
-#      image:
-#        tag: "bananas-fips"
-#        fips: true
-#    asserts:
-#      - matchRegex:
-#          path: spec.template.spec.containers[0].image
-#          pattern: ".*:bananas-fips$"
-#
-#  - it: fips is NOT requested but custom tag is
-#    set:
-#      scanOnStart:
-#        enabled: true
-#      image:
-#        tag: "bananas"
-#    asserts:
-#      - matchRegex:
-#          path: spec.template.spec.containers[0].image
-#          pattern: ".*:bananas$"
+  - it: checks job manifest is available when scanOnStart is enabled
+    set:
+      scanOnStart:
+        enabled: true
+    asserts:
+      - containsDocument:
+          kind: Job
+          apiVersion: batch/v1
+  - it: checks job name is same as scanOnStart.jobName
+    set:
+      scanOnStart:
+        enabled: true
+        jobName: foo
+    asserts:
+      - equal:
+          path: metadata.name
+          value: foo
+  - it: sets extraEnvVars on job
+    set:
+      scanOnStart:
+        enabled: true
+      extraEnvVars:
+        - name: FOO
+          value: bar
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FOO
+            value: bar
+  - it: sets default labels
+    set:
+      scanOnStart:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels['app.kubernetes.io/component']
+          value: registry-scanner-orchestrator
+      - equal:
+          path: spec.template.metadata.labels['app.kubernetes.io/component']
+          value: registry-scanner-orchestrator
+  - it: ttlSecondsAfterFinished default value is set
+    set:
+      scanOnStart:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 3600
+  - it: ttlSecondsAfterFinished is set
+    set:
+      config.scan.orchestrator.ttlSecondsAfterFinished: '0'
+      scanOnStart:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 0
+  - it: ttlSecondsAfterFinished is unset
+    set:
+      config.scan.orchestrator.ttlSecondsAfterFinished: ''
+      scanOnStart:
+        enabled: true
+    asserts:
+      - isNull:
+          path: spec.ttlSecondsAfterFinished
+  - it: fips is requested
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        fips: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ".*-fips$"
+  - it: fips is requested along with a custom tag
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        tag: "bananas"
+        fips: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ".*:bananas-fips$"
+
+  - it: fips is requested along with a custom tag that already includes fips
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        tag: "bananas-fips"
+        fips: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ".*:bananas-fips$"
+
+  - it: fips is NOT requested but custom tag is
+    set:
+      scanOnStart:
+        enabled: true
+      image:
+        tag: "bananas"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ".*:bananas$"
   - it: uses generated secret name when existingSecretName is not set
     set:
       config.registryType: "ecr"


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
