### PR TITLE
feat(shield): add chart related envs on cluster-shield pods

### DIFF
--- a/charts/shield/templates/cluster/deployment.yaml
+++ b/charts/shield/templates/cluster/deployment.yaml
@@ -113,6 +113,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: SYSDIG_SHIELD_CHART_NAME
+              value: "{{ $.Chart.Name }}"
+            - name: SYSDIG_SHIELD_CHART_VERSION
+              value: "{{ $.Chart.Version }}"
             {{- if (include "cluster.container_vulnerability_management_enabled" .) }}
             - name: KUBE_SERVICE_NAME
               value: {{ include "cluster.container_vulnerability_management_service_name" . }}

--- a/charts/shield/tests/cluster/deployment_test.yaml
+++ b/charts/shield/tests/cluster/deployment_test.yaml
@@ -2,6 +2,8 @@ suite: Cluster - Deployment
 templates:
   - templates/cluster/deployment.yaml
   - templates/cluster/tls-certificates-admissionregistration.yaml
+chart:
+  version: 1.2.3-helmtest
 release:
   name: release-name
   namespace: shield-namespace
@@ -1013,6 +1015,10 @@ tests:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: SYSDIG_SHIELD_CHART_NAME
+              value: shield
+            - name: SYSDIG_SHIELD_CHART_VERSION
+              value: 1.2.3-helmtest
       - equal:
           path: spec.template.spec.volumes
           value:
@@ -1052,6 +1058,10 @@ tests:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: SYSDIG_SHIELD_CHART_NAME
+              value: shield
+            - name: SYSDIG_SHIELD_CHART_VERSION
+              value: 1.2.3-helmtest
       - equal:
           path: spec.template.spec.volumes
           value:
@@ -1099,6 +1109,10 @@ tests:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: SYSDIG_SHIELD_CHART_NAME
+              value: shield
+            - name: SYSDIG_SHIELD_CHART_VERSION
+              value: 1.2.3-helmtest
       - equal:
           path: spec.template.spec.volumes
           value:
@@ -1146,6 +1160,10 @@ tests:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: SYSDIG_SHIELD_CHART_NAME
+              value: shield
+            - name: SYSDIG_SHIELD_CHART_VERSION
+              value: 1.2.3-helmtest
       - equal:
           path: spec.template.spec.volumes
           value:
@@ -1493,4 +1511,18 @@ tests:
           value:
               - company.public
               - company.internal
+    template: templates/cluster/deployment.yaml
+
+  - it: Shield env vars
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].env
+          content:
+            name: SYSDIG_SHIELD_CHART_NAME
+            value: shield
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].env
+          content:
+            name: SYSDIG_SHIELD_CHART_VERSION
+            value: 1.2.3-helmtest
     template: templates/cluster/deployment.yaml


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
