### PR TITLE
fix(shield): support digest pinning for allowlist waiter image

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.37.0
+version: 1.37.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_helpers.tpl
+++ b/charts/shield/templates/host/_helpers.tpl
@@ -341,6 +341,14 @@ true
 {{- default (include "host.allowlist_waiter.fullname" .) .Values.gke_autopilot.allowlist_waiter.service_account_name }}
 {{- end }}
 
+{{- define "host.allowlist_waiter.tag_separator" -}}
+  {{- if (hasPrefix "sha256:" .Values.gke_autopilot.allowlist_waiter.image.tag) -}}
+    @
+  {{- else -}}
+    :
+  {{- end -}}
+{{- end }}
+
 {{- define "host.allowlist_waiter.image" -}}
-{{- .Values.gke_autopilot.allowlist_waiter.image.registry -}} / {{- .Values.gke_autopilot.allowlist_waiter.image.repository -}} : {{- .Values.gke_autopilot.allowlist_waiter.image.tag }}
+{{- .Values.gke_autopilot.allowlist_waiter.image.registry -}} / {{- .Values.gke_autopilot.allowlist_waiter.image.repository -}} {{- include "host.allowlist_waiter.tag_separator" . -}} {{- .Values.gke_autopilot.allowlist_waiter.image.tag }}
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:

The allowlist waiter image helper hardcoded a `:` separator between repository and tag, so pinning the waiter image by digest produced an invalid reference like `quay.io/sysdig/kubectl:sha256:...`.

This PR mirrors the existing `host` / `cluster` / `host_windows` `tag_separator` pattern: when `gke_autopilot.allowlist_waiter.image.tag` starts with `sha256:`, the helper emits `@` instead of `:`, producing a valid digest reference (`quay.io/sysdig/kubectl@sha256:...`). Regular tags continue to render with `:` and the default `values.yaml` is unchanged.

## Checklist

- [x] Title of the PR starts with type and scope
- [x] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (no new variables)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix (no new tests in this PR)