### PR TITLE
fix(shield): Sanitize version label on shield objects

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.15.3
+version: 1.15.4
 appVersion: "1.0.0"

--- a/charts/shield/templates/_helpers.tpl
+++ b/charts/shield/templates/_helpers.tpl
@@ -55,8 +55,13 @@ Component labels
 */}}
 {{- define "shield.component_labels" -}}
 {{ include "shield.component_name_label" .}}: {{ required "A valid component name must be provided" .name }}
-{{- if .version }}
-{{ include "shield.component_version_label" .}}: {{ .version | regexFind "^[^@]+" | trunc 63 }}
+
+{{ if .version }}
+  {{- $version := .version -}}
+  {{- if (hasPrefix "sha256:" .version) -}}
+    {{- $version = printf "sha256_%s" (trimPrefix "sha256:" .version) -}}
+  {{- end -}}
+  {{ include "shield.component_version_label" .}}: {{ $version | regexFind "^[^@]+" | trunc 63 }}
 {{- end }}
 {{- end }}
 

--- a/charts/shield/templates/_helpers.tpl
+++ b/charts/shield/templates/_helpers.tpl
@@ -56,7 +56,7 @@ Component labels
 {{- define "shield.component_labels" -}}
 {{ include "shield.component_name_label" .}}: {{ required "A valid component name must be provided" .name }}
 {{- if .version }}
-{{ include "shield.component_version_label" .}}: {{ .version }}
+{{ include "shield.component_version_label" .}}: {{ .version | regexFind "^[^@]+" | trunc 63 }}
 {{- end }}
 {{- end }}
 

--- a/charts/shield/templates/cluster/_helpers.tpl
+++ b/charts/shield/templates/cluster/_helpers.tpl
@@ -57,6 +57,14 @@ If release name contains chart name it will be used as a full name.
   {{- end -}}
 {{- end }}
 
+{{- define "cluster.tag_separator" -}}
+  {{- if (hasPrefix "sha256:" .Values.cluster.image.tag) -}}
+    @
+  {{- else -}}
+    :
+  {{- end -}}
+{{- end }}
+
 {{- define "cluster.has_priority_class" -}}
   {{- if or .Values.cluster.priority_class.create .Values.cluster.priority_class.name }}
     {{- true -}}

--- a/charts/shield/templates/cluster/deployment.yaml
+++ b/charts/shield/templates/cluster/deployment.yaml
@@ -67,7 +67,7 @@ spec:
       containers:
         - name: "cluster-shield"
           imagePullPolicy: {{ .Values.cluster.image.pull_policy }}
-          image: "{{ .Values.cluster.image.registry }}/{{ .Values.cluster.image.repository }}:{{ .Values.cluster.image.tag }}"
+          image: "{{ .Values.cluster.image.registry }}/{{ .Values.cluster.image.repository }}{{ include "cluster.tag_separator" . }}{{ .Values.cluster.image.tag }}"
           args: [ {{ (include "cluster.run_command" .) | quote }} ]
           {{- if not (include "cluster.is_single_process_mode" .) }}
           securityContext:

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -55,6 +55,14 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
+{{- define "host.tag_separator" -}}
+  {{- if (hasPrefix "sha256:" .Values.host.image.tag) -}}
+    @
+  {{- else -}}
+    :
+  {{- end -}}
+{{- end }}
+
 {{- define "host.service_account_name" -}}
 {{- default (include "host.fullname" .) .Values.host.rbac.service_account_name }}
 {{- end }}
@@ -128,11 +136,14 @@ true
 {{- end }}
 
 {{- define "host.shield_image" }}
-{{- .Values.host.image.registry -}} / {{- .Values.host.image.repository -}} / {{- .Values.host.image.shield_name -}} : {{- .Values.host.image.tag }}
+{{- .Values.host.image.registry -}} / {{- .Values.host.image.repository -}} / {{- .Values.host.image.shield_name -}} {{- include "host.tag_separator" . -}} {{- .Values.host.image.tag }}
 {{- end }}
 
 {{- define "host.kmodule_image" }}
-{{- .Values.host.image.registry -}} / {{- .Values.host.image.repository -}} / {{- .Values.host.image.kmodule_name -}} : {{- .Values.host.image.tag }}
+{{- if hasPrefix "sha256" .Values.host.image.tag -}}
+  {{- fail (printf "Image tag %s can't be speficied when not using universal_ebpf driver" .Values.host.image.tag ) }}
+{{- end -}}
+{{- .Values.host.image.registry -}} / {{- .Values.host.image.repository -}} / {{- .Values.host.image.kmodule_name -}} : {{- .Values.host.image.tag | regexFind "^[^@]+" }}
 {{- end }}
 
 {{- define "host.need_host_root" }}

--- a/charts/shield/templates/host/_windows_helpers.tpl
+++ b/charts/shield/templates/host/_windows_helpers.tpl
@@ -27,7 +27,15 @@
 {{- end }}
 
 {{- define "host.windows.shield_image" }}
-{{- .Values.host_windows.image.registry -}} / {{- .Values.host_windows.image.repository -}} / {{- .Values.host_windows.image.name -}} : {{- .Values.host_windows.image.tag }}
+{{- .Values.host_windows.image.registry -}} / {{- .Values.host_windows.image.repository -}} / {{- .Values.host_windows.image.name -}} {{- include "host.windows.tag_separator" . -}} {{- .Values.host_windows.image.tag }}
+{{- end }}
+
+{{- define "host.windows.tag_separator" -}}
+  {{- if (hasPrefix "sha256:" .Values.host_windows.image.tag) -}}
+    @
+  {{- else -}}
+    :
+  {{- end -}}
 {{- end }}
 
 {{- define "host.windows.env" -}}

--- a/charts/shield/tests/cluster/deployment_test.yaml
+++ b/charts/shield/tests/cluster/deployment_test.yaml
@@ -32,6 +32,21 @@ tests:
           value: myregistry.io/ext/sysdig/cluster-shield:1.4.0
     template: templates/cluster/deployment.yaml
 
+  - it: Specify digest in tag
+    set:
+      cluster:
+        image:
+          tag: 1.4.0@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].image
+          value: quay.io/sysdig/cluster-shield:1.4.0@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      - isSubset:
+          path: metadata.labels
+          content:
+            sysdig/component-version: 1.4.0
+    template: templates/cluster/deployment.yaml
+
   - it: Does not contain proxy environment variables
     asserts:
       - containsDocument:

--- a/charts/shield/tests/cluster/deployment_test.yaml
+++ b/charts/shield/tests/cluster/deployment_test.yaml
@@ -47,6 +47,20 @@ tests:
             sysdig/component-version: 1.4.0
     template: templates/cluster/deployment.yaml
 
+  - it: Specify digest only
+    set:
+      cluster:
+        image:
+          tag: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].image
+          value: quay.io/sysdig/cluster-shield@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      - equal:
+          path: metadata.labels["sysdig/component-version"]
+          value: sha256_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b
+    template: templates/cluster/deployment.yaml
+
   - it: Does not contain proxy environment variables
     asserts:
       - containsDocument:

--- a/charts/shield/tests/host/daemonset-windows_test.yaml
+++ b/charts/shield/tests/host/daemonset-windows_test.yaml
@@ -436,3 +436,30 @@ tests:
     asserts:
       - isNullOrEmpty:
           path: spec.template.spec.imagePullSecrets
+
+  - it: Digest in image tag
+    set:
+      host_windows:
+        image:
+          tag: 0.10.0@sha256:61fdf83f6ec198919d595ea1e6dc093258dfcdc3d75db81fe060b65cd6d7aba0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].image
+          value: quay.io/sysdig/host-shield:0.10.0@sha256:61fdf83f6ec198919d595ea1e6dc093258dfcdc3d75db81fe060b65cd6d7aba0
+      - isSubset:
+          path: metadata.labels
+          content:
+            sysdig/component-version: 0.10.0
+
+  - it: Specify digest only
+    set:
+      host_windows:
+        image:
+          tag: sha256:61fdf83f6ec198919d595ea1e6dc093258dfcdc3d75db81fe060b65cd6d7aba0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].image
+          value: quay.io/sysdig/host-shield@sha256:61fdf83f6ec198919d595ea1e6dc093258dfcdc3d75db81fe060b65cd6d7aba0
+      - equal:
+          path: metadata.labels["sysdig/component-version"]
+          value: sha256_61fdf83f6ec198919d595ea1e6dc093258dfcdc3d75db81fe060b65c

--- a/charts/shield/tests/host/daemonset_test.yaml
+++ b/charts/shield/tests/host/daemonset_test.yaml
@@ -193,6 +193,49 @@ tests:
           content:
             sysdig/component-version: 14.1.0
 
+  - it: Specify digest only
+    set:
+      host:
+        image:
+          tag: sha256:2c6401018cfe3f5fcbd0713b64b096c38d47de1b5cd6c11de4691912752263fc
+        driver: universal_ebpf
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].image
+          value: quay.io/sysdig/agent-slim@sha256:2c6401018cfe3f5fcbd0713b64b096c38d47de1b5cd6c11de4691912752263fc
+      - equal:
+          path: metadata.labels["sysdig/component-version"]
+          value: sha256_2c6401018cfe3f5fcbd0713b64b096c38d47de1b5cd6c11de4691912
+
+  - it: Digest is not used when tag is specified in kmodule image
+    set:
+      host:
+        image:
+          tag: 14.1.0@sha256:2c6401018cfe3f5fcbd0713b64b096c38d47de1b5cd6c11de4691912752263fc
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name == "sysdig-host-shield-kmodule")].image
+          value: quay.io/sysdig/agent-kmodule:14.1.0
+
+  - it: Digest only can't be used when tag is not specified and kmodule image is required
+    set:
+      host:
+        image:
+          tag: sha256:2c6401018cfe3f5fcbd0713b64b096c38d47de1b5cd6c11de4691912752263fc
+    asserts:
+      - failedTemplate:
+          errorMessage: Image tag sha256:2c6401018cfe3f5fcbd0713b64b096c38d47de1b5cd6c11de4691912752263fc can't be speficied when not using universal_ebpf driver
+
+  - it: Digest only can't be used when tag is not specified and kmodule image is required
+    set:
+      host:
+        driver: universal_ebpf
+        image:
+          tag: sha256:2c6401018cfe3f5fcbd0713b64b096c38d47de1b5cd6c11de4691912752263fc
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[?(@.name == "sysdig-host-shield-kmodule")]
+
   - it: Default workload labels
     set:
       host:

--- a/charts/shield/tests/host/daemonset_test.yaml
+++ b/charts/shield/tests/host/daemonset_test.yaml
@@ -179,6 +179,20 @@ tests:
           path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].image
           value: quay.io/sysdig/agent-slim:latest
 
+  - it: Digest in image tag
+    set:
+      host:
+        image:
+          tag: 14.1.0@sha256:2c6401018cfe3f5fcbd0713b64b096c38d47de1b5cd6c11de4691912752263fc
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].image
+          value: quay.io/sysdig/agent-slim:14.1.0@sha256:2c6401018cfe3f5fcbd0713b64b096c38d47de1b5cd6c11de4691912752263fc
+      - isSubset:
+          path: metadata.labels
+          content:
+            sysdig/component-version: 14.1.0
+
   - it: Default workload labels
     set:
       host:


### PR DESCRIPTION
## What this PR does / why we need it:
We must sanitize the image tag in the event that an image digest is appended to the image tag. That workflow results in the use of several characters that are not permissible in the label field as well as a violation of the maximum length of the field.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
