### PR TITLE
chore(shield): add cluster name mapping to windows host-shield config

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.6.1
+version: 1.6.2
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_windows_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_windows_configmap_helpers.tpl
@@ -69,6 +69,7 @@
 
 {{- if and (include "common.semver.is_valid" .Values.host_windows.image.tag) (semverCompare ">= 0.8.0" .Values.host_windows.image.tag) }}
 {{- $runtimeAdditionalSettings := (include "host.windows.runtime_config_override" .) | fromYaml }}
+{{- $_ := set $runtimeAdditionalSettings "k8s_cluster_name" .Values.cluster_config.name -}}
 {{- $config := merge $config (dict "internals" (dict "agent_runtime" (dict "additional_settings" $runtimeAdditionalSettings))) }}
 {{- end }}
 

--- a/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
+++ b/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
@@ -418,6 +418,8 @@ tests:
 
   - it: Test agent_runtime_additional_settings with version >= 0.8.0
     set:
+      cluster_config:
+        name: "test-cluster"
       host_windows:
         image:
           tag: "0.8.0"
@@ -433,3 +435,4 @@ tests:
               agent_runtime:
                 additional_settings:
                   connection_timeout: 1000
+                  k8s_cluster_name: test-cluster


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
