### PR TITLE
chore(agent,sysdig-deploy,shield): add /sys/fs mount

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 1.36.5
+version: 1.36.6

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -288,6 +288,8 @@ spec:
 
           {{- /* Slim = false, Autopilot = false */}}
           {{- if and (not .Values.slim.enabled) (not (include "agent.gke.autopilot" .)) }}
+            - mountPath: /host/sys/fs
+              name: sysfs-vol
             - mountPath: /etc/modprobe.d
               name: modprobe-d
               readOnly: true
@@ -326,6 +328,8 @@ spec:
               name: vardata-vol
             - mountPath: /host/var/run
               name: varrun-vol
+            - mountPath: /host/sys/fs
+              name: sysfs-vol
             {{- if (include "agent.ebpfEnabled" .) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -431,6 +435,10 @@ spec:
 
       {{- /* Slim = false, Autopilot = false */}}
       {{- if and (not .Values.slim.enabled) (not (include "agent.gke.autopilot" .)) }}
+        - name: sysfs-vol
+          readOnly: true
+          hostPath:
+            path: /sys/fs
         - name: modprobe-d
           hostPath:
             path: /etc/modprobe.d
@@ -463,6 +471,10 @@ spec:
 
       {{- /* Slim = true, Autopilot = false */}}
       {{- if and (.Values.slim.enabled) (not (include "agent.gke.autopilot" .)) }}
+        - name: sysfs-vol
+          readOnly: true
+          hostPath:
+            path: /sys/fs
         - name: modprobe-d
           hostPath:
             path: /etc/modprobe.d

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -290,6 +290,7 @@ spec:
           {{- if and (not .Values.slim.enabled) (not (include "agent.gke.autopilot" .)) }}
             - mountPath: /host/sys/fs
               name: sysfs-vol
+              readOnly: true
             - mountPath: /etc/modprobe.d
               name: modprobe-d
               readOnly: true
@@ -330,6 +331,7 @@ spec:
               name: varrun-vol
             - mountPath: /host/sys/fs
               name: sysfs-vol
+              readOnly: true
             {{- if (include "agent.ebpfEnabled" .) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -436,7 +438,6 @@ spec:
       {{- /* Slim = false, Autopilot = false */}}
       {{- if and (not .Values.slim.enabled) (not (include "agent.gke.autopilot" .)) }}
         - name: sysfs-vol
-          readOnly: true
           hostPath:
             path: /sys/fs
         - name: modprobe-d
@@ -472,7 +473,6 @@ spec:
       {{- /* Slim = true, Autopilot = false */}}
       {{- if and (.Values.slim.enabled) (not (include "agent.gke.autopilot" .)) }}
         - name: sysfs-vol
-          readOnly: true
           hostPath:
             path: /sys/fs
         - name: modprobe-d

--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.3.3
+version: 1.3.4
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -136,7 +136,7 @@ true
 {{- end }}
 
 {{- define "host.need_host_root" }}
-{{- if or .Values.features.posture.host_posture.enabled .Values.features.vulnerability_management.host_vulnerability_management.enabled }}
+{{- if or (eq (include "host.response_actions_enabled" .) "true") .Values.features.posture.host_posture.enabled .Values.features.vulnerability_management.host_vulnerability_management.enabled }}
 {{- true -}}
 {{- end }}
 {{- end }}
@@ -211,6 +211,24 @@ capabilities:
 {{- if (dig (include "host.respond_key" .) "rapid_response" "enabled" false .) }}
 true
 {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+  This function checks if the response_actions feature is enabled for the host.
+  It first checks the additional_settings and than the features.
+  If neither is found, it defaults to false.
+*/}}
+{{- define "host.response_actions_enabled" }}
+{{- $feature_respond := get .Values.features (include "host.respond_key" .Values.features) }}
+{{- $additional_features := default (dict) (get .Values.host.additional_settings "features") }}
+{{- $additional_respond := get $additional_features (include "host.respond_key" $additional_features) }}
+{{- if (and (eq (typeOf $additional_respond) "map[string]interface {}") (hasKey $additional_respond "response_actions")) }}
+{{- dig "response_actions" "enabled" false $additional_respond -}}
+{{- else if (and (eq (typeOf $feature_respond) "map[string]interface {}") (hasKey $feature_respond "response_actions")) }}
+{{- dig "response_actions" "enabled" false $feature_respond -}}
+{{- else }}
+{{- false -}}
 {{- end }}
 {{- end }}
 

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -216,19 +216,17 @@ true
 
 {{/*
   This function checks if the response_actions feature is enabled for the host.
-  It first checks the additional_settings and than the features.
+  It first checks the additional_settings and then the features.
   If neither is found, it defaults to false.
 */}}
 {{- define "host.response_actions_enabled" }}
-{{- $feature_respond := get .Values.features (include "host.respond_key" .Values.features) }}
-{{- $additional_features := default (dict) (get .Values.host.additional_settings "features") }}
-{{- $additional_respond := get $additional_features (include "host.respond_key" $additional_features) }}
-{{- if (and (eq (typeOf $additional_respond) "map[string]interface {}") (hasKey $additional_respond "response_actions")) }}
+{{- $feature_respond := dig (include "host.respond_key" .Values.features) (dict) .Values.features }}
+{{- $additional_features := dig "features" (dict) .Values.host.additional_settings }}
+{{- $additional_respond := dig (include "host.respond_key" $additional_features) (dict) $additional_features }}
+{{- if hasKey $additional_respond "response_actions" }}
 {{- dig "response_actions" "enabled" false $additional_respond -}}
-{{- else if (and (eq (typeOf $feature_respond) "map[string]interface {}") (hasKey $feature_respond "response_actions")) }}
+{{- else if hasKey $feature_respond "response_actions" }}
 {{- dig "response_actions" "enabled" false $feature_respond -}}
-{{- else }}
-{{- false -}}
 {{- end }}
 {{- end }}
 

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -196,9 +196,6 @@ spec:
               name: vardata-vol
             - mountPath: /host/var/run
               name: varrun-vol
-            - mountPath: /host/sys/fs
-              name: sysfs-vol
-              readOnly: true
             {{- if (include "host.driver.is_ebpf" .) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -273,9 +270,6 @@ spec:
 
       {{- /* Autopilot = false */}}
       {{- if not  (include "common.cluster_type.is_gke_autopilot" .) }}
-        - name: sysfs-vol
-          hostPath:
-            path: /sys/fs
         - name: modprobe-d
           hostPath:
             path: /etc/modprobe.d

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -198,6 +198,7 @@ spec:
               name: varrun-vol
             - mountPath: /host/sys/fs
               name: sysfs-vol
+              readOnly: true
             {{- if (include "host.driver.is_ebpf" .) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -273,7 +274,6 @@ spec:
       {{- /* Autopilot = false */}}
       {{- if not  (include "common.cluster_type.is_gke_autopilot" .) }}
         - name: sysfs-vol
-          readOnly: true
           hostPath:
             path: /sys/fs
         - name: modprobe-d

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -196,6 +196,8 @@ spec:
               name: vardata-vol
             - mountPath: /host/var/run
               name: varrun-vol
+            - mountPath: /host/sys/fs
+              name: sysfs-vol
             {{- if (include "host.driver.is_ebpf" .) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -270,6 +272,10 @@ spec:
 
       {{- /* Autopilot = false */}}
       {{- if not  (include "common.cluster_type.is_gke_autopilot" .) }}
+        - name: sysfs-vol
+          readOnly: true
+          hostPath:
+            path: /sys/fs
         - name: modprobe-d
           hostPath:
             path: /etc/modprobe.d

--- a/charts/shield/tests/host/daemonset_test.yaml
+++ b/charts/shield/tests/host/daemonset_test.yaml
@@ -248,6 +248,80 @@ tests:
       - notExists:
           path: spec.template.spec.volumes[?(@.name == "host-tmp")]
 
+  - it: Host root mounted when response_actions is enabled (additional_settings)
+    set:
+      host:
+        additional_settings:
+          features:
+            respond:
+              response_actions:
+                enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-root
+            hostPath:
+              path: /
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].volumeMounts
+          content:
+            name: host-root
+            mountPath: /host
+            readOnly: true
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name == "host-tmp")]
+
+  - it: Host root mounted when response_actions is enabled (features)
+    set:
+      features:
+        respond:
+          response_actions:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-root
+            hostPath:
+              path: /
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].volumeMounts
+          content:
+            name: host-root
+            mountPath: /host
+            readOnly: true
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name == "host-tmp")]
+
+  - it: Host root mounted when response_actions is enabled (only on additional_settings)
+    set:
+      features:
+        respond:
+          response_actions:
+            enabled: false
+      host:
+        additional_settings:
+          features:
+            respond:
+              response_actions:
+                enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-root
+            hostPath:
+              path: /
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].volumeMounts
+          content:
+            name: host-root
+            mountPath: /host
+            readOnly: true
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name == "host-tmp")]
+
   - it: Host root mounted when host scanner is enabled
     set:
       features:

--- a/charts/sysdig-deploy/Chart.yaml
+++ b/charts/sysdig-deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sysdig-deploy
 description: A chart with various Sysdig components for Kubernetes
 type: application
-version: 1.80.2
+version: 1.80.3
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com
@@ -26,7 +26,7 @@ dependencies:
   - name: agent
     # repository: https://charts.sysdig.com
     repository: file://../agent
-    version: ~1.36.5
+    version: ~1.36.6
     alias: agent
     condition: agent.enabled
   - name: common


### PR DESCRIPTION
## What this PR does / why we need it:

We need to mount `/sys/fs` when response_actions is enabled.
In the `sysdig-deploy` chart we're adding it by default on NON GKE Autopilot envs.
On `shield` chart we're adding the whole host-root mount if the feature is enabled (checking both host.additional_settings and features section)

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
