### PR TITLE
chore(shield): remove default ca_certificate on http_proxy config for windows

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.3.5
+version: 1.3.6
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_windows_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_windows_configmap_helpers.tpl
@@ -81,9 +81,6 @@
 {{- if (include "common.proxy.enabled" . ) }}
   {{- $http_proxy := (include "host.dragent_proxy_config" . | fromYaml) -}}
   {{- $config := merge $config (dict "http_proxy" $http_proxy) -}}
-  {{- if (not $http_proxy.ca_certificate) -}}
-    {{- $_ := set $http_proxy "ca_certificate" "Certs/cacert.pem" -}}
-  {{- end -}}
 {{- end }}
 
 {{- if (include "host.windows.agent_runtime.log_level" . ) -}}

--- a/charts/shield/tests/host/configmap-windows-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-windows-dragent-yaml_test.yaml
@@ -86,7 +86,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy.example.com
               proxy_port: "8080"
               ssl: false
@@ -112,7 +111,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy-existing.example.com
               proxy_port: "8080"
               ssl: false
@@ -138,7 +136,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy.example.com
               proxy_password: password
               proxy_port: "8080"
@@ -166,7 +163,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy-existing.example.com
               proxy_password: passwordexisting
               proxy_port: "8080"
@@ -194,7 +190,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy.example.com
               proxy_port: "8080"
               ssl: true
@@ -220,7 +215,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy-existing.example.com
               proxy_port: "8080"
               ssl: true
@@ -246,7 +240,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy.example.com
               proxy_password: password
               proxy_port: "8080"
@@ -274,7 +267,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy-existing.example.com
               proxy_password: passwordexisting
               proxy_port: "8080"
@@ -302,7 +294,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy.example.com
               proxy_port: "8080"
               ssl: false
@@ -328,7 +319,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy-existing.example.com
               proxy_port: "8080"
               ssl: false
@@ -354,7 +344,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy.example.com
               proxy_password: password
               proxy_port: "8080"
@@ -382,7 +371,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy-existing.example.com
               proxy_password: passwordexisting
               proxy_port: "8080"
@@ -409,7 +397,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy.example.com
               proxy_port: "8080"
               ssl: true
@@ -435,7 +422,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy-existing.example.com
               proxy_port: "8080"
               ssl: true
@@ -460,7 +446,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy.example.com
               proxy_password: password
               proxy_port: "8080"
@@ -488,7 +473,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy-existing.example.com
               proxy_password: passwordexisting
               proxy_port: "8080"
@@ -516,7 +500,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy.example.com
               proxy_password: password
               proxy_port: "8080"
@@ -544,7 +527,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy-existing.example.com
               proxy_password: passwordexisting
               proxy_port: "8080"
@@ -572,7 +554,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy.example.com
               proxy_password: password
               proxy_port: "8080"
@@ -600,7 +581,6 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             http_proxy:
-              ca_certificate: Certs/cacert.pem
               proxy_host: proxy-existing.example.com
               proxy_password: passwordexisting
               proxy_port: "8080"


### PR DESCRIPTION
## What this PR does / why we need it:

Remove default `http_proxy.ca_certificate` on dragent.yaml for windows. Since now it's correctly handled by the agent itself

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
