### PR TITLE
fix(agent): place readOnly attributes for sysfs-vol correctly

### DIFF
--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -290,6 +290,7 @@ spec:
           {{- if and (not .Values.slim.enabled) (not (include "agent.gke.autopilot" .)) }}
             - mountPath: /host/sys/fs
               name: sysfs-vol
+              readOnly: true
             - mountPath: /etc/modprobe.d
               name: modprobe-d
               readOnly: true
@@ -330,6 +331,7 @@ spec:
               name: varrun-vol
             - mountPath: /host/sys/fs
               name: sysfs-vol
+              readOnly: true
             {{- if (include "agent.ebpfEnabled" .) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -436,7 +438,6 @@ spec:
       {{- /* Slim = false, Autopilot = false */}}
       {{- if and (not .Values.slim.enabled) (not (include "agent.gke.autopilot" .)) }}
         - name: sysfs-vol
-          readOnly: true
           hostPath:
             path: /sys/fs
         - name: modprobe-d
@@ -472,7 +473,6 @@ spec:
       {{- /* Slim = true, Autopilot = false */}}
       {{- if and (.Values.slim.enabled) (not (include "agent.gke.autopilot" .)) }}
         - name: sysfs-vol
-          readOnly: true
           hostPath:
             path: /sys/fs
         - name: modprobe-d

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -198,6 +198,7 @@ spec:
               name: varrun-vol
             - mountPath: /host/sys/fs
               name: sysfs-vol
+              readOnly: true
             {{- if (include "host.driver.is_ebpf" .) }}
             - mountPath: /root/.sysdig
               name: bpf-probes
@@ -273,7 +274,6 @@ spec:
       {{- /* Autopilot = false */}}
       {{- if not  (include "common.cluster_type.is_gke_autopilot" .) }}
         - name: sysfs-vol
-          readOnly: true
           hostPath:
             path: /sys/fs
         - name: modprobe-d


### PR DESCRIPTION
## What this PR does / why we need it:

```
repos/charts ‹sysdig-deploy-add-fs-mount*›$ helm upgrade -n sysdig-agent sysdig-agent charts/sysdig-deploy
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(DaemonSet.spec.template.spec.volumes[8]): unknown field "readOnly" in io.k8s.api.core.v1.Volume
```

```
repos/charts ‹jacalvo/fix-sysdig-deploy-add-fs-mount›$ helm upgrade -n sysdig-agent sysdig-agent charts/sysdig-deploy
Release "sysdig-agent" has been upgraded. Happy Helming!
```

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
