### PR TITLE
chore(shield): handle on windows host the agent additional_settings inside host-shield.yaml config

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.6.0
+version: 1.6.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_windows_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_windows_configmap_helpers.tpl
@@ -67,6 +67,16 @@
 
 {{- $config := merge $config (dict "proxy" (include "host.proxy_config" . | fromYaml)) }}
 
+{{- if and (include "common.semver.is_valid" .Values.host_windows.image.tag) (semverCompare ">= 0.8.0" .Values.host_windows.image.tag) }}
+{{- $runtimeAdditionalSettings := dict }}
+{{- if (include "host.windows.agent_runtime.log_level" . ) -}}
+  {{- $console_priority := dict "console_priority" (include "host.windows.agent_runtime.log_level" .) -}}
+  {{- $_ := set $runtimeAdditionalSettings "log" $console_priority -}}
+{{- end }}
+{{- $runtimeAdditionalSettings = mergeOverwrite $runtimeAdditionalSettings ((include "host.windows.runtime_config_override" .) | fromYaml) }}
+{{- $config := merge $config (dict "internals" (dict "agent_runtime" (dict "additional_settings" $runtimeAdditionalSettings))) }}
+{{- end }}
+
 {{- $override := (include "host.windows.shield_config_override" .) | fromYaml }}
 {{- $finalConfig := mergeOverwrite $config $override }}
 {{- $finalConfig | toYaml }}

--- a/charts/shield/templates/host/_windows_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_windows_configmap_helpers.tpl
@@ -68,12 +68,7 @@
 {{- $config := merge $config (dict "proxy" (include "host.proxy_config" . | fromYaml)) }}
 
 {{- if and (include "common.semver.is_valid" .Values.host_windows.image.tag) (semverCompare ">= 0.8.0" .Values.host_windows.image.tag) }}
-{{- $runtimeAdditionalSettings := dict }}
-{{- if (include "host.windows.agent_runtime.log_level" . ) -}}
-  {{- $console_priority := dict "console_priority" (include "host.windows.agent_runtime.log_level" .) -}}
-  {{- $_ := set $runtimeAdditionalSettings "log" $console_priority -}}
-{{- end }}
-{{- $runtimeAdditionalSettings = mergeOverwrite $runtimeAdditionalSettings ((include "host.windows.runtime_config_override" .) | fromYaml) }}
+{{- $runtimeAdditionalSettings := (include "host.windows.runtime_config_override" .) | fromYaml }}
 {{- $config := merge $config (dict "internals" (dict "agent_runtime" (dict "additional_settings" $runtimeAdditionalSettings))) }}
 {{- end }}
 

--- a/charts/shield/templates/host/configmap-windows.yaml
+++ b/charts/shield/templates/host/configmap-windows.yaml
@@ -9,6 +9,8 @@ metadata:
 data:
   host-shield.yaml: |
     {{- include "host.windows.host_shield_config" . | nindent 4 }}
+{{- if and (include "common.semver.is_valid" .Values.host_windows.image.tag) (semverCompare "< 0.8.0" .Values.host_windows.image.tag) }}
   dragent.yaml: |
     {{- include "host.windows.configmap" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/shield/tests/host/configmap-windows-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-windows-dragent-yaml_test.yaml
@@ -729,3 +729,16 @@ tests:
           pattern: |
             collector: ingest-alt-eu1.app.sysdig.com
             collector_port: 6443
+
+  - it: Test agent_runtime_additional_settings with version < 0.8.0
+    set:
+      host_windows:
+        image:
+          tag: "0.7.1"
+        agent_runtime_additional_settings:
+          connection_timeout: 1000
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: |
+            connection_timeout: 1000

--- a/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
+++ b/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
@@ -415,3 +415,36 @@ tests:
             sysdig_endpoint:
               collector: {}
               region: eu1-alt
+
+  - it: Test log_level with version >= 0.8.0
+    set:
+      host_windows:
+        image:
+          tag: "0.8.0"
+        additional_settings:
+          log_level: debug
+    asserts:
+      - matchRegex:
+          path: data['host-shield.yaml']
+          pattern: |
+            internals:
+              agent_runtime:
+                additional_settings:
+                  log:
+                    console_priority: debug
+
+  - it: Test agent_runtime_additional_settings with version >= 0.8.0
+    set:
+      host_windows:
+        image:
+          tag: "0.8.0"
+        agent_runtime_additional_settings:
+          connection_timeout: 1000
+    asserts:
+      - matchRegex:
+          path: data['host-shield.yaml']
+          pattern: |
+            internals:
+              agent_runtime:
+                additional_settings:
+                  connection_timeout: 1000

--- a/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
+++ b/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
@@ -416,23 +416,6 @@ tests:
               collector: {}
               region: eu1-alt
 
-  - it: Test log_level with version >= 0.8.0
-    set:
-      host_windows:
-        image:
-          tag: "0.8.0"
-        additional_settings:
-          log_level: debug
-    asserts:
-      - matchRegex:
-          path: data['host-shield.yaml']
-          pattern: |
-            internals:
-              agent_runtime:
-                additional_settings:
-                  log:
-                    console_priority: debug
-
   - it: Test agent_runtime_additional_settings with version >= 0.8.0
     set:
       host_windows:

--- a/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
+++ b/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
@@ -424,6 +424,8 @@ tests:
         agent_runtime_additional_settings:
           connection_timeout: 1000
     asserts:
+      - notExists:
+          path: data['dragent.yaml']
       - matchRegex:
           path: data['host-shield.yaml']
           pattern: |


### PR DESCRIPTION
From the next `0.8.0` host-shield windows version, we're going to move the legacy dragent.yaml configuration under host-shield.yaml

## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
