### PR TITLE
fix(shield): add startupProbe to cluster-shield deployment

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.34.5
+version: 1.34.6
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/deployment.yaml
+++ b/charts/shield/templates/cluster/deployment.yaml
@@ -132,6 +132,13 @@ spec:
             {{- include "cluster.env" . | nindent 12 }}
           resources:
             {{- toYaml .Values.cluster.resources | nindent 12 }}
+          {{- if .Values.cluster.probes.startup }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.cluster.additional_settings.monitoring_port }}
+            {{- .Values.cluster.probes.startup | toYaml | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/shield/tests/cluster/deployment_test.yaml
+++ b/charts/shield/tests/cluster/deployment_test.yaml
@@ -256,6 +256,52 @@ tests:
             periodSeconds: 5
     template: templates/cluster/deployment.yaml
 
+  - it: Default startup probe
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].startupProbe
+          value:
+            httpGet:
+              path: /healthz
+              port: 8080
+            failureThreshold: 30
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+    template: templates/cluster/deployment.yaml
+
+  - it: Custom startup probe
+    set:
+      cluster:
+        probes:
+          startup:
+            failureThreshold: 5
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            timeoutSeconds: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].startupProbe
+          value:
+            httpGet:
+              path: /healthz
+              port: 8080
+            failureThreshold: 5
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            timeoutSeconds: 1
+    template: templates/cluster/deployment.yaml
+
+  - it: Disabled startup probe
+    set:
+      cluster:
+        probes:
+          startup: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].startupProbe
+    template: templates/cluster/deployment.yaml
+
   - it: Custom readiness probe
     set:
       cluster:

--- a/charts/shield/values.yaml
+++ b/charts/shield/values.yaml
@@ -537,6 +537,18 @@ cluster:
       periodSeconds: 5
       # The readiness probe failure threshold
       failureThreshold: 9
+    startup:
+      # The startup probe initial delay
+      initialDelaySeconds: 15
+      # The startup probe period
+      periodSeconds: 10
+      # The startup probe failure threshold. Combined with periodSeconds, it gives
+      # the container ~5 minutes to finish warmup before liveness takes over. This
+      # protects slow-booting clusters (e.g. GKE Windows) from being killed by the
+      # liveness probe during initial health-check warmup.
+      failureThreshold: 30
+      # The startup probe timeout
+      timeoutSeconds: 3
   # The number of replicas for the cluster shield
   replica_count: 2
   update_strategy:


### PR DESCRIPTION
### Description

Cluster-shield currently has only a liveness probe with a ~50s budget (`initialDelaySeconds=5, periodSeconds=5, failureThreshold=9`). On slow or noisy clusters the `/healthz` endpoint can take longer than 50s to become responsive during CVM warmup, causing the kubelet to kill the container with exit code 1067 and restart it.

This PR adds a `startupProbe` with a ~5 minute budget so the liveness probe is suspended during warmup and only takes over once the container has reported healthy at least once. Steady-state liveness/readiness behaviour is unchanged.

### Motivation

Observed on QA build Kubelet events from the failing pod:

```
Warning Unhealthy  Liveness probe failed: Get ".../healthz": context deadline exceeded
Warning Unhealthy  Readiness probe failed: Get ".../healthz": context deadline exceeded
Warning Unhealthy  Liveness probe failed: HTTP probe failed with statuscode: 500
Normal  Killing    Container cluster-shield failed liveness probe, will be restarted
```

Pod `lastState.terminated.exitCode: 1067`, reason `Error`. The pod recovers on restart — this is startup latency, not a steady-state bug.

### What changed
- **`charts/shield/values.yaml`**: new `cluster.probes.startup` section with default budget of ~5 min (`initialDelay=15, period=10, failureThreshold=30, timeout=3`).
- **`charts/shield/templates/cluster/deployment.yaml`**: render `startupProbe` before `livenessProbe` when `cluster.probes.startup` is set. The `if` guard lets users disable the startup probe by setting `cluster.probes.startup: null`.
- **`charts/shield/tests/cluster/deployment_test.yaml`**: three new cases — default startup probe, custom overrides, and explicit disable.
- **`charts/shield/Chart.yaml`**: bump `1.34.5 → 1.34.6`.

### Test plan
- [x] `helm unittest charts/shield` → 79/79 pass locally
- [x] `helm lint charts/shield -f charts/shield/ci/test-values.yaml` clean
- [x] `helm template ... -f ci/test-values.yaml` renders the expected `startupProbe` block
- [ ] After merge: rerun `qa/QA-shield/cluster/gke-windows-2019-x86_64` to confirm no cluster-shield restarts

### Notes / Trade-offs
- Chose a long startup budget (5 min) because the GKE Windows reproducer takes ~80s between container start and `/healthz` stability; a shorter budget would still risk flakes on noisy clusters.
- Opt-out via `cluster.probes.startup: null` preserves the current behaviour for users who want to override it.
- Alternative fix would be to bump `failureThreshold`/`initialDelaySeconds` on the liveness probe itself, but that weakens steady-state liveness semantics. A dedicated startupProbe is the minimal-blast-radius option.

### Related
- QA-reported failure: `test_cluster_shield_pods_no_restarts`
- Product investigation Jira: _will link after ticket is filed_