### PR TITLE
ci(host-shield): add windows release auto pr

### DIFF
--- a/.github/updatecli.d/config-host-shield-windows-release.yaml
+++ b/.github/updatecli.d/config-host-shield-windows-release.yaml
@@ -1,0 +1,57 @@
+name: update shield charts for new host-shield windows release
+
+scms:
+  github:
+    kind: "github"
+    spec:
+      user: "updatecli"
+      email: "updatecli@sysdig.com"
+      owner: "sysdiglabs"
+      repository: "charts"
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: draios-jenkins
+      branch: "main"
+
+actions:
+  github:
+    kind: "github/pullrequest"
+    scmid: "github"
+    spec:
+      automerge: true
+      description: 'bump host-shield image tags for `shield` chart to {{ requiredEnv "HOST_SHIELD_RELEASE" }}'
+      labels:
+        - "automated PR"
+      mergemethod: squash
+      title: 'feat(shield): release host-shield windows {{ requiredEnv "HOST_SHIELD_RELEASE" }}'
+
+sources:
+  hostShieldRelease:
+    kind: dockerimage
+    spec:
+      image: quay.io/sysdig/host-shield
+      tagfilter: '{{ requiredEnv "HOST_SHIELD_RELEASE" }}'
+      versionfilter:
+        kind: regex
+        pattern: '[0-9]+\.[0-9]+\.[0-9]+$'
+
+targets:
+  updateShieldChart:
+    name: "update the shield chart"
+    kind: helmchart
+    scmid: github
+    spec:
+      name: "charts/shield"
+      file: values.yaml
+      key: "$.host_windows.image.tag"
+      versionincrement: auto
+
+  updateShieldReadme:
+    name: "update the shield readme"
+    kind: shell
+    scmid: github
+    disablesourceinput: true
+    dependson:
+      - updateShieldChart
+    spec:
+      shell: /bin/bash
+      command: "sed -i 's/: # /:  # /g' charts/shield/values.yaml && make docs"

--- a/.github/workflows/host-shield-release.yaml
+++ b/.github/workflows/host-shield-release.yaml
@@ -1,0 +1,33 @@
+---
+name: Update charts for Host Shield release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Host Shield Version'
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  host-shield-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@v2.97.0
+
+      - name: Run Updatecli in apply mode
+        run: "updatecli apply --config .github/updatecli.d/config-host-shield-windows-release.yaml"
+        env:
+          HOST_SHIELD_RELEASE: "${{ inputs.release }}"
+          GITHUB_TOKEN: "${{ secrets.TOOLS_JENKINS_ADMIN_ACCESS_GITHUB_TOKEN }}"


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
