### PR TITLE
fix: Remove permissions that don't exist

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.33.0
+version: 1.33.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/clusterrole.yaml
+++ b/charts/shield/templates/cluster/clusterrole.yaml
@@ -38,20 +38,42 @@ rules:
 {{- if (include "cluster.container_vulnerability_management_enabled" .) }}
 - apiGroups:
     - ""
-    - apps
-    - batch
-    - extensions
   resources:
-    - cronjobs
-    - daemonsets
-    - deployments
-    - jobs
     - namespaces
     - nodes
     - pods
-    - replicasets
     - replicationcontrollers
     - secrets
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - daemonsets
+    - deployments
+    - replicasets
+    - statefulsets
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - cronjobs
+    - jobs
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - daemonsets
+    - deployments
+    - replicasets
     - statefulsets
   verbs:
     - get
@@ -61,49 +83,108 @@ rules:
 {{- if (include "cluster.posture_enabled" .) }}
 - apiGroups:
     - ""
-    - rbac.authorization.k8s.io
-    - extensions
-    - apps
-    - batch
-    - networking.k8s.io
-    - autoscaling
-    - policy
-    - storage.k8s.io
-    - config.openshift.io
   resources:
+    - configmaps
+    - events
+    - limitranges
+    - namespaces
+    - nodes
+    - persistentvolumeclaims
+    - persistentvolumes
     - pods
     - pods/log
-    - namespaces
-    - deployments
+    - replicationcontrollers
+    - resourcequotas
+    - secrets
+    - serviceaccounts
+    - services
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - controllerrevisions
     - daemonsets
+    - deployments
+    - replicasets
     - statefulsets
-    - jobs
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - batch
+  resources:
     - cronjobs
+    - jobs
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - config.openshift.io
+  resources:
+    - clusterversions
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - daemonsets
+    - deployments
+    - ingresses
+    - replicasets
+    - statefulsets
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - networking.k8s.io
+  resources:
+    - ingresses
+    - ingressclasses
+    - networkpolicies
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - podsecuritypolicies
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
     - clusterroles
     - clusterrolebindings
     - roles
     - rolebindings
-    - services
-    - serviceaccounts
-    - nodes
-    - ingresses
-    - ingressclasses
-    - networkpolicies
-    - replicasets
-    - configmaps
-    - events
-    - limitranges
-    - persistentvolumes
-    - persistentvolumeclaims
-    - replicationcontrollers
-    - resourcequotas
-    - controllerrevisions
-    - horizontalpodautoscalers
-    - podsecuritypolicies
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - storage.k8s.io
+  resources:
     - storageclasses
     - volumeattachments
-    - clusterversions
-    - secrets
   verbs:
     - get
     - list

--- a/charts/shield/templates/cluster/role.yaml
+++ b/charts/shield/templates/cluster/role.yaml
@@ -12,39 +12,63 @@ metadata:
   {{- end }}
 rules:
 {{- if (and (include "cluster.posture_enabled" .) (include "cluster.need_posture_lease" .) .) }}
-  - apiGroups: ["", "coordination.k8s.io"]
+  - apiGroups: ["coordination.k8s.io"]
     resources:
       - "leases"
     resourceNames:
       - {{ include "cluster.posture_lease_name" . }}
-    verbs: ["*"]
-  - apiGroups: ["", "coordination.k8s.io"]
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups: ["coordination.k8s.io"]
     resources:
       - "leases"
     verbs: ["create"]
 {{- end }}
 {{- if (include "cluster.container_vulnerability_management_enabled" .) }}
-  - apiGroups: ["", "coordination.k8s.io"]
+  - apiGroups: ["coordination.k8s.io"]
     resources:
       - "leases"
     resourceNames:
       - {{ include "cluster.container_vulnerability_management_lease_name" . }}
-    verbs: ["*"]
-  - apiGroups: ["", "coordination.k8s.io"]
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups: ["coordination.k8s.io"]
     resources:
       - "leases"
     verbs: ["create"]
-  - apiGroups: ["*"]
+  - apiGroups: [""]
     resources:
       - "endpoints"
     verbs: ["get", "watch", "list"]
-  - apiGroups: ["*"]
+  - apiGroups: [""]
     resources:
       - "endpoints"
       # Following is required for OpenShift. See https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/pods_and_services.html#endpoints
       - "endpoints/restricted"
     resourceNames:
       - {{ include "cluster.container_vulnerability_management_service_name" . }}
-    verbs: ["*"]
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
   {{- end }}
 {{- end }}

--- a/charts/shield/tests/cluster/clusterrole_test.yaml
+++ b/charts/shield/tests/cluster/clusterrole_test.yaml
@@ -200,20 +200,51 @@ tests:
           content:
             apiGroups:
               - ""
-              - apps
-              - batch
-              - extensions
             resources:
-              - cronjobs
-              - daemonsets
-              - deployments
-              - jobs
               - namespaces
               - nodes
               - pods
-              - replicasets
               - replicationcontrollers
               - secrets
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps
+            resources:
+              - daemonsets
+              - deployments
+              - replicasets
+              - statefulsets
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - batch
+            resources:
+              - cronjobs
+              - jobs
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+            resources:
+              - daemonsets
+              - deployments
+              - replicasets
               - statefulsets
             verbs:
               - get
@@ -260,53 +291,140 @@ tests:
           content:
             apiGroups:
               - ""
-              - rbac.authorization.k8s.io
-              - extensions
-              - apps
-              - batch
-              - networking.k8s.io
-              - autoscaling
-              - policy
-              - storage.k8s.io
-              - config.openshift.io
             resources:
-              - pods
-              - pods/log
-              - namespaces
-              - deployments
-              - daemonsets
-              - statefulsets
-              - jobs
-              - cronjobs
-              - clusterroles
-              - clusterrolebindings
-              - roles
-              - rolebindings
-              - services
-              - serviceaccounts
-              - nodes
-              - ingresses
-              - ingressclasses
-              - networkpolicies
-              - replicasets
               - configmaps
               - events
               - limitranges
-              - persistentvolumes
+              - namespaces
+              - nodes
               - persistentvolumeclaims
+              - persistentvolumes
+              - pods
+              - pods/log
               - replicationcontrollers
               - resourcequotas
-              - controllerrevisions
-              - horizontalpodautoscalers
-              - podsecuritypolicies
-              - storageclasses
-              - volumeattachments
-              - clusterversions
               - secrets
+              - serviceaccounts
+              - services
             verbs:
               - get
               - list
               - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps
+            resources:
+              - controllerrevisions
+              - daemonsets
+              - deployments
+              - replicasets
+              - statefulsets
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - autoscaling
+            resources:
+              - horizontalpodautoscalers
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - batch
+            resources:
+              - cronjobs
+              - jobs
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - config.openshift.io
+            resources:
+              - clusterversions
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+            resources:
+              - daemonsets
+              - deployments
+              - ingresses
+              - replicasets
+              - statefulsets
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - networking.k8s.io
+            resources:
+              - ingresses
+              - ingressclasses
+              - networkpolicies
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - policy
+            resources:
+              - podsecuritypolicies
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - rbac.authorization.k8s.io
+            resources:
+              - clusterroles
+              - clusterrolebindings
+              - roles
+              - rolebindings
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - storage.k8s.io
+            resources:
+              - storageclasses
+              - volumeattachments
+            verbs:
+              - get
+              - list
+              - watch
+
 
   - it: Admission Control with Container Vulnerability Management
     set:
@@ -325,20 +443,51 @@ tests:
           content:
             apiGroups:
               - ""
-              - apps
-              - batch
-              - extensions
             resources:
-              - cronjobs
-              - daemonsets
-              - deployments
-              - jobs
               - namespaces
               - nodes
               - pods
-              - replicasets
               - replicationcontrollers
               - secrets
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps
+            resources:
+              - daemonsets
+              - deployments
+              - replicasets
+              - statefulsets
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - batch
+            resources:
+              - cronjobs
+              - jobs
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+            resources:
+              - daemonsets
+              - deployments
+              - replicasets
               - statefulsets
             verbs:
               - get

--- a/charts/shield/tests/cluster/role_test.yaml
+++ b/charts/shield/tests/cluster/role_test.yaml
@@ -33,17 +33,25 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["", "coordination.k8s.io"]
+            apiGroups: ["coordination.k8s.io"]
             resources:
               - "leases"
             resourceNames:
               - "release-name-shield-cluster-container-vulnerability-management"
-            verbs: ["*"]
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
       - contains:
           path: rules
           content:
-            apiGroups: ["", "coordination.k8s.io"]
+            apiGroups: ["coordination.k8s.io"]
             resources:
               - "leases"
             verbs: ["create"]
@@ -51,7 +59,7 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["*"]
+            apiGroups: [""]
             resources:
               - "endpoints"
             verbs: ["get", "watch", "list"]
@@ -59,13 +67,21 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["*"]
+            apiGroups: [""]
             resources:
               - "endpoints"
               - "endpoints/restricted"
             resourceNames:
               - "release-name-shield-cluster-container-vm"
-            verbs: ["*"]
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
   - it: Admission Control withContainer Vulnerability Management
     set:
@@ -83,17 +99,25 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["", "coordination.k8s.io"]
+            apiGroups: ["coordination.k8s.io"]
             resources:
               - "leases"
             resourceNames:
               - "release-name-shield-cluster-container-vulnerability-management"
-            verbs: ["*"]
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
       - contains:
           path: rules
           content:
-            apiGroups: ["", "coordination.k8s.io"]
+            apiGroups: ["coordination.k8s.io"]
             resources:
               - "leases"
             verbs: ["create"]
@@ -101,7 +125,7 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["*"]
+            apiGroups: [""]
             resources:
               - "endpoints"
             verbs: ["get", "watch", "list"]
@@ -109,13 +133,21 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["*"]
+            apiGroups: [""]
             resources:
               - "endpoints"
               - "endpoints/restricted"
             resourceNames:
               - "release-name-shield-cluster-container-vm"
-            verbs: ["*"]
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
   - it: Posture
     set:
@@ -132,17 +164,25 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["", "coordination.k8s.io"]
+            apiGroups: ["coordination.k8s.io"]
             resources:
               - "leases"
             resourceNames:
               - "release-name-shield-cluster-posture"
-            verbs: ["*"]
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
       - contains:
           path: rules
           content:
-            apiGroups: ["", "coordination.k8s.io"]
+            apiGroups: ["coordination.k8s.io"]
             resources:
               - "leases"
             verbs: ["create"]


### PR DESCRIPTION
We're using ArgoCD Service Account Impersonation to deploy. This relies on [Privilege escalation prevention](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping)

Currently I'm getting errors like:
```
clusterroles.rbac.authorization.k8s.io "shield-cluster" is forbidden: user "system:serviceaccount:security-system:argocd-deployer" (groups=["system:serviceaccounts" "system:serviceaccounts:security-system" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["clusterrolebindings"], Verbs:["get" "list" "watch"]}
{APIGroups:[""], Resources:["clusterroles"], Verbs:["get" "list" "watch"]}
{APIGroups:[""], Resources:["clusterversions"], Verbs:["get" "list" "watch"]}
{APIGroups:[""], Resources:["controllerrevisions"], Verbs:["get" "list" "watch"]}
{APIGroups:[""], Resources:["cronjobs"], Verbs:["get" "list" "watch" "get" "list" "watch"]}
{APIGroups:[""], Resources:["daemonsets"], Verbs:["get" "list" "watch" "get" "list" "watch"]}
{APIGroups:[""], Resources:["deployments"], Verbs:["get" "list" "watch" "get" "list" "watch"]}
{APIGroups:[""], Resources:["horizontalpodautoscalers"], Verbs:["get" "list" "watch"]}
{APIGroups:[""], Resources:["ingressclasses"], Verbs:["get" "list" "watch"]}
{APIGroups:[""], Resources:["ingresses"], Verbs:["get" "list" "watch"]}
{APIGroups:[""], Resources:["jobs"], Verbs:["get" "list" "watch" "get" "list" "watch"]}
{APIGroups:[""], Resources:["networkpolicies"], Verbs:["get" "list" "watch"]}
{APIGroups:[""], Resources:["pods"], Verbs:["delete"]}
{APIGroups:[""], Resources:["podsecuritypolicies"], Verbs:["get" "list" "watch"]}
{APIGroups:[""], Resources:["replicasets"], Verbs:["get" "list" "watch" "get" "list" "watch"]}
{APIGroups:[""], Resources:["rolebindings"], Verbs:["get" "list" "watch"]}
{APIGroups:[""], Resources:["roles"], Verbs:["get" "list" "watch"]}
{APIGroups:[""], Resources:["secrets"], Verbs:["get" "list" "watch" "get" "list" "watch" "get" "get" "list" "watch"]}
{APIGroups:[""], Resources:["statefulsets"], Verbs:["get" "list" "watch" "get" "list" "watch"]}
{APIGroups:[""], Resources:["storageclasses"], Verbs:["get" "list" "watch"]}
{APIGroups:[""], Resources:["volumeattachments"], Verbs:["get" "list" "watch"]}
...many more
```

This appears to be because the ClusterRoles are misconfigured to reference lots of permissions that do not actually exist.

This PR cleans those up by using the correct api groups to reference them.

In addition it removes some "*" grants, as per least-privilege best practice.

## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
