### PR TITLE
fix(hostshield): add delete authorization to Leases RBAC

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.31.0
+version: 1.31.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/role.yaml
+++ b/charts/shield/templates/host/role.yaml
@@ -21,4 +21,5 @@ rules:
       - list
       - update
       - watch
+      - delete
 {{- end }}

--- a/charts/shield/tests/host/role_test.yaml
+++ b/charts/shield/tests/host/role_test.yaml
@@ -35,6 +35,7 @@ tests:
                 - list
                 - update
                 - watch
+                - delete
 
   - it: Ensure the Role is not created when not requested
     set:


### PR DESCRIPTION
## What this PR does / why we need it:
The delete authorization is needed to update existing lease with an OwnerReference

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
