### PR TITLE
feat(host-shield): add proper container name when unprivileged mode is set

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 0.10.2
+version: 0.10.3
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_annotations.tpl
+++ b/charts/shield/templates/host/_annotations.tpl
@@ -11,7 +11,7 @@
     {{- $_ := set $podAnnotations "autopilot.gke.io/no-connect" "true" -}}
   {{- end -}}
   {{- if not .Values.host.privileged -}}
-    {{- $_ := set $podAnnotations "container.apparmor.security.beta.kubernetes.io/sysdig" "unconfined" -}}
+    {{- $_ := set $podAnnotations "container.apparmor.security.beta.kubernetes.io/sysdig-host-shield" "unconfined" -}}
   {{- end -}}
   {{- $podAnnotations | toYaml -}}
 {{- end -}}

--- a/charts/shield/tests/host/daemonset_test.yaml
+++ b/charts/shield/tests/host/daemonset_test.yaml
@@ -117,7 +117,7 @@ tests:
       - isSubset:
           path: spec.template.metadata.annotations
           content:
-            container.apparmor.security.beta.kubernetes.io/sysdig: unconfined
+            container.apparmor.security.beta.kubernetes.io/sysdig-host-shield: unconfined
       - isSubset:
           path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].securityContext
           content:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ x ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ x ] Chart Version bumped for the respective charts
- [ x ] Variables are documented in the README.md (or README.tpl in some charts)
- [ x ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ x ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
