### PR TITLE
docs(harbor-scanner-sysdig-secure): automate readme generation

### DIFF
--- a/charts/harbor-scanner-sysdig-secure/README.md
+++ b/charts/harbor-scanner-sysdig-secure/README.md
@@ -1,4 +1,18 @@
-# Chart: Harbor Scanner Adapter for Sysdig Secure
+<!--
+TODO: Correct content is now in README.md, being refactories. We will copy back to README.tpl once finished
+
+DO NOT MODIFY README.md MANUALLY!! CHANGE README.tpl instead!!
+
+README.md IS AUTO-GENERATED vía README.tpl with pre-comit plugin
+this is under construction so it must be launched manually
+
+in the project root, run:
+$ pre-commit install
+$ pre-commit run -a
+
+-->
+
+# Harbor Scanner Adapter for Sysdig Secure
 
 This chart deploys the [Harbor Scanner Adapter](https://github.com/sysdiglabs/harbor-scanner-sysdig-secure) for Sysdig Secure on your Kubernetes cluster.
 
@@ -14,7 +28,7 @@ To install the chart:
 ```console
 helm repo add sysdig https://charts.sysdig.com
 helm repo update
-helm install harbor-scanner-sysdig-secure --namespace harbor-scanner-sysdig-secure --create-namespace -f values.yaml sysdig/harbor-scanner-sysdig-secure
+helm install sysdig-harbor-scanner --namespace sysdig-harbor-scanner --create-namespace -f values.yaml sysdig/harbor-scanner-sysdig-secure
 ```
 
 ## Verify the integrity and origin
@@ -44,55 +58,63 @@ Specify each parameter using the `--set key=value[,key=value]` argument to the `
 
 For example:
 
-```console
-helm install harborscanner-release \
-    --set sysdig.secure.apiToken=<SECURE-API-TOKEN> \
-    sysdig/harbor-scanner-sysdig-secure
+```bash
+helm upgrade --install sysdig-harbor-scanner sysdig/harbor-scanner-sysdig-secure \
+    --create-namespace -n sysdig-harbor-scanner --version=0.9.0  \
+    --set sysdig.secure.apiToken=<SECURE-API-TOKEN>
 ```
 
 ### Using values.yaml
 
-The `values.yaml` file specifies the values for the configuration parameters.  You can add the configuration to the `values.yaml` file, then use it in the `helm install` command.
+The `values.yaml` file specifies the values for the admission controller configuration parameters.  You can add the configuration to the `values.yaml` file, then use it in the `helm install` command.
 
-```console
-$ helm install harborscanner-release -f values.yaml sysdig/harbor-scanner-sysdig-secure
+For example:
+
+```bash
+helm upgrade --install sysdig-harbor-scanner sysdig/harbor-scanner-sysdig-secure \
+     --create-namespace -n sysdig-harbor-scanner --version=0.9.0  \
+    --values values.yaml
+
 ```
+
+See the default [`values.yaml`](./values.yaml) file for more information.
+
 
 ## Configuration Parameters
 
-The following table lists the configurable parameters of the Harbor Scanner
-Sysdig Secure chart and their default values:
+The following table lists the configurable parameters of the `harbor-scanner-sysdig-secure` chart and their default values.
 
-| Parameter                                    | Description                                                  | Default                                   |
-| -------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------- |
-| `customEntryPoint`                           | Overrides the container entrypoint.                          | `[]`                                      |
-| `replicaCount`                               | Specifies the number of replicas for the Scanner Adapter.    | `1`                                       |
-| `image.repository`                           | Specifies the image repository to pull the image from.       | `sysdiglabs/harbor-scanner-sysdig-secure` |
-| `image.tag`                                  | Specifies the image tag to pull.                             | `{{ Chart.AppVersion }}`                  |
-| `image.pullPolicy`                           | Specifies the image pull policy.                             | `IfNotPresent`                            |
-| `imagePullSecrets`                           | Specifies the image pull secrets.                            | `[]`                                      |
-| `nameOverride`                               | Specifies the chart name override.                           | ` `                                       |
-| `fullnameOverride`                           | Specifies the chart full name override                       | ` `                                       |
-| `serviceAccount.create`                      | Creates the service account.                                 | `true`                                    |
-| `serviceAccount.annotations`                 | Specifies the extra annotations for serviceAccount.          | `{}`                                      |
-| `serviceAccount.name`                        | Specifies the serviceAccount name.                           | ` `                                       |
-| `rbac.create`                                | Creates and uses RBAC resources.                             | `true`                                    |
-| `podAnnotations`                             | Specifies the custom pod annotations.                        | `{}`                                      |
-| `podSecurityContext`                         | Enables deployment PSPs.                                     | `{}`                                      |
-| `securityContext`                            | Enables securityContext.                                     | `{}`                                      |
-| `service.type`                               | Specifies the service type.                                  | `ClusterIP`                               |
-| `service.port`                               | Specifies the port for the service.                          | `5000`                                    |
-| `nodeSelector`                               | Specifies the nodeSelector for scheduling.                   | `{}`                                      |
-| `tolerations`                                | Specifies the tolerations for scheduling.                    | `[]`                                      |
-| `affinity`                                   | Enables affinity rules                                       | `{}`                                      |
-| `sysdig.secure.apiToken`                     | Specifies the API Token to access Sysdig Secure. This value is **required** if the `sysdig.secure.existingSecureAPITokenSecret` is not specified. | ` `                                       |
-| `sysdig.secure.existingSecureAPITokenSecret` | Specifies the existing secret name with API Token to access Sysdig Secure <br/>Alternatively, you can specify the name of a Kubernetes secret containing `sysdig_secure_api_token` entry. <br/><br/>If both are not configured, you must  provide the deployment with the `SECURE_API_TOKEN` environment variables. | ` `                                       |
-| `sysdig.secure.url`                          | Specifies the Sysdig Secure endpoint.                        | `https://secure.sysdig.com`               |
-| `sysdig.secure.verifySSL`                    | Verifies whether SSL certificate when connecting to Sysdig Secure endpoint. | `true`                                    |
-| `proxy.httpProxy`                            | Specifies the URL of the proxy for HTTP connections. Leave empty if not using proxy. It sets the `http_proxy` environment variable.    | ` `                                       |
-| `proxy.httpsProxy`                           | Specifies the URL of the proxy for HTTPS connections. Leave empty if not using proxy.  It sets the `https_proxy` environment variable. | ` `                                       |
-| `proxy.noProxy`                              | Specifies the comma-separated list of domain extensions proxy should not be used for. Includes the internal IP of the kube API server. | ` `                                       |
-| `cliScanning.enabled`                        | Enables the CLI Scanning feature.                            | `true`                                    |
-| `cliScanning.image`                          | Specifies the pullstring for the CLI Scanner Image.          | `alpine:latest`                           |
-| `cliScanning.existingSecureAPITokenSecret`   | Specifies the existing secret name with API Token to access Sysdig Secure                         | `{{ include "harbor-scanner-sysdig-secure.fullname" . }}`                                    |
-| `asyncMode.enabled`                          | Enables the Async-Mode feature.                              | `false`                                   |
+|                 Parameter                  |                                                                                                                                  Description                                                                                                                                   |                        Default                        |
+|--------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| replicaCount                               | Specifies the number of replicas for the Scanner Adapter.                                                                                                                                                                                                                      | <code>1</code>                                        |
+| image.repository                           | Specifies the image repository to pull the image from.                                                                                                                                                                                                                         | <code>sysdiglabs/harbor-scanner-sysdig-secure</code>  |
+| image.tag                                  | Specifies the image tag to pull.                                                                                                                                                                                                                                               | <code></code>                                         |
+| image.pullPolicy                           | Specifies the image pull policy.                                                                                                                                                                                                                                               | <code>IfNotPresent</code>                             |
+| imagePullSecrets                           | Specifies the image pull secrets.                                                                                                                                                                                                                                              | <code>[]</code>                                       |
+| nameOverride                               | Specifies the chart name override.                                                                                                                                                                                                                                             | <code>""</code>                                       |
+| fullnameOverride                           | Specifies the chart full name override                                                                                                                                                                                                                                         | <code>""</code>                                       |
+| podAnnotations                             | Specifies the custom pod annotations.                                                                                                                                                                                                                                          | <code>{}</code>                                       |
+| serviceAccount.create                      | Specifies whether a service account should be created                                                                                                                                                                                                                          | <code>true</code>                                     |
+| serviceAccount.annotations                 | Annotations to add to the service account                                                                                                                                                                                                                                      | <code>{}</code>                                       |
+| serviceAccount.name                        | The name of the service account to use. If not set and create is true, a name is generated using the fullname template                                                                                                                                                         | <code></code>                                         |
+| rbac.create                                | Creates and uses RBAC resources.                                                                                                                                                                                                                                               | <code>true</code>                                     |
+| podSecurityContext                         | Enables deployment PSPs.                                                                                                                                                                                                                                                       | <code>{}</code>                                       |
+| securityContext                            | Enables securityContext.                                                                                                                                                                                                                                                       | <code>{}</code>                                       |
+| service.type                               | Specifies the service type.                                                                                                                                                                                                                                                    | <code>ClusterIP</code>                                |
+| service.port                               | Specifies the port for the service.                                                                                                                                                                                                                                            | <code>5000</code>                                     |
+| resources                                  | Specifies the resources of the pod.                                                                                                                                                                                                                                            | <code>{}</code>                                       |
+| nodeSelector                               | Specifies the nodeSelector for scheduling.                                                                                                                                                                                                                                     | <code>{}</code>                                       |
+| tolerations                                | Specifies the tolerations for scheduling.                                                                                                                                                                                                                                      | <code>[]</code>                                       |
+| affinity                                   | Enables affinity rules                                                                                                                                                                                                                                                         | <code>{}</code>                                       |
+| customEntryPoint                           | Overrides the container entrypoint.                                                                                                                                                                                                                                            | <code>[]</code>                                       |
+| sysdig.secure.apiToken                     | Specifies the API Token to access Sysdig Secure. This value is **required** if the `sysdig.secure.existingSecureAPITokenSecret` is not specified.                                                                                                                              | <code>""</code>                                       |
+| sysdig.secure.existingSecureAPITokenSecret | Specifies the existing secret name with API Token to access Sysdig Secure. Specify the name of a Kubernetes secret containing an 'sysdig_secure_api_token' entry If both are not configured, you must provide the deployment with the `SECURE_API_TOKEN` environment variable. | <code>""</code>                                       |
+| sysdig.secure.url                          | Sysdig backend URL. SaaS Regions API endpoints are listed [here](https://docs.sysdig.com/en/docs/administration/saas-regions-and-ip-ranges/)                                                                                                                                   | <code>"https://secure.sysdig.com"</code>              |
+| sysdig.secure.verifySSL                    | Verifies whether SSL certificate when connecting to Sysdig Secure endpoint.                                                                                                                                                                                                    | <code>true</code>                                     |
+| proxy.httpProxy                            | Specifies the URL of the proxy for HTTP connections. Leave empty if not using proxy. It sets the `http_proxy` environment variable.                                                                                                                                            | <code></code>                                         |
+| proxy.httpsProxy                           | Specifies the URL of the proxy for HTTPS connections. Leave empty if not using proxy. It sets the `https_proxy` environment variable.                                                                                                                                          | <code></code>                                         |
+| proxy.noProxy                              | Comma-separated list of domain extensions proxy should not be used for. Include in `noProxy` the internal IP of the kubeapi server, and you probably need to add your registry if it is inside the cluster                                                                     | <code></code>                                         |
+| cliScanning.enabled                        | Enables the CLI Scanning feature.                                                                                                                                                                                                                                              | <code>true</code>                                     |
+| cliScanning.image                          | Specifies the pullstring for the CLI Scanner Image.                                                                                                                                                                                                                            | <code>quay.io/sysdig/sysdig-cli-scanner:latest</code> |
+| cliScanning.existingSecureAPITokenSecret   | Specifies the existing secret name with API Token to access Sysdig Secure                                                                                                                                                                                                      | <code>""</code>                                       |
+| asyncMode.enabled                          | Enables the Async-Mode feature.                                                                                                                                                                                                                                                | <code>true</code>                                     |

--- a/charts/harbor-scanner-sysdig-secure/README.tpl
+++ b/charts/harbor-scanner-sysdig-secure/README.tpl
@@ -1,0 +1,87 @@
+<!--
+TODO: Correct content is now in README.md, being refactories. We will copy back to README.tpl once finished
+
+DO NOT MODIFY README.md MANUALLY!! CHANGE README.tpl instead!!
+
+README.md IS AUTO-GENERATED vía README.tpl with pre-comit plugin
+this is under construction so it must be launched manually
+
+in the project root, run:
+$ pre-commit install
+$ pre-commit run -a
+
+-->
+
+# {{ .Project.App }}
+
+This chart deploys the [Harbor Scanner Adapter](https://github.com/sysdiglabs/harbor-scanner-sysdig-secure) for Sysdig Secure on your Kubernetes cluster.
+
+## Prerequisites
+
+- Helm 3
+- [Sysdig Secure API Token](https://docs.sysdig.com/en/docs/administration/administration-settings/user-profile-and-password/retrieve-the-sysdig-api-token/)
+
+## Installation
+
+To install the chart:
+
+```console
+helm repo add {{ .Repository.Name }} {{ .Repository.URL }}
+helm repo update
+helm install {{ .Release.Name }} --namespace {{ .Release.Name }} --create-namespace -f values.yaml {{ .Repository.Name }}/{{ .Chart.Name }}
+```
+
+## Verify the integrity and origin
+Sysdig Helm Charts are signed so users can verify the integrity and origin of each chart, the steps are as follows:
+
+### Import the Public Key
+
+```console
+$ curl -o "/tmp/sysdig_public.gpg" "https://charts.sysdig.com/public.gpg"
+$ gpg --import /tmp/sysdig_public.gpg
+```
+
+### Verify the chart
+
+To check the integrity and the origin of the charts you can now append the `--verify` flag to the `install`, `upgrade` and `pull` helm commands.
+
+## Configuration
+
+You can use the Helm chart to update the default agent configurations by using either of the following:
+
+- Using the key-value pair: `--set sysdig.settings.key = value`
+- `values.yaml` file
+
+### Using the Key-Value Pair
+
+Specify each parameter using the `--set key=value[,key=value]` argument to the `helm install`command.
+
+For example:
+
+```bash
+helm upgrade --install {{ .Release.Name }} {{ .Repository.Name }}/{{ .Chart.Name }} \
+    --create-namespace -n {{ .Release.Namespace }}{{ with .Chart.Version }} --version={{.}} {{ end }} \
+    --set sysdig.secure.apiToken=<SECURE-API-TOKEN>
+```
+
+### Using values.yaml
+
+The `values.yaml` file specifies the values for the admission controller configuration parameters.  You can add the configuration to the `values.yaml` file, then use it in the `helm install` command.
+
+For example:
+
+```bash
+helm upgrade --install {{ .Release.Name }} {{ .Repository.Name }}/{{ .Chart.Name }} \
+     --create-namespace -n {{ .Release.Namespace }}{{ with .Chart.Version }} --version={{.}} {{ end }} \
+    --values values.yaml
+
+```
+
+See the default [`values.yaml`](./values.yaml) file for more information.
+
+
+## Configuration Parameters
+
+The following table lists the configurable parameters of the `{{ .Chart.Name }}` chart and their default values.
+
+{{ .Chart.Values }}

--- a/charts/harbor-scanner-sysdig-secure/doc.yaml
+++ b/charts/harbor-scanner-sysdig-secure/doc.yaml
@@ -1,0 +1,22 @@
+project:
+  name: Harbor Scanner Adapter for Sysdig Secure
+  shortName: Harbor Adapter
+  url: https://github.com/sysdiglabs/harbor-scanner-sysdig-secure
+  description: This chart deploys the Sysdig Harbor Scanner Adapter in your Kubernetes cluster.
+  app: Harbor Scanner Adapter for Sysdig Secure
+repository:
+  url: https://charts.sysdig.com
+  name: sysdig
+chart:
+  name: harbor-scanner-sysdig-secure
+  #  version: v0.9.0-rc.0
+  #  values: "-- generate from values file --"
+  valuesExample: "sysdig.secure.apiToken=<SECURE-API-TOKEN>"
+prerequisites:
+  - "Helm 3.6"
+  - "Kubernetes v1.16+"
+  - "Sysdig Secure API Token"
+
+release:
+  name: sysdig-harbor-scanner
+  namespace: sysdig-harbor-scanner

--- a/charts/harbor-scanner-sysdig-secure/values.yaml
+++ b/charts/harbor-scanner-sysdig-secure/values.yaml
@@ -2,17 +2,25 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Specifies the number of replicas for the Scanner Adapter.
 replicaCount: 1
 
 image:
+  # Specifies the image repository to pull the image from.
   repository: sysdiglabs/harbor-scanner-sysdig-secure
-  # tag: latest
+  # Specifies the image tag to pull.
+  tag:
+  # Specifies the image pull policy.
   pullPolicy: IfNotPresent
 
+# Specifies the image pull secrets.
 imagePullSecrets: []
+# Specifies the chart name override.
 nameOverride: ""
+# Specifies the chart full name override
 fullnameOverride: ""
 
+# Specifies the custom pod annotations.
 podAnnotations: {}
 
 serviceAccount:
@@ -25,11 +33,14 @@ serviceAccount:
   name:
 
 rbac:
+  # Creates and uses RBAC resources.
   create: true
 
+# Enables deployment PSPs.
 podSecurityContext: {}
   # fsGroup: 2000
 
+# Enables securityContext.
 securityContext: {}
   # capabilities:
   #   drop:
@@ -39,9 +50,12 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  # Specifies the service type.
   type: ClusterIP
+  # Specifies the port for the service.
   port: 5000
 
+# Specifies the resources of the pod.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -54,44 +68,51 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# Specifies the nodeSelector for scheduling.
 nodeSelector: {}
 
+# Specifies the tolerations for scheduling.
 tolerations: []
 
+# Enables affinity rules
 affinity: {}
 
-# Custom entrypoint for the harbor plugin
+# Overrides the container entrypoint.
 customEntryPoint: []
 
 sysdig:
   secure:
 
-    # **required**
-    # API Token to access Sysdig Secure.
-    # If neither this value nor `sysdig.secure.existingSecureAPITokenSecret` are configured, the
-    # user will be required to provide the deployment the `SECURE_API_TOKEN` environment variables.
+    # Specifies the API Token to access Sysdig Secure. This value is **required** if the `sysdig.secure.existingSecureAPITokenSecret` is not specified.
     apiToken: ""
 
-    # Alternatively, specify the name of a Kubernetes secret containing an 'sysdig_secure_api_token' entry
+    # Specifies the existing secret name with API Token to access Sysdig Secure. Specify the name of a Kubernetes secret containing an 'sysdig_secure_api_token' entry
+    # If both are not configured, you must provide the deployment with the `SECURE_API_TOKEN` environment variable.
     existingSecureAPITokenSecret: ""
 
-    # Sysdig backend URL (SaaS Regions API endpoints are listed here: https://docs.sysdig.com/en/docs/administration/saas-regions-and-ip-ranges/)
+    # Sysdig backend URL. SaaS Regions API endpoints are listed [here](https://docs.sysdig.com/en/docs/administration/saas-regions-and-ip-ranges/)
     url: "https://secure.sysdig.com"
+    # Verifies whether SSL certificate when connecting to Sysdig Secure endpoint.
     verifySSL: true
 
 proxy:
+  # Specifies the URL of the proxy for HTTP connections. Leave empty if not using proxy. It sets the `http_proxy` environment variable.
   httpProxy:
+  # Specifies the URL of the proxy for HTTPS connections. Leave empty if not using proxy. It sets the `https_proxy` environment variable.
   httpsProxy:
   # Comma-separated list of domain extensions proxy should not be used for.
-  # Include in noProxy the internal IP of the kubeapi server,
+  # Include in `noProxy` the internal IP of the kubeapi server,
   # and you probably need to add your registry if it is inside the cluster
   noProxy:
 
 cliScanning:
+  # Enables the CLI Scanning feature.
   enabled: true
-  image: alpine:latest
-  # specify the name of a Kubernetes secret containing an 'sysdig_secure_api_token' entry, defaults to harbor-scanner-sysdig-secure.fullname
+  # Specifies the pullstring for the CLI Scanner Image.
+  image: quay.io/sysdig/sysdig-cli-scanner:latest
+  # Specifies the existing secret name with API Token to access Sysdig Secure
   existingSecureAPITokenSecret: ""
 
 asyncMode:
+  # Enables the Async-Mode feature.
   enabled: true


### PR DESCRIPTION
## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
