### PR TITLE
chore(shield): handle respond mapping on cluster-shield

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.12.0
+version: 1.12.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/_config.tpl
+++ b/charts/shield/templates/cluster/_config.tpl
@@ -1,6 +1,7 @@
 {{- define "cluster.features_config" -}}
   {{- $monitorFeature := (dig "monitor" nil .Values.features) -}}
   {{- $investigationsFeature := (dig "investigations" nil .Values.features) -}}
+  {{- $respondFeature := (dig "respond" nil .Values.features) -}}
   {{- $features := list
       (dict "posture" (dig "posture" "cluster_posture" nil .Values.features ))
       (dict "container_vulnerability_management" (dig "vulnerability_management" "container_vulnerability_management" nil .Values.features ))
@@ -9,6 +10,7 @@
       (dict "kubernetes_metadata" (dig "kubernetes_metadata" nil .Values.features ))
       (dict "monitor" (pick $monitorFeature "kube_state_metrics" "kubernetes_events"))
       (dict "investigations" (pick $investigationsFeature "investigations" "network_security"))
+      (dict "respond" (pick $respondFeature "response_actions"))
   -}}
   {{- $featuresConfig := dict -}}
   {{- range $feature := $features }}
@@ -17,6 +19,7 @@
     {{- end -}}
   {{- end }}
   {{- $_ := set $featuresConfig.container_vulnerability_management "in_use" .Values.features.vulnerability_management.in_use -}}
+  {{- $_ := set $featuresConfig.respond "response_actions" (pick $featuresConfig.respond.response_actions "enabled" "queue_length" "timeout" "cluster") -}}
   {{- $additionalFeaturesSettings := (dig "features" (dict) .Values.cluster.additional_settings) -}}
   {{- (mergeOverwrite $featuresConfig $additionalFeaturesSettings) | toYaml -}}
 {{- end }}
@@ -189,3 +192,40 @@
     {{- true -}}
   {{- end -}}
 {{- end }}
+
+{{/*
+  Checks if the cluster has the response actions feature enabled.
+  (either by the feature config or additional settings)
+*/}}
+{{- define "cluster.response_actions_enabled" -}}
+  {{- $featureConfig := (include "cluster.features_config" . | fromYaml) -}}
+  {{- if dig "respond" "response_actions" "enabled" false $featureConfig -}}
+    {{- true -}}
+  {{- end -}}
+{{- end }}
+
+{{/*
+Response Actions: Cluster actions
+In the future we will have more complex logic to determine if the action is enabled or not.
+*/}}
+{{- define "cluster.response_actions.rollout_restart.enabled" }}
+    {{- include "cluster.response_actions_enabled" . }}
+{{- end}}
+{{- define "cluster.response_actions.delete_pod.enabled" }}
+    {{- include "cluster.response_actions_enabled" . }}
+{{- end}}
+{{- define "cluster.response_actions.isolate_network.enabled" }}
+    {{- include "cluster.response_actions_enabled" . }}
+{{- end}}
+{{- define "cluster.response_actions.delete_network_policy.enabled" }}
+    {{- include "cluster.response_actions_enabled" . }}
+{{- end}}
+{{- define "cluster.response_actions.get_logs.enabled" }}
+    {{- include "cluster.response_actions_enabled" . }}
+{{- end}}
+{{- define "cluster.response_actions.volume_snapshot.enabled" }}
+    {{- include "cluster.response_actions_enabled" . }}
+{{- end}}
+{{- define "cluster.response_actions.delete_volume_snapshot.enabled" }}
+    {{- include "cluster.response_actions_enabled" . }}
+{{- end}}

--- a/charts/shield/templates/cluster/_helpers.tpl
+++ b/charts/shield/templates/cluster/_helpers.tpl
@@ -126,37 +126,3 @@ If release name contains chart name it will be used as a full name.
 {{- . | toYaml -}}
 {{- end -}}
 {{- end -}}
-
-{{- define "cluster.response_actions_enabled" -}}
-{{- with .Values.features.respond.response_actions.enabled }}
-    {{- . }}
-{{- else }}
-    false
-{{- end }}
-{{- end }}
-
-{{/*
-Response Actions: Cluster actions
-In the future we will have more complex logic to determine if the action is enabled or not.
-*/}}
-{{- define "cluster.response_actions.rollout_restart.enabled" }}
-    {{- include "cluster.response_actions_enabled" . }}
-{{- end}}
-{{- define "cluster.response_actions.delete_pod.enabled" }}
-    {{- include "cluster.response_actions_enabled" . }}
-{{- end}}
-{{- define "cluster.response_actions.isolate_network.enabled" }}
-    {{- include "cluster.response_actions_enabled" . }}
-{{- end}}
-{{- define "cluster.response_actions.delete_network_policy.enabled" }}
-    {{- include "cluster.response_actions_enabled" . }}
-{{- end}}
-{{- define "cluster.response_actions.get_logs.enabled" }}
-    {{- include "cluster.response_actions_enabled" . }}
-{{- end}}
-{{- define "cluster.response_actions.volume_snapshot.enabled" }}
-    {{- include "cluster.response_actions_enabled" . }}
-{{- end}}
-{{- define "cluster.response_actions.delete_volume_snapshot.enabled" }}
-    {{- include "cluster.response_actions_enabled" . }}
-{{- end}}

--- a/charts/shield/tests/cluster/configmap_test.yaml
+++ b/charts/shield/tests/cluster/configmap_test.yaml
@@ -90,6 +90,9 @@ tests:
                   enabled: false
               posture:
                 enabled: false
+              respond:
+                response_actions:
+                  enabled: false
             kubernetes:
               ca_cert_file: /etc/sysdig/tls-certificates/ca.crt
               root_namespace: kube-system
@@ -230,6 +233,86 @@ tests:
               investigations:
                 network_security:
                   enabled: true
+
+  - it: Enable respond.response_actions
+    set:
+      features:
+        respond:
+          response_actions:
+            enabled: true
+            queue_length: 1000
+            timeout: 10
+            cluster:
+              volume_snapshot_class: "a-volume-snapshot-class"
+            another_config_not_relevant: "not-relevant"
+    asserts:
+      - exists:
+          path: data["cluster-shield.yaml"]
+      - matchRegex:
+          path: data['cluster-shield.yaml']
+          pattern: |
+            features:
+              admission_control:
+                container_vulnerability_management:
+                  enabled: false
+                dry_run: true
+                enabled: false
+                excluded_namespaces: \[\]
+                failure_policy: Ignore
+                http_port: 8443
+                posture:
+                  enabled: true
+                timeout: 10
+              audit:
+                enabled: false
+                excluded_namespaces: \[\]
+                http_port: 6443
+                timeout: 10
+                webhook_rules:
+                - apiGroups:
+                  - ""
+                  - apps
+                  - autoscaling
+                  - batch
+                  - networking.k8s.io
+                  - rbac.authorization.k8s.io
+                  - extensions
+                  apiVersions:
+                  - '\*'
+                  operations:
+                  - '\*'
+                  resources:
+                  - '\*/\*'
+                  scope: '\*'
+              container_vulnerability_management:
+                enabled: false
+                in_use:
+                  enabled: false
+                  integration_enabled: false
+                local_cluster:
+                  registry_secrets: \[\]
+                platform_services_enabled: true
+                registry_ssl:
+                  verify: true
+              investigations:
+                network_security:
+                  enabled: false
+              kubernetes_metadata:
+                enabled: true
+              monitor:
+                kube_state_metrics:
+                  enabled: false
+                kubernetes_events:
+                  enabled: false
+              posture:
+                enabled: false
+              respond:
+                response_actions:
+                  cluster:
+                    volume_snapshot_class: a-volume-snapshot-class
+                  enabled: true
+                  queue_length: 1000
+                  timeout: 10
 
   - it: Sets NATS Url and Lock Name when Container Vulnerability Management is enabled
     set:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
