### PR TITLE
chore: convert operator bundle generation to workflow dispatch

### DIFF
--- a/.github/workflows/release-rh-shield-operator-bundle.yaml
+++ b/.github/workflows/release-rh-shield-operator-bundle.yaml
@@ -1,12 +1,7 @@
 name: Build and Certify Shield Operator Bundle
 
 on:
-  pull_request:
-    types: [closed]
-    branches:
-      - main
-    paths:
-      - 'rh-shield-operator/bundle/**'
+  workflow_dispatch:
 
 jobs:
   validate-and-prepare:


### PR DESCRIPTION
## What this PR does / why we need it:
Convert the operator bundle generation pipeline to workflow dispatch

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
