### PR TITLE
fix(shield): allow to override collector host if specified to keep consistent behaviour with port

### DIFF
--- a/charts/shield/templates/common/_regions.tpl
+++ b/charts/shield/templates/common/_regions.tpl
@@ -179,11 +179,21 @@
 {{- end }}
 
 {{- define "common.collector_endpoint" }}
-  {{- $regions := fromYaml (include "common.regions" .) }}
-  {{- if ne "custom" .Values.sysdig_endpoint.region }}
-    {{- get (get $regions .Values.sysdig_endpoint.region) "collector_endpoint"  }}
-  {{- else }}
+  {{- if .Values.sysdig_endpoint.collector.host }}
     {{- .Values.sysdig_endpoint.collector.host }}
+  {{- else }}
+    {{- if ne "custom" .Values.sysdig_endpoint.region }}
+      {{- $regions := fromYaml (include "common.regions" .) }}
+      {{- get (get $regions .Values.sysdig_endpoint.region) "collector_endpoint"  }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- define "common.collector_port" }}
+  {{- if .Values.sysdig_endpoint.collector.port }}
+    {{- .Values.sysdig_endpoint.collector.port }}
+  {{- else }}
+    6443
   {{- end }}
 {{- end }}
 

--- a/charts/shield/tests/common/regions_test.yaml
+++ b/charts/shield/tests/common/regions_test.yaml
@@ -4,23 +4,26 @@ templates:
 release:
   name: release-name
   namespace: shield-namespace
-values:
-  - ../values/base.yaml
 tests:
   - it: Sanity check for regions
     set:
+      cluster_config:
+        name: test-cluster
       sysdig_endpoint:
+        access_key: 12345678-1234-1234-1234-123456789012
         region: "eu1"
     asserts:
       - matchRegex:
           path: data["dragent.yaml"]
           pattern: |
             collector: ingest-eu1.app.sysdig.com
-            collector_port: 6443
 
   - it: API endpoint validation
     set:
+      cluster_config:
+        name: test-cluster
       sysdig_endpoint:
+        access_key: 12345678-1234-1234-1234-123456789012
         region: "us1"
     asserts:
       - matchRegex:

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -1107,6 +1107,18 @@ tests:
           pattern: |
             collector_port: 1234
 
+  - it: Validate collector endpoing can be overridden for region if provided
+    set:
+      sysdig_endpoint:
+        region: us1
+        collector:
+          host: ingest-alt-us1.app.sysdig.com
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            collector: ingest-alt-us1.app.sysdig.com
+
   - it: Check prometheus.yaml key is created when needed
     set:
       features:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
