### PR TITLE
feat(shield): add permissions for secrets and leases

### DIFF
--- a/charts/shield/templates/cluster/clusterrole.yaml
+++ b/charts/shield/templates/cluster/clusterrole.yaml
@@ -136,6 +136,7 @@ rules:
     - persistentvolumes
     - persistentvolumeclaims
     - configmaps
+    - secrets
   verbs:
     - get
     - list
@@ -213,6 +214,14 @@ rules:
     - events.k8s.io
   resources:
     - events
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
   verbs:
     - get
     - list

--- a/charts/shield/tests/cluster/clusterrole_test.yaml
+++ b/charts/shield/tests/cluster/clusterrole_test.yaml
@@ -30,6 +30,7 @@ tests:
               - persistentvolumes
               - persistentvolumeclaims
               - configmaps
+              - secrets
             verbs:
               - get
               - list
@@ -410,6 +411,7 @@ tests:
               - persistentvolumes
               - persistentvolumeclaims
               - configmaps
+              - secrets
             verbs:
               - get
               - list
@@ -514,6 +516,17 @@ tests:
               - events.k8s.io
             resources:
               - events
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - coordination.k8s.io
+            resources:
+              - leases
             verbs:
               - get
               - list


### PR DESCRIPTION
## What this PR does / why we need it:

Fix permissions to get/list/watch leases and secrets

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
