### PR TITLE
chore(shield): add tests to verify that cluster.validatingwebhookconfiguration.create works as expected

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.34.4
+version: 1.34.5
 appVersion: "1.0.0"

--- a/charts/shield/tests/cluster/tls-certificates-admissionregistration_test.yaml
+++ b/charts/shield/tests/cluster/tls-certificates-admissionregistration_test.yaml
@@ -827,3 +827,61 @@ tests:
       - notExists:
           path: .webhooks[0].clientConfig.caBundle
         template: templates/cluster/tls-certificates-admissionregistration.yaml
+
+  - it: Admission Control AdmissionRegistration (Webhook creation disabled)
+    set:
+      cluster:
+        validatingwebhookconfiguration:
+          create: false
+      features:
+        admission_control:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+          name: shield-release-cluster-tls-certificates
+          namespace: shield-namespace
+        documentIndex: 0
+
+  - it: Audit AdmissionRegistration (Webhook creation disabled)
+    set:
+      cluster:
+        validatingwebhookconfiguration:
+          create: false
+      features:
+        detections:
+          kubernetes_audit:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+          name: shield-release-cluster-tls-certificates
+          namespace: shield-namespace
+        documentIndex: 0
+
+  - it: Admission Control and Audit AdmissionRegistration (Webhook creation disabled)
+    set:
+      cluster:
+        validatingwebhookconfiguration:
+          create: false
+      features:
+        admission_control:
+          enabled: true
+        detections:
+          kubernetes_audit:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+          name: shield-release-cluster-tls-certificates
+          namespace: shield-namespace
+        documentIndex: 0


### PR DESCRIPTION
## What this PR does / why we need it:

SSIA

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
