### PR TITLE
fix(ci): ensure readme file is updated in shield chart

### DIFF
--- a/.github/updatecli.d/config-agent-release.yaml
+++ b/.github/updatecli.d/config-agent-release.yaml
@@ -47,7 +47,7 @@ targets:
       versionincrement: auto
 
   updateShieldChart:
-    name: "update the the shield chart"
+    name: "update the shield chart"
     kind: helmchart
     scmid: github
     spec:
@@ -55,3 +55,13 @@ targets:
       file: values.yaml
       key: "$.host.image.tag"
       versionincrement: auto
+
+  updateShieldReadme:
+    name: "update the shield readme"
+    kind: shell
+    scmid: github
+    dependson:
+      - updateShieldChart
+    spec:
+      shell: /bin/bash
+      command: make docs


### PR DESCRIPTION
## What this PR does / why we need it:
ensure that host shield release process also updates the readme file so that CI passes on the automated release PRs.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
