### PR TITLE
cluster-shield Windows exit 1067 — add startupProbe to prevent liveness kill on slow Windows startup

### DIFF
--- a/charts/shield/templates/cluster/deployment.yaml
+++ b/charts/shield/templates/cluster/deployment.yaml
@@ -132,6 +132,13 @@ spec:
             {{- include "cluster.env" . | nindent 12 }}
           resources:
             {{- toYaml .Values.cluster.resources | nindent 12 }}
+          {{- if .Values.cluster.probes.startup }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.cluster.additional_settings.monitoring_port }}
+            {{- .Values.cluster.probes.startup | toYaml | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/shield/values.yaml
+++ b/charts/shield/values.yaml
@@ -523,6 +523,15 @@ cluster:
   # Automatically adds the Prometheus annotations to the Cluster Shield pods
   enable_prometheus_scraping: true
   probes:
+    startup:
+      # The startup probe period — gives the container time to initialize before
+      # liveness/readiness checks begin. Required on slow-starting platforms such as
+      # Windows Server 2019 where cluster-shield needs ~90 s to reach /healthz.
+      # failureThreshold * periodSeconds defines the maximum startup budget (default
+      # 18 * 10s = 180 s).  Set to null/empty to disable the startup probe.
+      periodSeconds: 10
+      # The startup probe failure threshold
+      failureThreshold: 18
     readiness:
       # The readiness probe initial delay
       initialDelaySeconds: 10


### PR DESCRIPTION
## Summary

- **Root cause**: cluster-shield pod `shield-cluster-79b776546f-kjzdp` on GKE Windows 2019 crashed with exit code 1067 (Windows: process terminated unexpectedly) because the Kubernetes liveness probe killed it before it could initialize. The liveness probe's grace window (initialDelaySeconds=5 + failureThreshold=9 × periodSeconds=5 = **50 s total**) is too short for Windows 2019, where cluster-shield needs ~90 s to reach `/healthz`.
- **Bisect**:  used helm branch `fix/shield-cluster-startupProbe` and cluster-shield `1.22.0`. Failing builds #115 and #116 switched back to `helm:main` with `cs:latest` / `cs:dev`, which lack the startup probe.
- **Fix**: Add an optional `startupProbe` to the cluster-shield Deployment template. The probe defaults to `failureThreshold=18, periodSeconds=10` giving a **180 s startup budget** before liveness/readiness checks activate. This is the same approach used in the now-deleted `fix/shield-cluster-startupProbe` branch.

## Changes

- `charts/shield/templates/cluster/deployment.yaml`: render `startupProbe` block when `cluster.probes.startup` is set (guarded by `{{- if .Values.cluster.probes.startup }}`)
- `charts/shield/values.yaml`: add `cluster.probes.startup` defaults (`periodSeconds: 10`, `failureThreshold: 18`)

## Test plan

- [ ] Deploy shield chart to a GKE Windows 2019 cluster and verify `test_cluster_shield_pods_no_restarts` passes
- [ ] Verify liveness/readiness probes still activate after startup completes (no regression on Linux clusters)
- [ ] Run `helm template` and confirm `startupProbe` appears in rendered YAML
- [ ] Verify setting `cluster.probes.startup: null` in values disables the startup probe (backward compat)

