### PR TITLE
chore(shield): add missing respond mapping on cluster-shield

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.12.0
+version: 1.12.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/_config.tpl
+++ b/charts/shield/templates/cluster/_config.tpl
@@ -1,6 +1,7 @@
 {{- define "cluster.features_config" -}}
   {{- $monitorFeature := (dig "monitor" nil .Values.features) -}}
   {{- $investigationsFeature := (dig "investigations" nil .Values.features) -}}
+  {{- $respondFeature := (dig "respond" nil .Values.features) -}}
   {{- $features := list
       (dict "posture" (dig "posture" "cluster_posture" nil .Values.features ))
       (dict "container_vulnerability_management" (dig "vulnerability_management" "container_vulnerability_management" nil .Values.features ))
@@ -9,6 +10,7 @@
       (dict "kubernetes_metadata" (dig "kubernetes_metadata" nil .Values.features ))
       (dict "monitor" (pick $monitorFeature "kube_state_metrics" "kubernetes_events"))
       (dict "investigations" (pick $investigationsFeature "investigations" "network_security"))
+      (dict "respond" (pick $respondFeature "respond" "response_actions"))
   -}}
   {{- $featuresConfig := dict -}}
   {{- range $feature := $features }}

--- a/charts/shield/tests/cluster/configmap_test.yaml
+++ b/charts/shield/tests/cluster/configmap_test.yaml
@@ -90,6 +90,9 @@ tests:
                   enabled: false
               posture:
                 enabled: false
+              respond:
+                response_actions:
+                  enabled: false
             kubernetes:
               ca_cert_file: /etc/sysdig/tls-certificates/ca.crt
               root_namespace: kube-system


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
