### PR TITLE
fix(cluster-shield,shield): remove allowedUnsafeSysctls

### DIFF
--- a/charts/cluster-shield/Chart.yaml
+++ b/charts/cluster-shield/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cluster-shield
 description: Cluster Shield Helm Chart for Kubernetes
 type: application
-version: 1.12.0
-appVersion: "1.12.0"
+version: 1.12.1
+appVersion: "1.12.1"
 maintainers:
   - name: AlbertoBarba
     email: alberto.barba@sysdig.com

--- a/charts/cluster-shield/templates/openshift_securitycontextconstraint.yaml
+++ b/charts/cluster-shield/templates/openshift_securitycontextconstraint.yaml
@@ -16,7 +16,6 @@ allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 allowedCapabilities: []
-allowedUnsafeSysctls: []
 defaultAddCapabilities: []
 fsGroup:
   type: RunAsAny

--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.8.0
+version: 1.8.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/openshift-securitycontextconstraint.yaml
+++ b/charts/shield/templates/cluster/openshift-securitycontextconstraint.yaml
@@ -16,7 +16,6 @@ allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 allowedCapabilities: []
-allowedUnsafeSysctls: []
 defaultAddCapabilities: []
 fsGroup:
   type: RunAsAny


### PR DESCRIPTION
## What this PR does / why we need it:

This restores some changes made in #2005. For some reason commit #2173 (chore) reverted some of them (I'm guessing unintentional).

Encountered by using OpenShift GitOps (Argo CD) with the Shield chart v1.7.1 as explained in #2005.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

