### PR TITLE
chore(rh-shield-operator): prep for release

### DIFF
--- a/rh-shield-operator/Makefile
+++ b/rh-shield-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.4.0
+VERSION ?= 0.4.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")


### PR DESCRIPTION
## What this PR does / why we need it:
Increment the VERSION field for the 0.4.1 release.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
