### PR TITLE
fix(shield): do not set proxy configuration on host-shield when proxy is not configured

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.12.5
+version: 1.12.6
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_windows_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_windows_configmap_helpers.tpl
@@ -73,7 +73,9 @@
 
 {{- $_ := set $config "ssl" $sslConfig -}}
 
-{{- $config := merge $config (dict "proxy" (include "host.proxy_config" . | fromYaml)) }}
+{{- if (include "common.proxy.enabled" . ) }}
+  {{- $config := merge $config (dict "proxy" (include "host.proxy_config" . | fromYaml)) }}
+{{- end }}
 
 {{- if and (include "common.semver.is_valid" .Values.host_windows.image.tag) (semverCompare ">= 0.8.0-0" .Values.host_windows.image.tag) }}
 {{- $runtimeAdditionalSettings := (include "host.windows.runtime_config_override" .) | fromYaml }}

--- a/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
+++ b/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
@@ -180,7 +180,7 @@ tests:
                 in_use:
                   enabled: true
 
-  - it: Default No Proxy
+  - it: Default Proxy
     asserts:
       - hasDocuments:
           count: 1
@@ -193,11 +193,10 @@ tests:
           value: shield-namespace
       - exists:
           path: data["host-shield.yaml"]
-      - matchRegex:
+      - notMatchRegex:
           path: data["host-shield.yaml"]
-          pattern: |-
-            proxy:
-              no_proxy: 127.0.0.1,localhost,169.254.0.0/16,.cluster.local
+          pattern: |
+            proxy: .*
 
   - it: With Only HTTP Proxy (http protocol)
     set:
@@ -220,6 +219,7 @@ tests:
           pattern: |-
             proxy:
               http_proxy: http://proxy.example.com:8080
+              no_proxy: 127.0.0.1,localhost,169.254.0.0/16,.cluster.local
 
   - it: With Only HTTP Proxy (http protocol) [Existing Secret]
     set:
@@ -242,6 +242,7 @@ tests:
           pattern: |-
             proxy:
               http_proxy: http://proxy-existing.example.com:8080
+              no_proxy: 127.0.0.1,localhost,169.254.0.0/16,.cluster.local
 
   - it: With Only HTTPS Proxy (https protocol)
     set:
@@ -264,6 +265,7 @@ tests:
           pattern: |
             proxy:
               https_proxy: https://proxy.example.com:8080
+              no_proxy: 127.0.0.1,localhost,169.254.0.0/16,.cluster.local
 
   - it: With Only HTTPS Proxy (https protocol) [Existing Secret]
     set:
@@ -286,6 +288,7 @@ tests:
           pattern: |
             proxy:
               https_proxy: https://proxy-existing.example.com:8080
+              no_proxy: 127.0.0.1,localhost,169.254.0.0/16,.cluster.local
 
   - it: With Only NO Proxy
     set:
@@ -303,11 +306,10 @@ tests:
           value: shield-namespace
       - exists:
           path: data["host-shield.yaml"]
-      - matchRegex:
+      - notMatchRegex:
           path: data["host-shield.yaml"]
           pattern: |
-            proxy:
-              no_proxy: example.com,127.0.0.1,localhost,169.254.0.0/16,.cluster.local
+            proxy: .*
 
   - it: With Only NO Proxy [Existing Secret]
     set:
@@ -325,10 +327,61 @@ tests:
           value: shield-namespace
       - exists:
           path: data["host-shield.yaml"]
-      - matchRegex:
+      - notMatchRegex:
           path: data["host-shield.yaml"]
           pattern: |
+            proxy: .*
+
+  - it: With No Proxy
+    set:
+      proxy:
+        http_proxy: "http://proxy.example.com:8080"
+        https_proxy: "https://proxy.example.com:8080"
+        no_proxy: "example.com"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+          name: release-name-shield-host-windows
+      - equal:
+          path: metadata.namespace
+          value: shield-namespace
+      - exists:
+          path: data["host-shield.yaml"]
+      - matchRegex:
+          path: data["host-shield.yaml"]
+          pattern: |-
             proxy:
+              http_proxy: http://proxy.example.com:8080
+              https_proxy: https://proxy.example.com:8080
+              no_proxy: example.com,127.0.0.1,localhost,169.254.0.0/16,.cluster.local
+
+  - it: With No Proxy [Existing Secret]
+    set:
+      proxy:
+        http_proxy_existing_secret: "proxy-secret"
+        https_proxy_existing_secret: "proxy-secret"
+        no_proxy_existing_secret: "proxy-secret"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+          name: release-name-shield-host-windows
+      - equal:
+          path: metadata.namespace
+          value: shield-namespace
+      - exists:
+          path: data["host-shield.yaml"]
+      - matchRegex:
+          path: data["host-shield.yaml"]
+          pattern: |-
+            proxy:
+              http_proxy: http://proxy-existing.example.com:8080
+              https_proxy: https://proxy-existing.example.com:8080
               no_proxy: example.com
 
   - it: Alternative regions (default)


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
