### PR TITLE
fix(shield,cluster-shield): fixed shield and cluster-shield charts for AC with image-signature only

### DIFF
--- a/charts/cluster-shield/Chart.yaml
+++ b/charts/cluster-shield/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-shield
 description: Cluster Shield Helm Chart for Kubernetes
 type: application
-version: 1.18.0
+version: 1.18.1
 appVersion: "1.18.0"
 maintainers:
   - name: AlbertoBarba

--- a/charts/cluster-shield/templates/validatingwebhookconfiguration.yaml
+++ b/charts/cluster-shield/templates/validatingwebhookconfiguration.yaml
@@ -60,7 +60,7 @@ webhooks:
         apiVersions: [ "v1" ]
         operations: [ "CREATE", "UPDATE" ]
         resources:
-          {{- if .Values.cluster_shield.features.admission_control.container_vulnerability_management.enabled }}
+          {{- if or .Values.cluster_shield.features.admission_control.container_vulnerability_management.enabled (and (.Values.cluster_shield.features.admission_control.supply_chain).enabled ((.Values.cluster_shield.features.admission_control.supply_chain).image_signature).enabled)}}
           - "pods"
           {{- end }}
           - "deployments"

--- a/charts/cluster-shield/tests/validatingwebhookconfiguration_test.yaml
+++ b/charts/cluster-shield/tests/validatingwebhookconfiguration_test.yaml
@@ -525,3 +525,49 @@ tests:
             resources:
               - pods
             scope: Namespaced
+  - it: Enable pod resources when image signature is enabled
+    set:
+      cluster_shield:
+        features:
+          admission_control:
+            enabled: true
+            supply_chain:
+              enabled: true
+              image_signature:
+                enabled: true
+            container_vulnerability_management:
+              enabled: false
+            failure_policy: Fail
+    documentIndex: 0
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          kind: ValidatingWebhookConfiguration
+          apiVersion: admissionregistration.k8s.io/v1
+          name: shield-release-cluster-shield
+      - exists:
+          path: .webhooks[?(@.name == "vac.secure.sysdig.com")]
+      - exists:
+          path: .webhooks[?(@.name == "vac.secure.sysdig.com")].rules
+      - lengthEqual:
+          path: .webhooks[?(@.name == "vac.secure.sysdig.com")].rules
+          count: 1
+      - contains:
+          path: .webhooks[?(@.name == "vac.secure.sysdig.com")].rules
+          content:
+            apiGroups:
+              - ""
+              - apps
+              - batch
+            apiVersions: [ "v1" ]
+            operations: [ "CREATE", "UPDATE" ]
+            resources:
+              - pods
+              - deployments
+              - replicasets
+              - statefulsets
+              - daemonsets
+              - jobs
+              - cronjobs
+            scope: Namespaced

--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.24.0
+version: 1.24.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/tls-certificates-admissionregistration.yaml
+++ b/charts/shield/templates/cluster/tls-certificates-admissionregistration.yaml
@@ -117,7 +117,7 @@ webhooks:
         apiVersions: [ "v1" ]
         operations: [ "CREATE", "UPDATE" ]
         resources:
-          {{- if .Values.features.admission_control.container_vulnerability_management.enabled }}
+          {{- if or .Values.features.admission_control.container_vulnerability_management.enabled (and (.Values.features.admission_control.supply_chain).enabled ((.Values.features.admission_control.supply_chain).image_signature).enabled)}}
           - pods
           {{- end }}
           - deployments

--- a/charts/shield/tests/cluster/tls-certificates-admissionregistration_test.yaml
+++ b/charts/shield/tests/cluster/tls-certificates-admissionregistration_test.yaml
@@ -636,6 +636,56 @@ tests:
             scope: Namespaced
         documentIndex: 1
 
+  - it: Enable pod resources when image signature is enabled
+    set:
+      features:
+        admission_control:
+          enabled: true
+          supply_chain:
+            enabled: true
+            image_signature:
+              enabled: true
+        container_vulnerability_management:
+          enabled: false
+        failure_policy: Fail
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          kind: ValidatingWebhookConfiguration
+          apiVersion: admissionregistration.k8s.io/v1
+          name: shield-release-cluster-admission-control
+        documentIndex: 1
+      - exists:
+          path: .webhooks[?(@.name == "vac.secure.sysdig.com")]
+        documentIndex: 1
+      - exists:
+          path: .webhooks[?(@.name == "vac.secure.sysdig.com")].rules
+        documentIndex: 1
+      - lengthEqual:
+          path: .webhooks[?(@.name == "vac.secure.sysdig.com")].rules
+          count: 1
+        documentIndex: 1
+      - contains:
+          path: .webhooks[?(@.name == "vac.secure.sysdig.com")].rules
+          content:
+            apiGroups:
+              - ""
+              - apps
+              - batch
+            apiVersions: [ "v1" ]
+            operations: [ "CREATE", "UPDATE" ]
+            resources:
+              - pods
+              - deployments
+              - replicasets
+              - statefulsets
+              - daemonsets
+              - jobs
+              - cronjobs
+            scope: Namespaced
+        documentIndex: 1
+
   - it: Cert Manager Integration exclusive with tls secret name
     set:
       features:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
