### PR TITLE
fix(shield): host shield honor the ssl.verify flag

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_configmap_helpers.tpl
@@ -115,7 +115,7 @@ true
 {{- define "host.dragent_yaml.host_scanner" }}
   {{- $config := dict }}
   {{- $config = merge $config (dict "host_fs_mount_path" "/host") }}
-  {{- if not .Values.ssl.verify }}
+  {{- if and (include "shield.is_semver" .Values.host.image.tag) (semverCompare "< 13.10.0" .Values.host.image.tag) (not .Values.ssl.verify) }}
     {{- $config = merge $config (dict "verify_certificate" false) }}
   {{- end }}
   {{- if hasKey .Values.host.additional_settings "host_scanner" }}
@@ -128,7 +128,7 @@ true
   {{- $config := dict }}
   {{- $respond := get .Values.features (include "host.respond_key" .Values.features) }}
   {{- $rapid_response := omit (get $respond "rapid_response") "password" }}
-  {{- if not .Values.ssl.verify }}
+  {{- if and (include "shield.is_semver" .Values.host.image.tag) (semverCompare "< 13.10.0" .Values.host.image.tag) (not .Values.ssl.verify) }}
     {{- $rapid_response = merge $rapid_response (dict "tls_skip_check" true) }}
   {{- end }}
   {{ $rapid_response | toJson }}

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -239,6 +239,13 @@ true
 {{- end }}
 {{- end }}
 
+{{- define "host.host_scanner_enabled" }}
+{{- if or .Values.features.vulnerability_management.host_vulnerability_management.enabled
+          (dig "host_scanner" "enabled" false .Values.host.additional_settings) }}
+true
+{{- end }}
+{{- end }}
+
 {{- define "host.monitor_key" }}
 {{- if hasKey . "monitoring" }}
 {{- print "monitoring" }}

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -1227,7 +1227,9 @@ tests:
       - matchRegex:
           path: data['dragent.yaml']
           pattern: |-
-            verify_certificate: false
+            host_scanner:
+              host_fs_mount_path: /host
+              verify_certificate: false
 
   - it: Disable SSL verification [Agent >= 13.10.0]
     set:
@@ -1248,13 +1250,13 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             ssl_verify_certificate: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |
             rapid_response:
               enabled: true
               tls_skip_check: true
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |
             host_scanner:

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -1198,3 +1198,146 @@ tests:
     asserts:
       - notExists:
           path: data["prometheus.yaml"]
+
+  - it: Disable SSL verification [Agent < 13.10.0]
+    set:
+      host:
+        image:
+          tag: 13.9.0
+      ssl:
+        verify: false
+      features:
+        respond:
+          rapid_response:
+            enabled: true
+        vulnerability_management:
+          host_vulnerability_management:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            ssl_verify_certificate: false
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            rapid_response:
+              enabled: true
+              tls_skip_check: true
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |-
+            verify_certificate: false
+
+  - it: Disable SSL verification [Agent >= 13.10.0]
+    set:
+      host:
+        image:
+          tag: 13.10.0
+      ssl:
+        verify: false
+      features:
+        respond:
+          rapid_response:
+            enabled: true
+        vulnerability_management:
+          host_vulnerability_management:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            ssl_verify_certificate: false
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            rapid_response:
+              enabled: true
+              tls_skip_check: true
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            host_scanner:
+              host_fs_mount_path: /host
+              verify_certificate: false
+
+  - it: Ensure ssl verification is not disabled by default
+    set:
+      features:
+        respond:
+          rapid_response:
+            enabled: true
+        vulnerability_management:
+          host_vulnerability_management:
+            enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            ssl_verify_certificate: false
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            rapid_response:
+              enabled: true
+              tls_skip_check: true
+      - notMatchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            host_scanner:
+              host_fs_mount_path: /host
+              verify_certificate: false
+
+  - it: Validate rapid response cert verification can be overridden
+    set:
+      host:
+        additional_settings:
+          rapid_response:
+            tls_skip_check: false
+      ssl:
+        verify: false
+      features:
+        respond:
+          rapid_response:
+            enabled: true
+        vulnerability_management:
+          host_vulnerability_management:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            ssl_verify_certificate: false
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            rapid_response:
+              enabled: true
+              tls_skip_check: false
+
+  - it: Validate host scanner cert verification can be overridden
+    set:
+      host:
+        additional_settings:
+          host_scanner:
+            verify_certificate: true
+      ssl:
+        verify: false
+      features:
+        respond:
+          rapid_response:
+            enabled: true
+        vulnerability_management:
+          host_vulnerability_management:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            ssl_verify_certificate: false
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            host_scanner:
+              host_fs_mount_path: /host
+              verify_certificate: true


### PR DESCRIPTION
## What this PR does / why we need it:
The `ssl.verify` key was not being inspected as it should for the various Host Shield ConfigMap entries. This led to connection failures in environments where verification must be disabled.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
