### PR TITLE
feat(harbor-scanner-sysdig-deploy): Allow usage of an existing secret for cliScanning

### DIFF
--- a/.github/workflows/helm-unit-test.yaml
+++ b/.github/workflows/helm-unit-test.yaml
@@ -65,5 +65,8 @@ jobs:
       - name: Test sysdig-stackdriver-bridge
         run: helm unittest --strict ./charts/sysdig-stackdriver-bridge
 
+      - name: Test harbor-scanner-sysdig-secure
+        run: helm unittest --strict ./charts/harbor-scanner-sysdig-secure
+
       - name: Test shield
         run: helm unittest --strict -f 'tests/*/*_test.yaml' ./charts/shield

--- a/charts/harbor-scanner-sysdig-secure/Chart.yaml
+++ b/charts/harbor-scanner-sysdig-secure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: harbor-scanner-sysdig-secure
 description: Harbor Scanner for Sysdig Secure
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: 0.8.0
 home: https://github.com/sysdiglabs/harbor-scanner-sysdig-secure
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/harbor-scanner-sysdig-secure/Chart.yaml
+++ b/charts/harbor-scanner-sysdig-secure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: harbor-scanner-sysdig-secure
 description: Harbor Scanner for Sysdig Secure
 type: application
-version: 0.8.1
+version: 0.9.0
 appVersion: 0.8.0
 home: https://github.com/sysdiglabs/harbor-scanner-sysdig-secure
 icon: https://avatars.githubusercontent.com/u/5068817?s=200&v=4

--- a/charts/harbor-scanner-sysdig-secure/README.md
+++ b/charts/harbor-scanner-sysdig-secure/README.md
@@ -85,14 +85,14 @@ Sysdig Secure chart and their default values:
 | `nodeSelector`                               | Specifies the nodeSelector for scheduling.                   | `{}`                                      |
 | `tolerations`                                | Specifies the tolerations for scheduling.                    | `[]`                                      |
 | `affinity`                                   | Enables affinity rules                                       | `{}`                                      |
-| `sysdig.secure.apiToken`                     | Specifies the API Token to access Sysdig Secure. This value is **mandatory**. | ` `                                       |
+| `sysdig.secure.apiToken`                     | Specifies the API Token to access Sysdig Secure. This value is **required** if the `sysdig.secure.existingSecureAPITokenSecret` is not specified. | ` `                                       |
 | `sysdig.secure.existingSecureAPITokenSecret` | Specifies the existing secret name with API Token to access Sysdig Secure <br/>Alternatively, you can specify the name of a Kubernetes secret containing `sysdig_secure_api_token` entry. <br/><br/>If both are not configured, you must  provide the deployment with the `SECURE_API_TOKEN` environment variables. | ` `                                       |
 | `sysdig.secure.url`                          | Specifies the Sysdig Secure endpoint.                        | `https://secure.sysdig.com`               |
 | `sysdig.secure.verifySSL`                    | Verifies whether SSL certificate when connecting to Sysdig Secure endpoint. | `true`                                    |
-| `proxy.httpProxy`                            | Specifies the URL of the proxy for HTTP connections. Leave empty if not using proxy. It sets the `http_proxy` environment variable. | ` `                                       |
+| `proxy.httpProxy`                            | Specifies the URL of the proxy for HTTP connections. Leave empty if not using proxy. It sets the `http_proxy` environment variable.    | ` `                                       |
 | `proxy.httpsProxy`                           | Specifies the URL of the proxy for HTTPS connections. Leave empty if not using proxy.  It sets the `https_proxy` environment variable. | ` `                                       |
 | `proxy.noProxy`                              | Specifies the comma-separated list of domain extensions proxy should not be used for. Includes the internal IP of the kube API server. | ` `                                       |
-| `cliScanning.enabled`                     | Enables the CLI Scanning feature.                         | `true`                                    |
-| `cliScanning.image`                       | Specifies the pullstring for the CLI Scanner Image.                         | `alpine:latest`                                    |
-| `cliScanning.existingSecureAPITokenSecret`                       | Specifies the existing secret name with API Token to access Sysdig Secure                         | `{{ include "harbor-scanner-sysdig-secure.fullname" . }}`                                    |
+| `cliScanning.enabled`                        | Enables the CLI Scanning feature.                            | `true`                                    |
+| `cliScanning.image`                          | Specifies the pullstring for the CLI Scanner Image.          | `alpine:latest`                           |
+| `cliScanning.existingSecureAPITokenSecret`   | Specifies the existing secret name with API Token to access Sysdig Secure                         | `{{ include "harbor-scanner-sysdig-secure.fullname" . }}`                                    |
 | `asyncMode.enabled`                          | Enables the Async-Mode feature.                              | `false`                                   |

--- a/charts/harbor-scanner-sysdig-secure/README.md
+++ b/charts/harbor-scanner-sysdig-secure/README.md
@@ -94,4 +94,5 @@ Sysdig Secure chart and their default values:
 | `proxy.noProxy`                              | Specifies the comma-separated list of domain extensions proxy should not be used for. Includes the internal IP of the kube API server. | ` `                                       |
 | `cliScanning.enabled`                     | Enables the CLI Scanning feature.                         | `true`                                    |
 | `cliScanning.image`                       | Specifies the pullstring for the CLI Scanner Image.                         | `alpine:latest`                                    |
+| `cliScanning.existingSecureAPITokenSecret`                       | Specifies the existing secret name with API Token to access Sysdig Secure                         | `{{ include "harbor-scanner-sysdig-secure.fullname" . }}`                                    |
 | `asyncMode.enabled`                          | Enables the Async-Mode feature.                              | `false`                                   |

--- a/charts/harbor-scanner-sysdig-secure/templates/deployment.yaml
+++ b/charts/harbor-scanner-sysdig-secure/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
             - name: NAMESPACE_NAME
               value: {{ .Release.Namespace }}
             - name: SECRET_NAME
-              value: {{ include "harbor-scanner-sysdig-secure.fullname" . }}
+              value: {{ .Values.cliScanning.existingSecureAPITokenSecret | default (include "harbor-scanner-sysdig-secure.fullname" .) }}
             - name: CLI_SCANNER_IMAGE
               value: {{ .Values.cliScanning.image | quote }}
             {{- end }}

--- a/charts/harbor-scanner-sysdig-secure/tests/secret_test.yaml
+++ b/charts/harbor-scanner-sysdig-secure/tests/secret_test.yaml
@@ -1,0 +1,46 @@
+suite: Test Harbor Scanner secrets
+templates:
+  - templates/secret.yaml
+  - templates/deployment.yaml
+tests:
+  - it: Do not create the secret if the API Token is not set
+    asserts:
+      - hasDocuments:
+          count: 0
+    template: templates/secret.yaml
+
+  - it: Create the secret if the API Token is set
+    set:
+      sysdig:
+        secure:
+          apiToken: 1234-1234
+    asserts:
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+      - equal:
+          path: .data.sysdig_secure_api_token
+          value: MTIzNC0xMjM0
+    template: templates/secret.yaml
+
+  - it: Use the default secret
+    set:
+      sysdig:
+        secure:
+          apiToken: 1234-1234
+    asserts:
+      - equal:
+          path: .spec.template.spec.containers[0].env[?(@.name=="SECURE_API_TOKEN")].valueFrom.secretKeyRef.name
+          value: RELEASE-NAME-harbor-scanner-sysdig-secure
+    template: templates/deployment.yaml
+
+  - it: Use the custome secret when specified
+    set:
+      sysdig:
+        secure:
+          existingSecureAPITokenSecret: custom-secure-api-token-secret
+    asserts:
+      - equal:
+          path: .spec.template.spec.containers[0].env[?(@.name=="SECURE_API_TOKEN")].valueFrom.secretKeyRef.name
+          value: custom-secure-api-token-secret
+    template: templates/deployment.yaml

--- a/charts/harbor-scanner-sysdig-secure/values.yaml
+++ b/charts/harbor-scanner-sysdig-secure/values.yaml
@@ -90,6 +90,8 @@ proxy:
 cliScanning:
   enabled: true
   image: alpine:latest
+  # specify the name of a Kubernetes secret containing an 'sysdig_secure_api_token' entry, defaults to harbor-scanner-sysdig-secure.fullname
+  existingSecureAPITokenSecret: ""
 
 asyncMode:
   enabled: true


### PR DESCRIPTION
## What this PR does / why we need it:
This allows the jobs spun up when cliScanning is enabled to use a secret with a different name than 'harbor-scanner-sysdig-secure.fullname'. This is useful if there is a secret defined with the same name for a different purpose.

This is a cherry-pick of PR:
https://github.com/sysdiglabs/charts/pull/2247


## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [X] Chart Version bumped for the respective charts
- [X] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
