### PR TITLE
fix(shield): correct RBAC apiGroups and replace wildcard verbs

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.34.1
+version: 1.34.2
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/clusterrole.yaml
+++ b/charts/shield/templates/cluster/clusterrole.yaml
@@ -38,20 +38,42 @@ rules:
 {{- if (include "cluster.container_vulnerability_management_enabled" .) }}
 - apiGroups:
     - ""
-    - apps
-    - batch
-    - extensions
   resources:
-    - cronjobs
-    - daemonsets
-    - deployments
-    - jobs
     - namespaces
     - nodes
     - pods
-    - replicasets
     - replicationcontrollers
     - secrets
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - daemonsets
+    - deployments
+    - replicasets
+    - statefulsets
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - cronjobs
+    - jobs
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - daemonsets
+    - deployments
+    - replicasets
     - statefulsets
   verbs:
     - get

--- a/charts/shield/templates/cluster/clusterrole.yaml
+++ b/charts/shield/templates/cluster/clusterrole.yaml
@@ -83,49 +83,108 @@ rules:
 {{- if (include "cluster.posture_enabled" .) }}
 - apiGroups:
     - ""
-    - rbac.authorization.k8s.io
-    - extensions
-    - apps
-    - batch
-    - networking.k8s.io
-    - autoscaling
-    - policy
-    - storage.k8s.io
-    - config.openshift.io
   resources:
+    - configmaps
+    - events
+    - limitranges
+    - namespaces
+    - nodes
+    - persistentvolumeclaims
+    - persistentvolumes
     - pods
     - pods/log
-    - namespaces
-    - deployments
+    - replicationcontrollers
+    - resourcequotas
+    - secrets
+    - serviceaccounts
+    - services
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - controllerrevisions
     - daemonsets
+    - deployments
+    - replicasets
     - statefulsets
-    - jobs
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - batch
+  resources:
     - cronjobs
+    - jobs
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - config.openshift.io
+  resources:
+    - clusterversions
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - daemonsets
+    - deployments
+    - ingresses
+    - replicasets
+    - statefulsets
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - networking.k8s.io
+  resources:
+    - ingresses
+    - ingressclasses
+    - networkpolicies
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - podsecuritypolicies
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
     - clusterroles
     - clusterrolebindings
     - roles
     - rolebindings
-    - services
-    - serviceaccounts
-    - nodes
-    - ingresses
-    - ingressclasses
-    - networkpolicies
-    - replicasets
-    - configmaps
-    - events
-    - limitranges
-    - persistentvolumes
-    - persistentvolumeclaims
-    - replicationcontrollers
-    - resourcequotas
-    - controllerrevisions
-    - horizontalpodautoscalers
-    - podsecuritypolicies
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - storage.k8s.io
+  resources:
     - storageclasses
     - volumeattachments
-    - clusterversions
-    - secrets
   verbs:
     - get
     - list

--- a/charts/shield/templates/cluster/role.yaml
+++ b/charts/shield/templates/cluster/role.yaml
@@ -12,39 +12,63 @@ metadata:
   {{- end }}
 rules:
 {{- if (and (include "cluster.posture_enabled" .) (include "cluster.need_posture_lease" .) .) }}
-  - apiGroups: ["", "coordination.k8s.io"]
+  - apiGroups: ["coordination.k8s.io"]
     resources:
       - "leases"
     resourceNames:
       - {{ include "cluster.posture_lease_name" . }}
-    verbs: ["*"]
-  - apiGroups: ["", "coordination.k8s.io"]
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups: ["coordination.k8s.io"]
     resources:
       - "leases"
     verbs: ["create"]
 {{- end }}
 {{- if (include "cluster.container_vulnerability_management_enabled" .) }}
-  - apiGroups: ["", "coordination.k8s.io"]
+  - apiGroups: ["coordination.k8s.io"]
     resources:
       - "leases"
     resourceNames:
       - {{ include "cluster.container_vulnerability_management_lease_name" . }}
-    verbs: ["*"]
-  - apiGroups: ["", "coordination.k8s.io"]
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups: ["coordination.k8s.io"]
     resources:
       - "leases"
     verbs: ["create"]
-  - apiGroups: ["*"]
+  - apiGroups: [""]
     resources:
       - "endpoints"
     verbs: ["get", "watch", "list"]
-  - apiGroups: ["*"]
+  - apiGroups: [""]
     resources:
       - "endpoints"
       # Following is required for OpenShift. See https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/pods_and_services.html#endpoints
       - "endpoints/restricted"
     resourceNames:
       - {{ include "cluster.container_vulnerability_management_service_name" . }}
-    verbs: ["*"]
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
   {{- end }}
 {{- end }}

--- a/charts/shield/tests/cluster/clusterrole_test.yaml
+++ b/charts/shield/tests/cluster/clusterrole_test.yaml
@@ -200,20 +200,51 @@ tests:
           content:
             apiGroups:
               - ""
-              - apps
-              - batch
-              - extensions
             resources:
-              - cronjobs
-              - daemonsets
-              - deployments
-              - jobs
               - namespaces
               - nodes
               - pods
-              - replicasets
               - replicationcontrollers
               - secrets
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps
+            resources:
+              - daemonsets
+              - deployments
+              - replicasets
+              - statefulsets
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - batch
+            resources:
+              - cronjobs
+              - jobs
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+            resources:
+              - daemonsets
+              - deployments
+              - replicasets
               - statefulsets
             verbs:
               - get
@@ -260,49 +291,135 @@ tests:
           content:
             apiGroups:
               - ""
-              - rbac.authorization.k8s.io
-              - extensions
-              - apps
-              - batch
-              - networking.k8s.io
-              - autoscaling
-              - policy
-              - storage.k8s.io
-              - config.openshift.io
             resources:
+              - configmaps
+              - events
+              - limitranges
+              - namespaces
+              - nodes
+              - persistentvolumeclaims
+              - persistentvolumes
               - pods
               - pods/log
-              - namespaces
-              - deployments
+              - replicationcontrollers
+              - resourcequotas
+              - secrets
+              - serviceaccounts
+              - services
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps
+            resources:
+              - controllerrevisions
               - daemonsets
+              - deployments
+              - replicasets
               - statefulsets
-              - jobs
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - autoscaling
+            resources:
+              - horizontalpodautoscalers
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - batch
+            resources:
               - cronjobs
+              - jobs
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - config.openshift.io
+            resources:
+              - clusterversions
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+            resources:
+              - daemonsets
+              - deployments
+              - ingresses
+              - replicasets
+              - statefulsets
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - networking.k8s.io
+            resources:
+              - ingresses
+              - ingressclasses
+              - networkpolicies
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - policy
+            resources:
+              - podsecuritypolicies
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - rbac.authorization.k8s.io
+            resources:
               - clusterroles
               - clusterrolebindings
               - roles
               - rolebindings
-              - services
-              - serviceaccounts
-              - nodes
-              - ingresses
-              - ingressclasses
-              - networkpolicies
-              - replicasets
-              - configmaps
-              - events
-              - limitranges
-              - persistentvolumes
-              - persistentvolumeclaims
-              - replicationcontrollers
-              - resourcequotas
-              - controllerrevisions
-              - horizontalpodautoscalers
-              - podsecuritypolicies
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - storage.k8s.io
+            resources:
               - storageclasses
               - volumeattachments
-              - clusterversions
-              - secrets
             verbs:
               - get
               - list
@@ -325,20 +442,51 @@ tests:
           content:
             apiGroups:
               - ""
-              - apps
-              - batch
-              - extensions
             resources:
-              - cronjobs
-              - daemonsets
-              - deployments
-              - jobs
               - namespaces
               - nodes
               - pods
-              - replicasets
               - replicationcontrollers
               - secrets
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps
+            resources:
+              - daemonsets
+              - deployments
+              - replicasets
+              - statefulsets
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - batch
+            resources:
+              - cronjobs
+              - jobs
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+            resources:
+              - daemonsets
+              - deployments
+              - replicasets
               - statefulsets
             verbs:
               - get

--- a/charts/shield/tests/cluster/role_test.yaml
+++ b/charts/shield/tests/cluster/role_test.yaml
@@ -33,17 +33,25 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["", "coordination.k8s.io"]
+            apiGroups: ["coordination.k8s.io"]
             resources:
               - "leases"
             resourceNames:
               - "release-name-shield-cluster-container-vulnerability-management"
-            verbs: ["*"]
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
       - contains:
           path: rules
           content:
-            apiGroups: ["", "coordination.k8s.io"]
+            apiGroups: ["coordination.k8s.io"]
             resources:
               - "leases"
             verbs: ["create"]
@@ -51,7 +59,7 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["*"]
+            apiGroups: [""]
             resources:
               - "endpoints"
             verbs: ["get", "watch", "list"]
@@ -59,13 +67,21 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["*"]
+            apiGroups: [""]
             resources:
               - "endpoints"
               - "endpoints/restricted"
             resourceNames:
               - "release-name-shield-cluster-container-vm"
-            verbs: ["*"]
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
   - it: Admission Control withContainer Vulnerability Management
     set:
@@ -83,17 +99,25 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["", "coordination.k8s.io"]
+            apiGroups: ["coordination.k8s.io"]
             resources:
               - "leases"
             resourceNames:
               - "release-name-shield-cluster-container-vulnerability-management"
-            verbs: ["*"]
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
       - contains:
           path: rules
           content:
-            apiGroups: ["", "coordination.k8s.io"]
+            apiGroups: ["coordination.k8s.io"]
             resources:
               - "leases"
             verbs: ["create"]
@@ -101,7 +125,7 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["*"]
+            apiGroups: [""]
             resources:
               - "endpoints"
             verbs: ["get", "watch", "list"]
@@ -109,13 +133,21 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["*"]
+            apiGroups: [""]
             resources:
               - "endpoints"
               - "endpoints/restricted"
             resourceNames:
               - "release-name-shield-cluster-container-vm"
-            verbs: ["*"]
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
   - it: Posture
     set:
@@ -132,17 +164,25 @@ tests:
       - contains:
           path: rules
           content:
-            apiGroups: ["", "coordination.k8s.io"]
+            apiGroups: ["coordination.k8s.io"]
             resources:
               - "leases"
             resourceNames:
               - "release-name-shield-cluster-posture"
-            verbs: ["*"]
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
       - contains:
           path: rules
           content:
-            apiGroups: ["", "coordination.k8s.io"]
+            apiGroups: ["coordination.k8s.io"]
             resources:
               - "leases"
             verbs: ["create"]


### PR DESCRIPTION
## Summary

  Fixes incorrect RBAC apiGroup-to-resource mappings in the cluster ClusterRole and Role templates. Resources like `daemonsets`, `deployments`, `cronjobs`, etc. were listed under the wrong apiGroups (e.g. core `""` instead of `apps`, `batch`), causing Kubernetes to silently create rules for non-existent resources. This breaks deployments using [RBAC privilege escalation prevention](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping) (e.g. ArgoCD Service Account Impersonation).

  ### Changes

  - **Split CVM clusterrole rules** into per-apiGroup blocks with correct resource mappings
  - **Split posture clusterrole rules** (10 apiGroups, ~30 resources) into 10 per-apiGroup blocks
  - **Fix Role apiGroups**: remove `""` from lease rules (leases only exist in `coordination.k8s.io`), replace `apiGroups: ["*"]` with `[""]` for endpoints
  - **Replace wildcard verbs**: `["*"]` → explicit verb lists for least-privilege compliance
  - **Update all RBAC tests** to match the new rule structure

From #2571 same fix, split into granular commits for easier review.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
