### PR TITLE
ci(shield): release branches automation

### DIFF
--- a/.github/workflows/shield-branch-updater.yaml
+++ b/.github/workflows/shield-branch-updater.yaml
@@ -12,7 +12,7 @@ on:
           - "cluster"
           - "host-windows"
           - "host-linux"
-      latest_release:
+      latest_release_version:
         description: 'Latest release version'
         required: true
       next_release_version:
@@ -23,7 +23,7 @@ permissions:
   contents: write
 
 env:
-  CURRENT_RELEASE_BRANCH: ${{ inputs.kind }}-shield-release-${{ inputs.latest_release}}
+  CURRENT_RELEASE_BRANCH: ${{ inputs.kind }}-shield-release-${{ inputs.latest_release_version}}
   NEXT_RELEASE_BRANCH: ${{ inputs.kind }}-shield-release-${{ inputs.next_release_version}}
 
 jobs:

--- a/.github/workflows/shield-branch-updater.yaml
+++ b/.github/workflows/shield-branch-updater.yaml
@@ -54,6 +54,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
           ./scripts/shield/rebase.sh
+          git push --force-with-lease
 
   update-next-release-branch:
     runs-on: ubuntu-latest
@@ -82,3 +83,4 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
           ./scripts/shield/rebase.sh
+          git push --force-with-lease

--- a/.github/workflows/shield-branch-updater.yaml
+++ b/.github/workflows/shield-branch-updater.yaml
@@ -1,0 +1,84 @@
+name: Shield Release Branch Updater
+
+on:
+  workflow_dispatch:
+    inputs:
+      kind:
+        description: 'Shield component'
+        required: true
+        default: "cluster"
+        type: choice
+        options:
+          - "cluster"
+          - "host-windows"
+          - "host-linux"
+      latest_release:
+        description: 'Latest release version'
+        required: true
+      next_release_version:
+        description: 'Next release version'
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  CURRENT_RELEASE_BRANCH: ${{ inputs.kind }}-shield-release-${{ inputs.latest_release}}
+  NEXT_RELEASE_BRANCH: ${{ inputs.kind }}-shield-release-${{ inputs.next_release_version}}
+
+jobs:
+  update-current-release-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current release branch
+        id: checkout
+        uses: actions/checkout@v5
+        continue-on-error: true
+        with:
+          ref: ${{ env.CURRENT_RELEASE_BRANCH }}
+          fetch-depth: 0
+
+      - name: Checkout main branch
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v5
+
+      - name: Create current release branch
+        if: steps.checkout.outcome == 'failure'
+        run: |
+          git checkout -b ${{ env.CURRENT_RELEASE_BRANCH }}
+          git push -u origin ${{ env.CURRENT_RELEASE_BRANCH }}
+
+      - name: Update current release branch
+        if: steps.checkout.outcome == 'success'
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          ./scripts/shield/rebase.sh
+
+  update-next-release-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout next release branch
+        id: checkout
+        uses: actions/checkout@v5
+        continue-on-error: true
+        with:
+          ref: ${{ env.NEXT_RELEASE_BRANCH }}
+          fetch-depth: 0
+
+      - name: Checkout main branch
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v5
+
+      - name: Create next release branch
+        if: steps.checkout.outcome == 'failure'
+        run: |
+          git checkout -b ${{ env.NEXT_RELEASE_BRANCH }}
+          git push -u origin ${{ env.NEXT_RELEASE_BRANCH }}
+
+      - name: Update next release branch
+        if: steps.checkout.outcome == 'success'
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          ./scripts/shield/rebase.sh

--- a/scripts/shield/rebase.sh
+++ b/scripts/shield/rebase.sh
@@ -33,5 +33,3 @@ else
     echo "Rebase conflicts detected"
     check_conflicts
 fi
-
-git push -f

--- a/scripts/shield/rebase.sh
+++ b/scripts/shield/rebase.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+function check_conflicts() {
+  # check if the only conflict is on the chart version
+  CONFLICTS=$(git --no-pager diff --cc --name-only)
+  if [[ "$CONFLICTS" = "charts/shield/Chart.yaml" ]]; then
+    echo "Chart version conflict detected, accepting the incoming change"
+
+    # Accept the main branch version for Chart.yaml
+    git checkout --ours charts/shield/Chart.yaml
+    git add charts/shield/Chart.yaml
+
+    echo "Resolved Chart.yaml conflict, continuing rebase"
+    export GIT_EDITOR=true
+    if git rebase --continue; then
+        echo "Rebase continued successfully"
+    else
+        echo "Checking for conflicts again ..."
+        check_conflicts
+    fi
+  elif [[ "$CONFLICTS" = "" ]]; then
+    echo "All conflicts resolved!"
+  else
+    echo "Unexpected conflicts detected in: $CONFLICTS"
+    git rebase --abort
+    exit 1
+  fi
+}
+
+if git pull --rebase origin main; then
+    echo "Rebased successfully!"
+else
+    echo "Rebase conflicts detected"
+    check_conflicts
+fi
+
+git push -f


### PR DESCRIPTION
## What this PR does / why we need it:

This automation allows us to create and keep updated the *-shield release branches.
Given the `kind` (cluster, host-windows, host-linux), `latest_release` and the `next_release` we will pull-rebase the branches from main or create them if not exists.

The release branch format is `${kind}-shield-release-${version}`

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
