### PR TITLE
feat(shield): improve regions handling logic to allow override region specific settings without setting region to custom

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.3.1
+version: 1.3.2
 appVersion: "1.0.0"

--- a/charts/shield/templates/common/_regions.tpl
+++ b/charts/shield/templates/common/_regions.tpl
@@ -180,8 +180,8 @@
 
 {{- define "common.collector_endpoint" }}
   {{- $regions := fromYaml (include "common.regions" .) }}
-  {{- if ne "custom" .Values.sysdig_endpoint.region }}
-    {{- get (get $regions .Values.sysdig_endpoint.region) "collector_endpoint"  }}
+  {{- if not .Values.sysdig_endpoint.collector.host }}
+    {{- get (get $regions .Values.sysdig_endpoint.region) "collector_endpoint" }}
   {{- else }}
     {{- .Values.sysdig_endpoint.collector.host }}
   {{- end }}
@@ -189,7 +189,7 @@
 
 {{- define "common.monitor_api_endpoint" }}
   {{- $regions := fromYaml (include "common.regions" .) }}
-  {{- if hasKey $regions .Values.sysdig_endpoint.region }}
+  {{- if not .Values.sysdig_endpoint.api_url }}
     {{- get (get $regions .Values.sysdig_endpoint.region) "monitor_api_endpoint" }}
   {{- else }}
     {{- .Values.sysdig_endpoint.api_url }}
@@ -198,7 +198,7 @@
 
 {{- define "common.secure_api_endpoint" }}
   {{- $regions := fromYaml (include "common.regions" .) }}
-  {{- if ne "custom" .Values.sysdig_endpoint.region }}
+  {{- if not .Values.sysdig_endpoint.api_url }}
     {{- get (get $regions .Values.sysdig_endpoint.region) "secure_api_endpoint" }}
   {{- else }}
     {{- .Values.sysdig_endpoint.api_url }}
@@ -207,9 +207,9 @@
 
 {{- define "common.secure_ui" }}
   {{- $regions := fromYaml (include "common.regions" .) }}
-  {{- if ne "custom" .Values.sysdig_endpoint.region }}
+  {{- if not .Values.sysdig_endpoint.api_url }}
     {{- get (get $regions .Values.sysdig_endpoint.region) "secure_ui" }}
   {{- else }}
-    {{- .Values.sysdig_endpoint.api_url}}
+    {{- .Values.sysdig_endpoint.api_url }}
   {{- end }}
 {{- end }}

--- a/charts/shield/tests/common/regions_test.yaml
+++ b/charts/shield/tests/common/regions_test.yaml
@@ -11,19 +11,59 @@ tests:
     set:
       sysdig_endpoint:
         region: "eu1"
+        api_url:
+        collector:
+          host:
+          port:
     asserts:
       - matchRegex:
           path: data["dragent.yaml"]
           pattern: |
             collector: ingest-eu1.app.sysdig.com
-            collector_port: 6443
 
   - it: API endpoint validation
     set:
       sysdig_endpoint:
         region: "us1"
+        api_url:
+        collector:
+          host:
+          port:
     asserts:
       - matchRegex:
           path: data["dragent.yaml"]
           pattern: |
             sysdig_api_endpoint: secure.sysdig.com
+
+  - it: Collector and API endpoint validation when collector host and port set, but region is not custom and api_url is not set.
+    set:
+      cluster_config:
+        name: test-cluster
+      sysdig_endpoint:
+        region: "us2"
+        collector:
+          host: ingest-alt-us2.app.sysdig.com
+          port: 443
+        api_url:
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: |
+            collector: ingest-alt-us2.app.sysdig.com
+            collector_port: 443
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: |
+            sysdig_api_endpoint: us2.app.sysdig.com
+
+  - it: Collector host, port and API endpoint validation when region is custom.
+    asserts:
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: |
+            collector: example.com
+            collector_port: 6443
+      - matchRegex:
+          path: data["dragent.yaml"]
+          pattern: |
+            sysdig_api_endpoint: https://www.example.com


### PR DESCRIPTION
## What this PR does / why we need it:
improve regions handling logic to allow override region specific settings without setting region to custom. Currently if we want to use alternative collector settings we have to use custom region and specify each of the following values:
```
sysdig_endpoint:
  region: custom
  api_url: https://www.example.com
  collector:
    host: example.com
    port: 6443
```
Many customers want to keep using default region settings and update only collector endpoints and use config like below:
```
sysdig_endpoint:
  region: us2
  collector:
    host: alt-example.com
    port: 443
```

This PR is addressing that functionality.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
