### PR TITLE
fix(shield): allowHostPorts when promex is enabled

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.34.2
+version: 1.34.3
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/openshift-securitycontextconstraint.yaml
+++ b/charts/shield/templates/host/openshift-securitycontextconstraint.yaml
@@ -12,7 +12,7 @@ allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: true
 allowHostPID: true
-allowHostPorts: {{ or .Values.features.posture.host_posture.enabled (dig "kspm_analyzer" "enabled" false .Values.host.additional_settings) }}
+allowHostPorts: {{ or .Values.features.posture.host_posture.enabled (dig "prometheus_exporter" "enabled" false .Values.host.additional_settings) (dig "kspm_analyzer" "enabled" false .Values.host.additional_settings) }}
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 {{- if .Values.host.privileged }}

--- a/charts/shield/tests/host/openshift-securitycontextconstraint_test.yaml
+++ b/charts/shield/tests/host/openshift-securitycontextconstraint_test.yaml
@@ -102,7 +102,21 @@ tests:
           path: allowHostPorts
           value: true
 
-  - it: SecurityContextConstraints allowHostPorts is false when features.posture.host_posture.enabled and host.additional_settings.kspm_analyzer.enabled are false
+  - it: SecurityContextConstraints allowHostPorts is true when host.additional_settings.prometheus_exporter.enabled is true
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1
+    set:
+      host:
+        additional_settings:
+          prometheus_exporter:
+            enabled: true
+    asserts:
+      - equal:
+          path: allowHostPorts
+          value: true
+
+  - it: SecurityContextConstraints allowHostPorts is false when features.posture.host_posture.enabled, host.additional_settings.kspm_analyzer.enabled and host.additional_settings.prometheus_exporter.enabled are false
     capabilities:
       apiVersions:
         - security.openshift.io/v1
@@ -114,6 +128,8 @@ tests:
       host:
         additional_settings:
           kspm_analyzer:
+            enabled: false
+          prometheus_exporter:
             enabled: false
     asserts:
       - equal:


### PR DESCRIPTION
## What this PR does / why we need it:
The OpenShift SecurityContextConstraints for the shield host component was not accounting for the prometheus_exporter when determining whether host ports should be allowed. If prometheus_exporter was the only host feature requiring a port (i.e. host_posture and kspm_analyzer were both disabled), the SCC would not grant allowHostPorts, causing the pod to fail on OpenShift.

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
