### PR TITLE
fix(agent): support memdump and network_topology in secure light mode

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 2.8.1
+version: 2.8.2

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -480,23 +480,12 @@ agent config to prevent a backend push from enabling them after installation.
         {{- end }}
     {{- else if (not $isAgent14OrAbove) }}
         {{ if and (include "agent.enableFalcoBaselineSecureLight" .) $secureLightMode }}
-            {{- range $secureFeature := (list
-                "network_topology") }}
-                {{- $_ := set $secureConfig $secureFeature (dict "enabled" false) }}
-            {{- end }}
-            {{- if not (hasKey .Values.sysdig.settings "memdump") }}
-                {{- $_ := set $secureConfig "memdump" (dict "enabled" false) }}
-            {{- end }}
         {{ else if $secureLightMode }}
             {{- range $secureFeature := (list
                 "drift_control"
                 "drift_killer"
-                "falcobaseline"
-                "network_topology") }}
+                "falcobaseline") }}
                 {{- $_ := set $secureConfig $secureFeature (dict "enabled" false) }}
-            {{- end }}
-            {{- if not (hasKey .Values.sysdig.settings "memdump") }}
-                {{- $_ := set $secureConfig "memdump" (dict "enabled" false) }}
             {{- end }}
         {{- end }}
     {{- else if $secureLightMode }}

--- a/charts/agent/tests/secure_enable_test.yaml
+++ b/charts/agent/tests/secure_enable_test.yaml
@@ -200,12 +200,12 @@ tests:
           pattern: |-
             statsd:
               enabled: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |-
             memdump:
               enabled: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |-
             network_topology:

--- a/charts/agent/tests/secure_light_config_test.yaml
+++ b/charts/agent/tests/secure_light_config_test.yaml
@@ -29,12 +29,12 @@ tests:
           pattern: |-
             falcobaseline:
               enabled: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |-
             memdump:
               enabled: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |-
             network_topology:
@@ -68,12 +68,12 @@ tests:
           pattern: |-
             falcobaseline:
               enabled: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |-
             memdump:
               enabled: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |-
             network_topology:
@@ -107,12 +107,12 @@ tests:
           pattern: |-
             falcobaseline:
               enabled: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |-
             memdump:
               enabled: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |-
             network_topology:
@@ -146,12 +146,12 @@ tests:
           pattern: |-
             falcobaseline:
               enabled: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |-
             memdump:
               enabled: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |-
             network_topology:
@@ -185,12 +185,12 @@ tests:
           pattern: |-
             falcobaseline:
               enabled: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |-
             memdump:
               enabled: false
-      - matchRegex:
+      - notMatchRegex:
           path: data['dragent.yaml']
           pattern: |-
             network_topology:


### PR DESCRIPTION
Secure Light mode now supports `memdump` and `network_topology`. Both features were unavailable when Secure Light first shipped but have been added over time. The agent template still force-disabled them for `secure_light`, which prevented features that rely on memdump (such as policy-triggered captures) from working in this mode.

This stops force-disabling `memdump` and `network_topology` in `secure_light` mode. They now follow their normal defaults and can still be set explicitly via `sysdig.settings` (the existing memdump override behavior is unchanged).

The `secure_light` helm-unittest assertions were updated to match the new behavior, and the agent chart version was bumped. All `charts/agent` unit tests pass (342/342).
