### PR TITLE
ci: update go setup

### DIFF
--- a/.github/updatecli.d/config-agent-release.yaml
+++ b/.github/updatecli.d/config-agent-release.yaml
@@ -60,6 +60,7 @@ targets:
     name: "update the shield readme"
     kind: shell
     scmid: github
+    disablesourceinput: true
     dependson:
       - updateShieldChart
     spec:

--- a/.github/workflows/agent-release.yaml
+++ b/.github/workflows/agent-release.yaml
@@ -19,6 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@v2.92.0
 

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -21,10 +21,9 @@ jobs:
         with:
           python-version: "3.10"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: "^1.18"
-          check-latest: true
+          go-version: "1.24"
 
       - name: Install pre-commit
         run: pip install pre-commit

--- a/charts/shield/values.yaml
+++ b/charts/shield/values.yaml
@@ -180,7 +180,7 @@ host_windows:
     # The image name for the host shield
     name: host-shield
     # The tag for the host shield images
-    tag: 0.12.0
+    tag: 0.11.0
     # The pull policy for the host shield images
     pull_policy: IfNotPresent
     # The pull secrets for the host shield images

--- a/charts/shield/values.yaml
+++ b/charts/shield/values.yaml
@@ -180,7 +180,7 @@ host_windows:
     # The image name for the host shield
     name: host-shield
     # The tag for the host shield images
-    tag: 0.11.0
+    tag: 0.12.0
     # The pull policy for the host shield images
     pull_policy: IfNotPresent
     # The pull secrets for the host shield images


### PR DESCRIPTION
## What this PR does / why we need it:

- Update go setup@6 + go version to 1.24;
- Fix agent release updatecli docs step

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
