### PR TITLE
fix(shield): correct response_actions ClusterRole RBAC scoping

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.36.0
+version: 1.36.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/_config.tpl
+++ b/charts/shield/templates/cluster/_config.tpl
@@ -224,21 +224,28 @@
 {{- end }}
 
 {{/*
-Generic helper: checks if .Values.features.respond.response_actions.<action>.trigger == "all"
+Generic helper: returns "true" when the response_actions feature is enabled at
+the master level (.Values.features.respond.response_actions.enabled) AND the
+specific per-action trigger is not explicitly set to "none". Returns "false"
+otherwise.
 Usage: {{ include "cluster.response_actions.is_enabled" (dict "Action" "delete_pod" "Context" .) }}
 */}}
 {{- define "cluster.response_actions.is_enabled" -}}
     {{- $action := .Action }}
     {{- $ctx := .Context }}
-    {{- with $ctx.Values.features.respond.response_actions -}}
-        {{- $entry := index . $action }}
-        {{- if and $entry (eq $entry.trigger "none") -}}
-            false
+    {{- if eq "true" (include "cluster.response_actions_enabled" $ctx) -}}
+        {{- with $ctx.Values.features.respond.response_actions -}}
+            {{- $entry := index . $action }}
+            {{- if and $entry (eq $entry.trigger "none") -}}
+                false
+            {{- else -}}
+                true
+            {{- end -}}
         {{- else -}}
             true
         {{- end -}}
     {{- else -}}
-        true
+        false
     {{- end -}}
 {{- end -}}
 

--- a/charts/shield/templates/cluster/clusterrole.yaml
+++ b/charts/shield/templates/cluster/clusterrole.yaml
@@ -308,7 +308,6 @@ rules:
     - list
     - watch
 {{- end }}
-{{- end }}
 
 {{- if eq "true" (include "cluster.response_actions_enabled" .) }}
 - apiGroups:
@@ -454,4 +453,5 @@ rules:
     - get
     - watch
     - patch # needed to remove finalizers, which could prevent deletion
+{{- end }}
 {{- end }}

--- a/charts/shield/tests/cluster/clusterrole_test.yaml
+++ b/charts/shield/tests/cluster/clusterrole_test.yaml
@@ -837,3 +837,97 @@ tests:
             verbs:
               - create
               - patch
+
+  - it: response_actions disabled by default does not leak per-action RBAC
+    asserts:
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: release-name-shield-cluster
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - pods
+            verbs:
+              - delete
+              - get
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - networking.k8s.io
+            resources:
+              - networkpolicies
+            verbs:
+              - get
+              - delete
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - snapshot.storage.k8s.io
+            resources:
+              - volumesnapshots
+            verbs:
+              - delete
+              - get
+              - watch
+              - patch
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - pods/log
+            verbs:
+              - get
+
+  - it: response_actions enabled with delete_pod trigger none suppresses only delete_pod rule
+    set:
+      features:
+        respond:
+          response_actions:
+            enabled: true
+            delete_pod:
+              trigger: none
+    asserts:
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: release-name-shield-cluster
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - pods
+            verbs:
+              - delete
+              - get
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - networking.k8s.io
+            resources:
+              - networkpolicies
+            verbs:
+              - get
+              - delete
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - snapshot.storage.k8s.io
+            resources:
+              - volumesnapshots
+            verbs:
+              - delete
+              - get
+              - watch
+              - patch

--- a/charts/shield/tests/cluster/clusterrole_test.yaml
+++ b/charts/shield/tests/cluster/clusterrole_test.yaml
@@ -886,6 +886,28 @@ tests:
             verbs:
               - get
 
+  - it: cluster.rbac.create false renders no ClusterRole
+    set:
+      cluster:
+        rbac:
+          create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: cluster.rbac.create false with response_actions enabled still renders no ClusterRole
+    set:
+      cluster:
+        rbac:
+          create: false
+      features:
+        respond:
+          response_actions:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: response_actions enabled with delete_pod trigger none suppresses only delete_pod rule
     set:
       features:


### PR DESCRIPTION
## Summary

Fixes two related defects in the cluster-shield ClusterRole template that caused `response_actions` RBAC to render incorrectly.

### Bug 1 — per-action gates ignored the master `enabled` flag

`cluster.response_actions.<action>.is_enabled` (in `templates/cluster/_config.tpl`) only short-circuited when an individual action's `trigger` was explicitly `"none"` — it never consulted `features.respond.response_actions.enabled`. With chart defaults (master flag `false`), every per-action gate still resolved to `"true"` and the cluster-shield ClusterRole was granted `delete` on `pods`, `networkpolicies`, and `volumesnapshots`, plus the `isolate_network` / `rollout_restart` / `get_logs` / `volume_snapshot` rules. Real least-privilege violation.

### Bug 2 — response_actions blocks rendered outside the `cluster.rbac.create` wrapper

The seven `response_actions.*` rule blocks in `templates/cluster/clusterrole.yaml` lived **outside** the outer `{{- if .Values.cluster.rbac.create }} ... {{- end }}` guard. With `cluster.rbac.create: false`, the document head (`apiVersion / kind / metadata / rules:`) was correctly suppressed but the per-action rule snippets still rendered, producing a top-level YAML array that Helm could not parse:

```
Error: YAML parse error on shield/templates/cluster/clusterrole.yaml:
error unmarshaling JSON: while decoding JSON:
json: cannot unmarshal array into Go value of type util.SimpleHead
```

Reported by @EdwardArchive in #2603.

## Fix

- `templates/cluster/_config.tpl`: `is_enabled` returns `false` early when the master `features.respond.response_actions.enabled` flag is falsy. Per-action `trigger: "none"` overrides remain effective when the master flag is on.
- `templates/cluster/clusterrole.yaml`: moved the `{{- end }}` of the `cluster.rbac.create` wrapper past the seven `response_actions.*` blocks so they live inside it (matching the working pattern in `templates/host/clusterrole.yaml`).
- `Chart.yaml`: bumped to `1.36.1`.

## Behavior matrix

| `response_actions.enabled` | `<action>.trigger` | Before | After |
|---|---|---|---|
| `false` (default) | unset | rules **leaked** into ClusterRole | rules absent |
| `false` | `"none"` | rules absent | rules absent |
| `true` | unset | rules present | rules present |
| `true` | `"none"` | rules absent | rules absent |

| `cluster.rbac.create` | `response_actions.enabled` | Before | After |
|---|---|---|---|
| `true` (default) | any | renders ClusterRole | renders ClusterRole |
| `false` | `false` (default) | **`helm template` error** | renders no document |
| `false` | `true` | **`helm template` error** | renders no document |

## Tests

`charts/shield/tests/cluster/clusterrole_test.yaml`:

- **`response_actions disabled by default does not leak per-action RBAC`** — asserts `pods: delete,get`, `networkpolicies: get,delete`, `volumesnapshots: delete,get,watch,patch`, and `pods/log: get` are absent under chart defaults.
- **`cluster.rbac.create false renders no ClusterRole`** — `hasDocuments: count: 0`.
- **`cluster.rbac.create false with response_actions enabled still renders no ClusterRole`** — covers the original failure mode from #2603.
- **`response_actions enabled with delete_pod trigger none suppresses only delete_pod rule`** — verifies fine-grained per-action overrides still work.

`helm unittest --strict -f "tests/**/*_test.yaml" charts/shield`: **463 / 463 pass** (459 baseline + 4 new).

## Test plan

- [x] `helm unittest` passes (463/463)
- [x] `helm template` with `cluster.rbac.create: false` no longer errors
- [x] Default render (no overrides) emits no response-action rules in cluster-shield ClusterRole
- [x] `features.respond.response_actions.enabled: true` still emits all per-action rules
- [x] `enabled: true` + per-action `trigger: "none"` suppresses only that rule
- [ ] CI lint + helm-unit-test workflows

Closes #2603