### PR TITLE
feat(shield): gate nodes/proxy on live_logs in host ClusterRole

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.42.1
+version: 1.43.0
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/clusterrole.yaml
+++ b/charts/shield/templates/host/clusterrole.yaml
@@ -22,7 +22,6 @@ rules:
       - namespaces
       - nodes
       - nodes/metrics
-      - nodes/proxy
       - resourcequotas
       - persistentvolumes
       - persistentvolumeclaims
@@ -113,6 +112,16 @@ rules:
       - get
       - list
       - watch
+{{- if .Values.features.investigations.live_logs.enabled }}
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/proxy
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}
 {{- if or (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1/PodSecurityPolicy") (has "rbac.authorization.k8s.io/v1beta1/PodSecurityPolicy" .Values.extra_capabilities_api_versions) }}
 
   - apiGroups:

--- a/charts/shield/tests/host/clusterrole_test.yaml
+++ b/charts/shield/tests/host/clusterrole_test.yaml
@@ -266,6 +266,58 @@ tests:
             verbs:
               - list
 
+  - it: Default values do not grant nodes/proxy
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - nodes/proxy
+            verbs:
+              - get
+              - list
+              - watch
+
+  - it: live_logs enabled grants nodes/proxy
+    set:
+      features:
+        investigations:
+          live_logs:
+            enabled: true
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - nodes/proxy
+            verbs:
+              - get
+              - list
+              - watch
+
+  - it: live_logs disabled does not grant nodes/proxy
+    set:
+      features:
+        investigations:
+          live_logs:
+            enabled: false
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - nodes/proxy
+            verbs:
+              - get
+              - list
+              - watch
+
   - it: Propagates custom labels and annotations onto the ClusterRole
     set:
       host:


### PR DESCRIPTION
## What this PR does / why we need it

Removes the unconditional `nodes/proxy` grant from the host-shield ClusterRole — flagged as a Remote Code Execution vector by security scans because it proxies arbitrary requests to the kubelet API.

The permission is now feature-gated: it is only granted when `features.investigations.live_logs.enabled: true` (default `false`).

### Behaviour

| `features.investigations.live_logs.enabled` | `nodes/proxy` granted |
|---|---|
| `false` (default) | no |
| `true` | yes |

### Files changed

- `templates/host/clusterrole.yaml` — remove `nodes/proxy` from the base rule; add it back behind `live_logs.enabled`.
- `tests/host/clusterrole_test.yaml` — 3 new cases: default=no grant, live_logs=true=grant, live_logs=false=no grant.
- `Chart.yaml` — bump `1.42.1` → `1.43.0`.

## Test plan

- [x] `helm unittest -f 'tests/**/*_test.yaml' .` — 37/37 suites, 552/552 tests pass (3 new).
- [x] `helm template` with defaults → host ClusterRole has no `nodes/proxy`.
- [x] `helm template --set features.investigations.live_logs.enabled=true` → `nodes/proxy` present.

## Checklist

- [x] Title of the PR starts with type and scope (`feat(shield):`)
- [x] Chart version bumped (1.42.1 → 1.43.0)
- [x] All test files are added in the tests folder with a `_test` suffix

> Note: this is a reduced-scope follow-up to #2608. Version-aware K8s detection and `host.rbac.kubelet_authorization_mode` are deferred to a future PR once the live_logs refactor for `nodes/log` is complete.