### PR TITLE
chore(host-shield-windows): add support for the new tags structure

### DIFF
--- a/charts/shield/templates/host/_windows_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_windows_configmap_helpers.tpl
@@ -61,7 +61,11 @@
 
 {{- $clusterConfig := dict "name" .Values.cluster_config.name -}}
 {{- if .Values.cluster_config.tags -}}
-  {{- $_ := set $clusterConfig "tags" .Values.cluster_config.tags -}}
+  {{- if and (include "common.semver.is_valid" .Values.host_windows.image.tag) (semverCompare "< 0.14.0-0" .Values.host_windows.image.tag) }}
+    {{- $_ := set $clusterConfig "tags" .Values.cluster_config.tags -}}
+  {{- else -}}
+    {{- $_ := set $config "tags" .Values.cluster_config.tags -}}
+  {{- end -}}
 {{- end -}}
 {{- $_ := set $config "cluster_config" $clusterConfig -}}
 

--- a/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
+++ b/charts/shield/tests/host/configmap-windows-host-shield-config_test.yaml
@@ -509,3 +509,50 @@ tests:
               ca:
                 cert_path: certificates/rootCA.crt
               verify: true
+
+  - it: Test tags with version < 0.14.0
+    set:
+      cluster_config:
+        name: "test-cluster"
+        tags:
+          environment: "test"
+          team: "devops"
+      host_windows:
+        image:
+          tag: "0.13.0"
+    asserts:
+      - notExists:
+          path: data['dragent.yaml']
+      - matchRegex:
+          path: data['host-shield.yaml']
+          pattern: |
+            cluster_config:
+              name: test-cluster
+              tags:
+                environment: test
+                team: devops
+
+  - it: Test tags with version >= 0.14.0
+    set:
+      cluster_config:
+        name: "test-cluster"
+        tags:
+          environment: "test"
+          team: "devops"
+      host_windows:
+        image:
+          tag: "0.14.0"
+    asserts:
+      - notExists:
+          path: data['dragent.yaml']
+      - matchRegex:
+          path: data['host-shield.yaml']
+          pattern: |
+            cluster_config:
+              name: test-cluster
+      - matchRegex:
+          path: data['host-shield.yaml']
+          pattern: |
+            tags:
+              environment: test
+              team: devops


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
