### PR TITLE
chore(shield): add cluster.volume_snapshot_class default on cluster-shield

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.12.1
+version: 1.12.2
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/_config.tpl
+++ b/charts/shield/templates/cluster/_config.tpl
@@ -2,6 +2,9 @@
   {{- $monitorFeature := (dig "monitor" nil .Values.features) -}}
   {{- $investigationsFeature := (dig "investigations" nil .Values.features) -}}
   {{- $respondFeature := (dig "respond" nil .Values.features) -}}
+  {{- if not (hasKey $respondFeature.response_actions "cluster") }}
+    {{- $_ := set $respondFeature.response_actions "cluster" (dict "volume_snapshot_class" "") }}
+  {{- end }}
   {{- $features := list
       (dict "posture" (dig "posture" "cluster_posture" nil .Values.features ))
       (dict "container_vulnerability_management" (dig "vulnerability_management" "container_vulnerability_management" nil .Values.features ))

--- a/charts/shield/tests/cluster/configmap_test.yaml
+++ b/charts/shield/tests/cluster/configmap_test.yaml
@@ -92,6 +92,8 @@ tests:
                 enabled: false
               respond:
                 response_actions:
+                  cluster:
+                    volume_snapshot_class: ""
                   enabled: false
             kubernetes:
               ca_cert_file: /etc/sysdig/tls-certificates/ca.crt


### PR DESCRIPTION


## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
