### PR TITLE
fix(shield): add missing ca-cert volume mount on host-shield initContainer

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.25.4
+version: 1.25.5
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -70,7 +70,7 @@ spec:
             {{- include "common.custom_ca.envs" (merge (dict) . (dict "CACertsPath" "/opt/draios/certificates/")) | nindent 12 }}
           volumeMounts:
             {{- /* Custom CA */}}
-            - {{- include "common.custom_ca.volume_mount" (merge (dict) . (dict "CACertsPath" "/opt/draios/certificates/")) | nindent 12 }}
+            {{- include "common.custom_ca.volume_mount" (merge (dict) . (dict "CACertsPath" "/opt/draios/certificates/")) | nindent 12 }}
             {{- /* Autopilot = false */}}
             {{- if not (include "common.cluster_type.is_gke_autopilot" .) }}
             - mountPath: /etc/modprobe.d

--- a/charts/shield/templates/host/daemonset.yaml
+++ b/charts/shield/templates/host/daemonset.yaml
@@ -69,6 +69,8 @@ spec:
             {{- end }}
             {{- include "common.custom_ca.envs" (merge (dict) . (dict "CACertsPath" "/opt/draios/certificates/")) | nindent 12 }}
           volumeMounts:
+            {{- /* Custom CA */}}
+            - {{- include "common.custom_ca.volume_mount" (merge (dict) . (dict "CACertsPath" "/opt/draios/certificates/")) | nindent 12 }}
             {{- /* Autopilot = false */}}
             {{- if not (include "common.cluster_type.is_gke_autopilot" .) }}
             - mountPath: /etc/modprobe.d

--- a/charts/shield/tests/host/daemonset_test.yaml
+++ b/charts/shield/tests/host/daemonset_test.yaml
@@ -21,6 +21,8 @@ tests:
       - notExists:
           path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].env[?(@.name == "SSL_CERT_FILE")]
       - notExists:
+          path: spec.template.spec.initContainers[?(@.name == "sysdig-host-shield-kmodule")].volumeMounts[?(@.name == "ca-certs")]
+      - notExists:
           path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].volumeMounts[?(@.name == "ca-certs")]
       - notExists:
           path: spec.template.spec.volumes[?(@.name == "ca-certs")]
@@ -38,6 +40,12 @@ tests:
           value:
             name: SSL_CERT_FILE
             value: /opt/draios/certificates/custom-ca-from-values.crt
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "sysdig-host-shield-kmodule")].volumeMounts
+          content:
+            name: ca-certs
+            mountPath: /opt/draios/certificates/
+            readOnly: true
       - contains:
           path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].volumeMounts
           content:
@@ -63,6 +71,12 @@ tests:
           value:
             name: SSL_CERT_FILE
             value: /opt/draios/certificates/custom-ca-from-secret.crt
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "sysdig-host-shield-kmodule")].volumeMounts
+          content:
+            name: ca-certs
+            mountPath: /opt/draios/certificates/
+            readOnly: true
       - contains:
           path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].volumeMounts
           content:


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [X] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [X] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [X] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
