### PR TITLE
chore(dependabot): do not update operator base automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,3 @@ updates:
       - "draios/team-tools-agent"
     labels:
       - "dependencies"
-  - package-ecosystem: docker
-    directory: "/rh-shield-operator"
-    schedule:
-      interval: "daily"
-    reviewers:
-      - "draios/team-tools-agent"
-    labels:
-      - "dependencies"


### PR DESCRIPTION
## What this PR does / why we need it:
It is not safe to update the operator base image automatically as the upstream project will do breaking changes that require additional changes as a part of minor releases.

See the following for examples:
* https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.38.0/
* https://github.com/sysdiglabs/charts/pull/2098

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
