### PR TITLE
chore(agent,kspm-collector,node-analyzer): remove bitnami/kubectl usage

### DIFF
--- a/.github/updatecli.d/config-update-kubectl-image.yaml
+++ b/.github/updatecli.d/config-update-kubectl-image.yaml
@@ -1,4 +1,4 @@
-name: update bitnami/kubectl image tag for helm tests
+name: update sysdig/sysdig-kubectl image tag for helm tests
 
 scms:
   github:
@@ -19,24 +19,24 @@ actions:
     scmid: "github"
     spec:
       automerge: true
-      description: 'bump bitnami/kubectl image references'
+      description: 'bump sysdig/sysdig-kubectl image references'
       labels:
         - "automated PR"
       mergemethod: squash
-      title: 'chore(ci): bump bitnami/kubectl image references'
+      title: 'chore(ci): bump sysdig/sysdig-kubectl image references'
 
 sources:
-  bitnamiKubectlImage:
+  sysdigKubectlImage:
     kind: dockerimage
     spec:
-      image: bitnami/kubectl
+      image: quay.io/sysdig/sysdig-kubectl
       versionfilter:
-        kind: semver
-        strict: true
+        kind: regex
+        pattern: '[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+\.[0-9]+\.[0-9]+$'
 
 targets:
   bumpAgentChart:
-    name: "bump the bitnami/kubectl image reference in the agent chart"
+    name: "bump the sysdig/sysdig-kubectl image reference in the agent chart"
     kind: helmchart
     scmid: github
     spec:
@@ -45,7 +45,7 @@ targets:
       versionincrement: patch
 
   bumpKspmCollectorChart:
-    name: "bump the bitnami/kubectl image reference in the kspm-collector chart"
+    name: "bump the sysdig/sysdig-kubectl image reference in the kspm-collector chart"
     kind: helmchart
     scmid: github
     spec:
@@ -54,7 +54,7 @@ targets:
       versionincrement: patch
 
   bumpNodeAnalyzerChart:
-    name: "bump the bitnami/kubectl image reference in the node-analyzer chart"
+    name: "bump the sysdig/sysdig-kubectl image reference in the node-analyzer chart"
     kind: helmchart
     scmid: github
     spec:
@@ -63,7 +63,7 @@ targets:
       versionincrement: patch
 
   bumpRapidResponseChart:
-    name: "bump the bitnami/kubectl image reference in the rapid-response chart"
+    name: "bump the sysdig/sysdig-kubectl image reference in the rapid-response chart"
     kind: helmchart
     scmid: github
     spec:

--- a/.github/workflows/kubectl-update.yaml
+++ b/.github/workflows/kubectl-update.yaml
@@ -1,5 +1,5 @@
 ---
-name: Update bitnami/kubectl image reference for Helm tests
+name: Update sysdig/sysdig-kubectl image reference for Helm tests
 
 on:
   schedule:
@@ -20,6 +20,6 @@ jobs:
         uses: updatecli/updatecli-action@v2.92.0
 
       - name: Run Updatecli
-        run: "updatecli apply --config .github/updatecli.d/config-update-bitnami-kubectl-image.yaml"
+        run: "updatecli apply --config .github/updatecli.d/config-update-kubectl-image.yaml"
         env:
           GITHUB_TOKEN: "${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}"

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 2.3.1
+version: 2.3.2

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -421,8 +421,8 @@ tests:
   skip: false
   timeout: 300s
   image:
-    repo: bitnami/kubectl
-    tag: 1.33.4
+    repo: quay.io/sysdig/sysdig-kubectl
+    tag: 1.34.1-1.5.17
 # Allow to modify DNS policy
 dnsPolicy: null
 customSecurityContext: {}

--- a/charts/kspm-collector/Chart.yaml
+++ b/charts/kspm-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kspm-collector
 description: Sysdig KSPM collector
-version: 0.18.5
+version: 0.18.6
 appVersion: 1.39.15
 keywords:
   - monitoring

--- a/charts/kspm-collector/values.yaml
+++ b/charts/kspm-collector/values.yaml
@@ -223,5 +223,5 @@ tests:
   skip: false
   timeout: 300s
   image:
-    repo: bitnami/kubectl
-    tag: 1.33.4
+    repo: quay.io/sysdig/sysdig-kubectl
+    tag: 1.34.1-1.5.17

--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.36.9
+version: 1.36.10
 appVersion: 12.9.2
 keywords:
   - monitoring

--- a/charts/node-analyzer/values.yaml
+++ b/charts/node-analyzer/values.yaml
@@ -514,8 +514,8 @@ tests:
   skip: false
   timeout: 300s
   image:
-    repo: bitnami/kubectl
-    tag: 1.33.4
+    repo: quay.io/sysdig/sysdig-kubectl
+    tag: 1.34.1-1.5.17
 
 # Allow to modify DNS policy
 dnsPolicy: null

--- a/charts/rapid-response/Chart.yaml
+++ b/charts/rapid-response/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.26
+version: 0.9.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/rapid-response/values.yaml
+++ b/charts/rapid-response/values.yaml
@@ -218,5 +218,5 @@ tests:
     create: true
   timeout: 300s
   image:
-    repo: bitnami/kubectl
-    tag: 1.33.4
+    repo: quay.io/sysdig/sysdig-kubectl
+    tag: 1.34.1-1.5.17


### PR DESCRIPTION
## What this PR does / why we need it:

Bitnami ended free support for most container images on Aug 28, 2025 and are unavailable starting Sept 17, 2025.
Move `bitnami/kubectl` to an internal built image.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
