### PR TITLE
feat(shield): add cluster.nats_password_existing_secret for external NATS password

### DIFF
--- a/charts/shield/templates/cluster/_helpers.tpl
+++ b/charts/shield/templates/cluster/_helpers.tpl
@@ -117,6 +117,7 @@ the inheritance logic lives in a single place.
     (include "common.credentials.access_key_secret_name" .)
     (include "common.credentials.secure_api_token_secret_name" .)
     (include "cluster.fullname" .)
+    .Values.cluster.nats_password_existing_secret
     (dig "cluster_scanner" "runtime_status_integrator" "nats_server" "password_existing_secret" nil .Values.cluster.additional_settings)
   -}}
   {{- (uniq (compact $secrets)) | toYaml -}}

--- a/charts/shield/templates/cluster/_secret.tpl
+++ b/charts/shield/templates/cluster/_secret.tpl
@@ -2,7 +2,7 @@
   {{- $secret := dict -}}
   {{- if (include "cluster.container_vulnerability_management_enabled" .) -}}
     {{- $natsConfig := dig "cluster_scanner" "runtime_status_integrator" "nats_server" nil .Values.cluster.additional_settings -}}
-    {{- if not (hasKey $natsConfig "password_existing_secret") -}}
+    {{- if not (or (hasKey $natsConfig "password_existing_secret") .Values.cluster.nats_password_existing_secret) -}}
       {{- $_ := set $secret "sysdig-cluster-nats-password" (default (randAlphaNum 32) (get $natsConfig "password")) -}}
     {{- end -}}
   {{- end -}}

--- a/charts/shield/tests/cluster/deployment_test.yaml
+++ b/charts/shield/tests/cluster/deployment_test.yaml
@@ -1042,6 +1042,28 @@ tests:
               mountPath: /etc/sysdig/secret-files/release-name-shield-cluster
     template: templates/cluster/deployment.yaml
 
+  - it: Existing NATS secret is mounted when nats_password_existing_secret is set
+    set:
+      cluster:
+        nats_password_existing_secret: existing-nats-password-secret
+      features:
+        vulnerability_management:
+          container_vulnerability_management:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secret-existing-nats-password-secret
+            secret:
+              secretName: existing-nats-password-secret
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].volumeMounts
+          content:
+            name: secret-existing-nats-password-secret
+            mountPath: /etc/sysdig/secret-files/existing-nats-password-secret
+    template: templates/cluster/deployment.yaml
+
   - it: Default Values (with both access key and secure api token)
     set:
       sysdig_endpoint:

--- a/charts/shield/tests/cluster/secret_test.yaml
+++ b/charts/shield/tests/cluster/secret_test.yaml
@@ -83,3 +83,40 @@ tests:
           name: release-name-shield-cluster
       - notExists:
           path: data.sysdig-cluster-nats-password
+
+  - it: Container Vulnerability Management Enabled (existing NATS secret provided via value)
+    set:
+      cluster:
+        nats_password_existing_secret: existing-nats-password-secret
+      features:
+        vulnerability_management:
+          container_vulnerability_management:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+          name: release-name-shield-cluster
+      - notExists:
+          path: data.sysdig-cluster-nats-password
+
+  - it: nats_password_existing_secret value takes precedence over additional_settings password
+    set:
+      cluster:
+        nats_password_existing_secret: existing-nats-password-secret
+        additional_settings:
+          cluster_scanner:
+            runtime_status_integrator:
+                nats_server:
+                  password: test-password
+      features:
+        vulnerability_management:
+          container_vulnerability_management:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: data.sysdig-cluster-nats-password

--- a/charts/shield/values.schema.json
+++ b/charts/shield/values.schema.json
@@ -328,6 +328,10 @@
     "Cluster": {
       "type": "object",
       "properties": {
+        "nats_password_existing_secret": {
+          "type": "string",
+          "description": "Name of an existing Secret containing the NATS password (key: sysdig-cluster-nats-password). When set, suppresses random password generation."
+        },
         "run_mode": {
           "type": "string",
           "description": "The mode in which the cluster is running",

--- a/charts/shield/values.yaml
+++ b/charts/shield/values.yaml
@@ -586,6 +586,10 @@ cluster:
       periodSeconds: 5
       # The readiness probe failure threshold
       failureThreshold: 9
+  # Name of an existing Secret containing the NATS password (key: sysdig-cluster-nats-password).
+  # When set, the chart uses this Secret instead of generating a random password - useful for
+  # GitOps workflows where helm template is pre-rendered and committed to Git.
+  nats_password_existing_secret: ""
   # The number of replicas for the cluster shield
   replica_count: 2
   update_strategy:


### PR DESCRIPTION
## What

New chart value `cluster.nats_password_existing_secret`. When set, Cluster
Shield uses the named Secret (key `sysdig-cluster-nats-password`) for the NATS
password instead of generating a random one, and mounts that Secret into the
container. Default `""` keeps the existing generate-a-random-password behaviour.

## Why

GitOps workflows that pre-render `helm template` and commit the manifests
(e.g. ArgoCD with raw manifests) get a new random password on every render,
which shows up as constant drift. An externally managed Secret keeps it stable.

## Backward compatibility

Purely additive. The default (`""`) is unchanged, so existing installs behave
exactly as before.

## Changes

- `values.yaml` / `values.schema.json` - new key, default `""`
- `templates/cluster/_secret.tpl` - skip generation when the value is set
- `templates/cluster/_helpers.tpl` - mount the named Secret when the value is set

## Testing

- `helm lint` clean
- Unset: cluster Secret has a generated password (unchanged)
- Value set: cluster Secret `data` is empty and the named Secret is mounted
- New unit tests added for the value and its mount; existing tests unchanged and green