### PR TITLE
chore: bump the helm unittest plugin version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ lint:
 	docker run --rm -e CT_VALIDATE_MAINTAINERS=false -u $(shell id -u) -v $(PWD):/charts quay.io/helmpack/chart-testing:latest sh -c "cd /charts; ct lint --target-branch=main --all"
 
 deps-unittest:
-	@helm plugin install https://github.com/helm-unittest/helm-unittest --version=0.6.1 || true
+	@helm plugin install https://github.com/helm-unittest/helm-unittest --version=1.0.0 || true
 
 unittest: deps-unittest
 	find ./charts -name "Chart.yaml" | \

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 2.2.2
+version: 2.2.3

--- a/charts/agent/tests/delegated_agent_deployment_test.yaml
+++ b/charts/agent/tests/delegated_agent_deployment_test.yaml
@@ -257,13 +257,13 @@ tests:
   - it: Test container image
     set:
       image:
-        tag: 86.753.09
+        tag: 86.753.9
       delegatedAgentDeployment:
         enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "quay.io/sysdig/agent-slim:86.753.09"
+          value: "quay.io/sysdig/agent-slim:86.753.9"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent


### PR DESCRIPTION
## What this PR does / why we need it:
SSIA

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
