### PR TITLE
fix(shield): set port 443 on host when alt region is selected

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.8.1
+version: 1.8.2
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_configmap_helpers.tpl
@@ -136,7 +136,7 @@ true
   {{- $config = merge $config (dict "ssl_verify_certificate" false) }}
 {{- end }}
 {{- if (include "common.is_alt_region" .) -}}
-  {{- $_ := set $config "collector_port" 6443 -}}
+  {{- $_ := set $config "collector_port" 443 -}}
 {{- end -}}
 {{- if .Values.features.kubernetes_metadata.enabled }}
   {{- $_ := set $config "k8s_delegated_nodes" (dig "k8s_delegated_nodes" 0 .Values.host.additional_settings) -}}

--- a/charts/shield/templates/host/_windows_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_windows_configmap_helpers.tpl
@@ -46,7 +46,7 @@
     {{- $_ := set $sysdigEndpointConfig "region" "custom" -}}
     {{- $_ := set $sysdigEndpointConfig "api_url" (printf "https://%s" (include "common.secure_api_endpoint" .)) -}}
     {{- $_ := set $sysdigEndpointConfig.collector "host" (include "common.collector_endpoint" .) -}}
-    {{- $_ := set $sysdigEndpointConfig.collector "port" 6443 -}}
+    {{- $_ := set $sysdigEndpointConfig.collector "port" 443 -}}
   {{- end -}}
 {{- end -}}
 {{- $_ := set $config "sysdig_endpoint" $sysdigEndpointConfig -}}
@@ -95,7 +95,7 @@
   "collector" (include "common.collector_endpoint" .)
 }}
 {{- if (include "common.is_alt_region" .) -}}
-  {{- $_ := set $config "collector_port" 6443 -}}
+  {{- $_ := set $config "collector_port" 443 -}}
 {{- end -}}
 {{- if .Values.cluster_config.tags -}}
   {{- $tagList := list }}

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -1364,4 +1364,4 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             collector: ingest-alt-eu1.app.sysdig.com
-            collector_port: 6443
+            collector_port: 443

--- a/charts/shield/tests/host/configmap-windows-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-windows-dragent-yaml_test.yaml
@@ -728,7 +728,7 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             collector: ingest-alt-eu1.app.sysdig.com
-            collector_port: 6443
+            collector_port: 443
 
   - it: Test agent_runtime_additional_settings with version < 0.8.0
     set:

--- a/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
+++ b/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
@@ -384,7 +384,7 @@ tests:
               api_url: https://eu1.app.sysdig.com
               collector:
                 host: ingest-alt-eu1.app.sysdig.com
-                port: 6443
+                port: 443
               region: custom
 
   - it: Alternative regions (host-shield windows version > 0.7.1)


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
