### PR TITLE
fix(shield): set seLinuxOptions type to control_t for unprivileged host shield deployment 

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.21.2
+version: 1.21.3
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -201,6 +201,8 @@ capabilities:
 allowPrivilegeEscalation: false
 seccompProfile:
   type: Unconfined
+seLinuxOptions:
+  type: control_t
 capabilities:
   drop:
     - ALL

--- a/charts/shield/tests/host/daemonset_test.yaml
+++ b/charts/shield/tests/host/daemonset_test.yaml
@@ -96,6 +96,8 @@ tests:
             allowPrivilegeEscalation: false
             seccompProfile:
               type: Unconfined
+            seLinuxOptions:
+              type: control_t
             capabilities:
               drop:
                 - ALL

--- a/charts/shield/tests/host/security_context_test.yaml
+++ b/charts/shield/tests/host/security_context_test.yaml
@@ -47,6 +47,8 @@ tests:
             allowPrivilegeEscalation: false
             seccompProfile:
               type: Unconfined
+            seLinuxOptions:
+              type: control_t
       - isNotSubset:
           path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].securityContext
           content:


### PR DESCRIPTION
set seLinuxOptions type to control_t for unprivileged deployment of the host shield to be able to support response actions on BottleRocket

## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
