### PR TITLE
feat(shield): use secure_light for netsec_enabled

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_configmap_helpers.tpl
@@ -44,7 +44,7 @@
 {{- end }}
 
 {{/* Check if semver. The regex is from the code of the library Helm uses for semver. */}}
-{{- define "shield.isSemVer" -}}
+{{- define "shield.is_semver" -}}
     {{- if regexMatch "^v?([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?$" . }}
         true
     {{- end -}}
@@ -73,7 +73,7 @@ true
 {{/* Calculate the agent mode based on enabled features */}}
 {{- define "host.configmap.agent_mode" }}
 {{- $mode := "secure_light" }}
-{{- if and (include "host.features.netsec_enabled" .) (include "shield.isSemVer" .Values.host.image.tag) (semverCompare "< 13.9.0" .Values.host.image.tag) }}
+{{- if and (include "host.features.netsec_enabled" .) (include "shield.is_semver" .Values.host.image.tag) (semverCompare "< 13.9.0" .Values.host.image.tag) }}
 {{- $mode = "secure" }}
 {{- end }}
 {{- if (include "host.features.monitor_enabled" .) }}

--- a/charts/shield/templates/host/_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_configmap_helpers.tpl
@@ -44,7 +44,7 @@
 {{- end }}
 
 {{/* Check if semver. The regex is from the code of the library Helm uses for semver. */}}
-{{- define "agent.isSemVer" -}}
+{{- define "shield.isSemVer" -}}
     {{- if regexMatch "^v?([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?$" . }}
         true
     {{- end -}}
@@ -73,7 +73,7 @@ true
 {{/* Calculate the agent mode based on enabled features */}}
 {{- define "host.configmap.agent_mode" }}
 {{- $mode := "secure_light" }}
-{{- if and (include "host.features.netsec_enabled" .) (include "agent.isSemVer" .Values.image.tag) (semverCompare "< 13.9.0" .Values.image.tag) }}
+{{- if and (include "host.features.netsec_enabled" .) (include "shield.isSemVer" .Values.host.image.tag) (semverCompare "< 13.9.0" .Values.host.image.tag) }}
 {{- $mode = "secure" }}
 {{- end }}
 {{- if (include "host.features.monitor_enabled" .) }}

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -983,6 +983,8 @@ tests:
         investigations:
           network_security:
             enabled: true
+      image:
+        tag: 13.8.0
     asserts:
       - matchRegex:
           path: data['dragent.yaml']
@@ -990,18 +992,50 @@ tests:
             feature:
               mode: secure
 
+  - it: Test enabling NetSec does not flip agent to secure mode for 13.9.0
+    set:
+      features:
+        investigations:
+          network_security:
+            enabled: true
+      image:
+        tag: 13.9.0
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            feature:
+              mode: secure_light
+
   - it: Test enabling NetSec in additional_settings flips agent to secure mode
     set:
       host:
         additional_settings:
           network_topology:
             enabled: true
+      image:
+        tag: 13.8.0
     asserts:
       - matchRegex:
           path: data['dragent.yaml']
           pattern: |
             feature:
               mode: secure
+
+  - it: Test enabling NetSec in additional_settings does not flip agent to secure mode for 13.9.0
+    set:
+      host:
+        additional_settings:
+          network_topology:
+            enabled: true
+      image:
+        tag: 13.9.0
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            feature:
+              mode: secure_light
 
   - it: Test enabling a monitor feature forces agent mode to monitor
     set:

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -985,8 +985,9 @@ tests:
         investigations:
           network_security:
             enabled: true
-      image:
-        tag: 13.8.0
+      host:
+        image:
+          tag: 13.8.0
     asserts:
       - matchRegex:
           path: data['dragent.yaml']
@@ -1000,8 +1001,9 @@ tests:
         investigations:
           network_security:
             enabled: true
-      image:
-        tag: notAVersion
+      host:
+        image:
+          tag: notAVersion
     asserts:
       - matchRegex:
           path: data['dragent.yaml']
@@ -1015,8 +1017,9 @@ tests:
         investigations:
           network_security:
             enabled: true
-      image:
-        tag: 13.9.0
+      host:
+        image:
+          tag: 13.9.0
     asserts:
       - matchRegex:
           path: data['dragent.yaml']

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -786,9 +786,6 @@ tests:
         investigations:
           network_security:
             enabled: true
-      host:
-          image:
-            tag: 13.8.0
     asserts:
       - matchRegex:
           path: data['dragent.yaml']

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -786,8 +786,9 @@ tests:
         investigations:
           network_security:
             enabled: true
-      image:
-        tag: 13.8.0
+      host:
+          image:
+            tag: 13.8.0
     asserts:
       - matchRegex:
           path: data['dragent.yaml']
@@ -1033,8 +1034,8 @@ tests:
         additional_settings:
           network_topology:
             enabled: true
-      image:
-        tag: 13.8.0
+        image:
+          tag: 13.8.0
     asserts:
       - matchRegex:
           path: data['dragent.yaml']
@@ -1048,8 +1049,8 @@ tests:
         additional_settings:
           network_topology:
             enabled: true
-      image:
-        tag: 13.9.0
+        image:
+          tag: 13.9.0
     asserts:
       - matchRegex:
           path: data['dragent.yaml']

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -786,6 +786,8 @@ tests:
         investigations:
           network_security:
             enabled: true
+      image:
+        tag: 13.8.0
     asserts:
       - matchRegex:
           path: data['dragent.yaml']
@@ -991,6 +993,21 @@ tests:
           pattern: |
             feature:
               mode: secure
+
+  - it: Test enabling NetSec does not flip agent to secure mode for unknown version
+    set:
+      features:
+        investigations:
+          network_security:
+            enabled: true
+      image:
+        tag: notAVersion
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            feature:
+              mode: secure_light
 
   - it: Test enabling NetSec does not flip agent to secure mode for 13.9.0
     set:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
