### PR TITLE
fix: various fixes to rh-shield-operator release pipelines

### DIFF
--- a/.github/workflows/release-rh-shield-operator-bundle.yaml
+++ b/.github/workflows/release-rh-shield-operator-bundle.yaml
@@ -1,4 +1,4 @@
-name: Build and Certify Shield Operator Bundle
+name: Build Shield Operator Bundle
 
 on:
   workflow_dispatch:
@@ -89,67 +89,31 @@ jobs:
 
           echo "✅ Bundle image built and pushed successfully: $BUNDLE_IMAGE"
 
-  certify-bundle-image:
-    name: Certify the Bundle Image with Preflight
-    runs-on: ubuntu-latest
-    needs:
-      - validate-and-prepare
-      - build-operator-bundle
-    steps:
-      - name: Checkout charts repo
-        uses: actions/checkout@v6
-        with:
-          ref: main
-          fetch-depth: '1'
-
-      - name: Install Preflight
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          source: "github"
-          preflight: "latest"
-          github_pat: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run Preflight checks on Bundle
-        run: |
-          BUNDLE_IMAGE="${{ needs.build-operator-bundle.outputs.bundle_image }}"
-
-          echo "Running Preflight certification on: $BUNDLE_IMAGE"
-
-          preflight check container \
-            "$BUNDLE_IMAGE" \
-            --pyxis-api-token ${{ secrets.RH_SHIELD_OPERATOR_PYXIS_API_TOKEN }} \
-            --certification-project-id ${{ secrets.RH_SHIELD_BUNDLE_CERTIFICATION_PROJECT_ID }}
-
-          echo "✅ Bundle image certification completed"
-
   notify-completion:
     name: Notify Bundle Release Completion
     runs-on: ubuntu-latest
     needs:
       - validate-and-prepare
       - build-operator-bundle
-      - certify-bundle-image
     if: always()
     steps:
       - name: Report Success
-        if: needs.build-operator-bundle.result == 'success' && needs.certify-bundle-image.result == 'success'
+        if: needs.build-operator-bundle.result == 'success'
         run: |
           echo "🎉 Bundle Release Workflow Completed Successfully"
           echo ""
           echo "Version: v${{ needs.validate-and-prepare.outputs.release_version }}"
           echo "Bundle Image: ${{ needs.build-operator-bundle.outputs.bundle_image }}"
-          echo "Certification: ✅ Passed"
           echo ""
           echo "The rh-shield-operator release is now complete!"
 
       - name: Report Failure
-        if: needs.build-operator-bundle.result == 'failure' || needs.certify-bundle-image.result == 'failure'
+        if: needs.build-operator-bundle.result == 'failure'
         run: |
           echo "❌ Bundle Release Workflow Failed"
           echo ""
           echo "Version: v${{ needs.validate-and-prepare.outputs.release_version }}"
           echo "Build Status: ${{ needs.build-operator-bundle.result }}"
-          echo "Certification Status: ${{ needs.certify-bundle-image.result }}"
           echo ""
           echo "Check workflow logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           exit 1
@@ -161,14 +125,13 @@ jobs:
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
 
-          if [ "${{ needs.build-operator-bundle.result }}" == "success" ] && [ "${{ needs.certify-bundle-image.result }}" == "success" ]; then
+          if [ "${{ needs.build-operator-bundle.result }}" == "success" ]; then
             gh pr comment "$PR_NUMBER" \
-              --body "✅ **Bundle Build and Certification Completed**
+              --body "✅ **Bundle Build Completed**
 
-          The bundle image has been built and certified successfully!
+          The bundle image has been built successfully!
 
           - Bundle Image: \`${{ needs.build-operator-bundle.outputs.bundle_image }}\`
-          - Certification: ✅ Passed
           - Workflow: [View Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           🎉 **Release v${{ needs.validate-and-prepare.outputs.release_version }} is complete!**
@@ -177,10 +140,9 @@ jobs:
             gh pr comment "$PR_NUMBER" \
               --body "❌ **Bundle Build Failed**
 
-          There was an error building or certifying the bundle image.
+          There was an error building the bundle image.
 
           - Build Status: ${{ needs.build-operator-bundle.result }}
-          - Certification Status: ${{ needs.certify-bundle-image.result }}
           - Workflow: [View Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           Please check the workflow logs for details.

--- a/.github/workflows/release-rh-shield-operator-bundle.yaml
+++ b/.github/workflows/release-rh-shield-operator-bundle.yaml
@@ -7,8 +7,6 @@ jobs:
   validate-and-prepare:
     name: Validate Bundle PR
     runs-on: ubuntu-latest
-    # Only run if PR was actually merged (not just closed)
-    if: github.event.pull_request.merged == true
     outputs:
       release_version: ${{ steps.get-version.outputs.release_version }}
       image_tag_base: ${{ steps.get-image-base.outputs.image_tag_base }}

--- a/.github/workflows/release-rh-shield-operator-bundle.yaml
+++ b/.github/workflows/release-rh-shield-operator-bundle.yaml
@@ -1,7 +1,12 @@
 name: Build Shield Operator Bundle
 
 on:
-  workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+    paths:
+      - 'rh-shield-operator/bundle/**'
 
 jobs:
   validate-and-prepare:

--- a/.github/workflows/release-rh-shield-operator-bundle.yaml
+++ b/.github/workflows/release-rh-shield-operator-bundle.yaml
@@ -12,6 +12,8 @@ jobs:
   validate-and-prepare:
     name: Validate Bundle PR
     runs-on: ubuntu-latest
+    # Only run if PR was actually merged (not just closed)
+    if: github.event.pull_request.merged == true
     outputs:
       release_version: ${{ steps.get-version.outputs.release_version }}
       image_tag_base: ${{ steps.get-image-base.outputs.image_tag_base }}

--- a/.github/workflows/release-rh-shield-operator.yaml
+++ b/.github/workflows/release-rh-shield-operator.yaml
@@ -167,6 +167,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: '1'
+          ref: 'main'
 
       - name: Login to Docker registry
         uses: docker/login-action@v3

--- a/.github/workflows/release-rh-shield-operator.yaml
+++ b/.github/workflows/release-rh-shield-operator.yaml
@@ -181,7 +181,7 @@ jobs:
         # generated and pushed to the registry.
         run: |
           echo "Generating bundle with image digest: ${{ needs.build-operator.outputs.image_digest }}"
-          USE_IMAGE_DIGESTS=true make bundle
+          USE_IMAGE_DIGESTS=true LOCALBIN=$(pwd)/bin make bundle
         working-directory: rh-shield-operator
         env:
           VERSION: ${{ needs.validate-prerequisites.outputs.release_version }}

--- a/.github/workflows/release-rh-shield-operator.yaml
+++ b/.github/workflows/release-rh-shield-operator.yaml
@@ -207,7 +207,7 @@ jobs:
               "features.operators.openshift.io/token-auth-azure": "false",
               "features.operators.openshift.io/token-auth-gcp": "false"
             }' rh-shield-operator/bundle/manifests/rh-shield-operator.clusterserviceversion.yaml
-            yq e -i '.annotations."com.redhat.openshift.versions" = "v4.8-v4.17"' rh-shield-operator/bundle/metadata/annotations.yaml
+            yq e -i '.annotations."com.redhat.openshift.versions" = "v4.8-v4.20"' rh-shield-operator/bundle/metadata/annotations.yaml
 
       - name: Open Pull Request for Bundle update
         uses: peter-evans/create-pull-request@v8

--- a/.github/workflows/release-rh-shield-operator.yaml
+++ b/.github/workflows/release-rh-shield-operator.yaml
@@ -41,29 +41,29 @@ jobs:
           echo "image_tag_base=$IMAGE_TAG_BASE" >> $GITHUB_OUTPUT
         working-directory: rh-shield-operator
 
-      - name: Login to Docker registry
-        uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_RH_SHIELD_OPERATOR_USERNAME }}
-          password: ${{ secrets.QUAY_RH_SHIELD_OPERATOR_PASSWORD }}
-
-      - name: Check if Version Already Released
-        id: check-existing
-        run: |
-          # Check if this version already exists in the registry
-          IMAGE="${{ steps.get-image-base.outputs.image_tag_base }}:v${{ steps.get-operator-version.outputs.release_version }}"
-
-          echo "Checking if $IMAGE already exists..."
-
-          # This will fail if image doesn't exist, which is what we want
-          if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
-            echo "⚠️ WARNING: Image $IMAGE already exists in registry"
-            echo "should_skip=true" >> $GITHUB_OUTPUT
-          else
-            echo "✅ Version is new, proceeding with build"
-            echo "should_skip=false" >> $GITHUB_OUTPUT
-          fi
+#      - name: Login to Docker registry
+#        uses: docker/login-action@v3
+#        with:
+#          registry: quay.io
+#          username: ${{ secrets.QUAY_RH_SHIELD_OPERATOR_USERNAME }}
+#          password: ${{ secrets.QUAY_RH_SHIELD_OPERATOR_PASSWORD }}
+#
+#      - name: Check if Version Already Released
+#        id: check-existing
+#        run: |
+#          # Check if this version already exists in the registry
+#          IMAGE="${{ steps.get-image-base.outputs.image_tag_base }}:v${{ steps.get-operator-version.outputs.release_version }}"
+#
+#          echo "Checking if $IMAGE already exists..."
+#
+#          # This will fail if image doesn't exist, which is what we want
+#          if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+#            echo "⚠️ WARNING: Image $IMAGE already exists in registry"
+#            echo "should_skip=true" >> $GITHUB_OUTPUT
+#          else
+#            echo "✅ Version is new, proceeding with build"
+#            echo "should_skip=false" >> $GITHUB_OUTPUT
+#          fi
 
   build-operator:
     name: Build the Operator Image

--- a/.github/workflows/release-rh-shield-operator.yaml
+++ b/.github/workflows/release-rh-shield-operator.yaml
@@ -214,6 +214,9 @@ jobs:
         id: open-pr
         with:
           token: ${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}
+          add-paths: |
+            rh-shield-operator/bundle/
+            rh-shield-operator/config/
           commit-message: "chore(rh-shield-operator): update bundle for rh-shield-operator:v${{ needs.validate-prerequisites.outputs.release_version }}"
           title: "chore(rh-shield-operator): update bundle for rh-shield-operator:v${{ needs.validate-prerequisites.outputs.release_version }}"
           body: |

--- a/.github/workflows/release-rh-shield-operator.yaml
+++ b/.github/workflows/release-rh-shield-operator.yaml
@@ -149,7 +149,7 @@ jobs:
           preflight check container \
             "$IMAGE_TAG" \
             --pyxis-api-token ${{ secrets.RH_SHIELD_OPERATOR_PYXIS_API_TOKEN }} \
-            --certification-project-id ${{ secrets.RH_SHIELD_OPERATOR_CERTIFICATION_PROJECT_ID }}
+            --certification-component-id ${{ secrets.RH_SHIELD_OPERATOR_CERTIFICATION_PROJECT_ID }}
 
           echo "✅ Operator image certification completed"
 

--- a/.github/workflows/release-rh-shield-operator.yaml
+++ b/.github/workflows/release-rh-shield-operator.yaml
@@ -41,29 +41,29 @@ jobs:
           echo "image_tag_base=$IMAGE_TAG_BASE" >> $GITHUB_OUTPUT
         working-directory: rh-shield-operator
 
-#      - name: Login to Docker registry
-#        uses: docker/login-action@v3
-#        with:
-#          registry: quay.io
-#          username: ${{ secrets.QUAY_RH_SHIELD_OPERATOR_USERNAME }}
-#          password: ${{ secrets.QUAY_RH_SHIELD_OPERATOR_PASSWORD }}
-#
-#      - name: Check if Version Already Released
-#        id: check-existing
-#        run: |
-#          # Check if this version already exists in the registry
-#          IMAGE="${{ steps.get-image-base.outputs.image_tag_base }}:v${{ steps.get-operator-version.outputs.release_version }}"
-#
-#          echo "Checking if $IMAGE already exists..."
-#
-#          # This will fail if image doesn't exist, which is what we want
-#          if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
-#            echo "⚠️ WARNING: Image $IMAGE already exists in registry"
-#            echo "should_skip=true" >> $GITHUB_OUTPUT
-#          else
-#            echo "✅ Version is new, proceeding with build"
-#            echo "should_skip=false" >> $GITHUB_OUTPUT
-#          fi
+      - name: Login to Docker registry
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_RH_SHIELD_OPERATOR_USERNAME }}
+          password: ${{ secrets.QUAY_RH_SHIELD_OPERATOR_PASSWORD }}
+
+      - name: Check if Version Already Released
+        id: check-existing
+        run: |
+          # Check if this version already exists in the registry
+          IMAGE="${{ steps.get-image-base.outputs.image_tag_base }}:v${{ steps.get-operator-version.outputs.release_version }}"
+
+          echo "Checking if $IMAGE already exists..."
+
+          # This will fail if image doesn't exist, which is what we want
+          if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+            echo "⚠️ WARNING: Image $IMAGE already exists in registry"
+            echo "should_skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "✅ Version is new, proceeding with build"
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          fi
 
   build-operator:
     name: Build the Operator Image

--- a/rh-shield-operator/Makefile
+++ b/rh-shield-operator/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.36.1
+OPERATOR_SDK_VERSION ?= v1.38.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= ${IMAGE_TAG_BASE}:v${VERSION}


### PR DESCRIPTION
## What this PR does / why we need it:
The pipelines have been run successfully and the changes in this PR serve the following purposes:

1) Fix small issues found during the initial run
2) Converts the bundle release job back to being triggered automatically

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
