### PR TITLE
fix(shield): wrap response_actions rules in cluster.rbac.create guard

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.36.0
+version: 1.36.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/clusterrole.yaml
+++ b/charts/shield/templates/cluster/clusterrole.yaml
@@ -308,7 +308,6 @@ rules:
     - list
     - watch
 {{- end }}
-{{- end }}
 
 {{- if eq "true" (include "cluster.response_actions_enabled" .) }}
 - apiGroups:
@@ -454,4 +453,5 @@ rules:
     - get
     - watch
     - patch # needed to remove finalizers, which could prevent deletion
+{{- end }}
 {{- end }}

--- a/charts/shield/tests/cluster/clusterrole_test.yaml
+++ b/charts/shield/tests/cluster/clusterrole_test.yaml
@@ -680,6 +680,19 @@ tests:
               - list
               - watch
 
+  - it: No ClusterRole rendered when cluster.rbac.create is false
+    set:
+      cluster:
+        rbac:
+          create: false
+      features:
+        respond:
+          response_actions:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: Test response_actions enabled
     set:
       features:


### PR DESCRIPTION
The outer `{{- if .Values.cluster.rbac.create }}` in templates/cluster/clusterrole.yaml closed before the seven response_actions.* rule blocks, so disabling RBAC creation while any response action was enabled left orphaned `- apiGroups:` sequences. Helm then aborted with `cannot unmarshal !!seq into releaseutil.SimpleHead`.

Move the closing `{{- end }}` to the end of the file (matching the pattern in templates/host/clusterrole.yaml) so the entire ClusterRole, including response_actions rules, is suppressed when cluster.rbac.create is false.

Adds a regression unittest and bumps the chart to 1.36.1.

Refs sysdiglabs/charts#2603

## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
