### PR TITLE
chore(shield): use volumeMount instead of env for rapid-response pwd

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_configmap_helpers.tpl
@@ -100,6 +100,7 @@ true
 {{- end }}
 {{- end }}
 
+{{/* Generate the 'dragent.yaml' content */}}
 {{- define "host.configmap" }}
 {{- $config := dict
   "k8s_cluster_name" .Values.cluster_config.name

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -214,6 +214,17 @@ true
 {{- end }}
 {{- end }}
 
+# Taking the rapid_response password from host.additional_settings or from the features section
+{{- define "host.rapid_response_password" }}
+{{- if (dig "rapid_response" "password" "" .Values.host.additional_settings) }}
+  {{- (dig "rapid_response" "password" "" .Values.host.additional_settings) }}
+{{- else }}
+  {{- with .Values.features }}
+  {{- (dig (include "host.respond_key" .) "rapid_response" "password" "" .) }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "host.monitor_key" }}
 {{- if hasKey . "monitoring" }}
 {{- print "monitoring" }}

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -132,13 +132,6 @@ spec:
             {{- include "common.proxy.envs" . | nindent 12 }}
             {{- end }}
             {{- include "common.custom_ca.envs" (merge (dict) . (dict "CACertsPath" "/opt/draios/certificates/")) | nindent 12 }}
-            {{- if (include "host.rapid_response_enabled" .) }}
-            - name: PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "host.rapid_response_secret" . }}
-                  key: password
-            {{- end }}
             {{- include "host.env" . | nindent 12 }}
             {{ if or .Values.features.posture.host_posture.enabled (dig "kspm_analyzer" "enabled" false .Values.host.additional_settings) }}
             - name: POD_NAMESPACE
@@ -181,8 +174,14 @@ spec:
               name: dshm
             - mountPath: /opt/draios/etc/kubernetes/config
               name: host-shield-config
-            - mountPath: /opt/draios/etc/kubernetes/secrets
-              name: host-shield-secrets
+            - mountPath: /opt/draios/etc/kubernetes/secrets/access-key
+              name: access-key-secret
+              subPath: access-key
+            {{- if (include "host.rapid_response_enabled" .) }}
+            - mountPath: /opt/draios/etc/kubernetes/secrets/rapid-response/password
+              name: rapid-response-secret
+              subPath: password
+            {{- end }}
             - mountPath: /etc/podinfo
               name: podinfo
           {{- /* Autopilot = false */}}
@@ -249,9 +248,14 @@ spec:
         - name: host-shield-config
           configMap:
             name: {{ include "host.fullname" . }}
-        - name: host-shield-secrets
+        - name: access-key-secret
           secret:
             secretName: {{ include "common.credentials.access_key_secret_name" . }}
+        {{- if (include "host.rapid_response_enabled" .) }}
+        - name: rapid-response-secret
+          secret:
+            secretName: {{ include "host.rapid_response_secret" . }}
+        {{- end }}
         - name: podinfo
           downwardAPI:
             defaultMode: 420

--- a/charts/shield/templates/host/secrets.yaml
+++ b/charts/shield/templates/host/secrets.yaml
@@ -9,5 +9,5 @@ metadata:
     {{- include "host.labels" . | nindent 4 }}
 type: Opaque
 data:
-  password: {{ (dig "rapid_response" "password" "" .Values.host.additional_settings) | b64enc | quote }}
+  password: {{ (include "host.rapid_response_password" .) | b64enc | quote }}
 {{- end }}

--- a/charts/shield/tests/host/daemonset_test.yaml
+++ b/charts/shield/tests/host/daemonset_test.yaml
@@ -233,13 +233,17 @@ tests:
             password: abc123
     asserts:
       - contains:
-          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].env
+          path: spec.template.spec.volumes
           content:
-            name: PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: release-name-shield-host-rapid-response
-                key: password
+            name: rapid-response-secret
+            secret:
+              secretName: release-name-shield-host-rapid-response
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].volumeMounts
+          content:
+            mountPath: /opt/draios/etc/kubernetes/secrets/rapid-response/password
+            name: rapid-response-secret
+            subPath: password
 
   - it: Host root and tmp not mounted by default
     asserts:


### PR DESCRIPTION

## What this PR does / why we need it:

Using `rapid-response` password secret as volume instead of env.

NOTE: as of now we need to use `subPath` volumeMounts since access-key is under the standard `/opt/draios/etc/kubernetes/secrets/` while rapid-response password has an additional `rapid-response` folder.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
