### PR TITLE
fix(shield): remove nats passowrd configuration from the configmap if specified in additional_settings

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.43.1
+version: 1.43.2
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/_config.tpl
+++ b/charts/shield/templates/cluster/_config.tpl
@@ -79,13 +79,6 @@
     {{- end -}}
     {{- if (include "cluster.container_vulnerability_management_enabled" .) -}}
       {{- $clusterScannerConfig := dig "cluster_scanner" (dict) $config -}}
-      {{- $natsConfig := dig "cluster_scanner" "runtime_status_integrator" "nats_server" (dict) $clusterScannerConfig -}}
-      {{- if hasKey $natsConfig "password" -}}
-        {{- $_ := unset $clusterScannerConfig.runtime_status_integrator.nats_server "password" -}}
-      {{- end -}}
-      {{- if hasKey $natsConfig "password_existing_secret" -}}
-        {{- $_ := unset $clusterScannerConfig.runtime_status_integrator.nats_server "password_existing_secret" -}}
-      {{- end -}}
       {{- $iseConfig := dig "image_sbom_extractor" (dict) $clusterScannerConfig -}}
       {{- $_ := set $iseConfig "nats_url" (printf "nats://%s:4222" (include "cluster.container_vulnerability_management_service_name" .)) -}}
       {{- $_ := set $clusterScannerConfig "image_sbom_extractor" $iseConfig -}}
@@ -112,6 +105,12 @@
     {{- end -}}
     {{- $_ := set $config "ssl" (dict "verify" .Values.ssl.verify) -}}
     {{- $_ := mergeOverwrite $config .Values.cluster.additional_settings -}}
+    {{- if dig "cluster_scanner" "runtime_status_integrator" "nats_server" "password" nil $config -}}
+      {{- $_ := unset $config.cluster_scanner.runtime_status_integrator.nats_server "password" -}}
+    {{- end -}}
+    {{- if dig "cluster_scanner" "runtime_status_integrator" "nats_server" "password_existing_secret" nil $config -}}
+      {{- $_ := unset $config.cluster_scanner.runtime_status_integrator.nats_server "password_existing_secret" -}}
+    {{- end -}}
     {{- $config | toYaml -}}
 {{- end }}
 

--- a/charts/shield/tests/cluster/configmap_test.yaml
+++ b/charts/shield/tests/cluster/configmap_test.yaml
@@ -986,3 +986,57 @@ tests:
                   enabled: true
                   queue_length: 1000
                   timeout: 10
+
+  - it: NATS Existing Secret doesn't appear
+    set:
+      cluster:
+        additional_settings:
+          cluster_scanner:
+            runtime_status_integrator:
+              nats_server:
+                password_existing_secret: test-nats-password-secret
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+          name: release-name-shield-cluster
+      - equal:
+          path: metadata.namespace
+          value: shield-namespace
+      - exists:
+          path: data["cluster-shield.yaml"]
+      - matchRegex:
+          path: data['cluster-shield.yaml']
+          pattern: |
+            cluster_scanner:
+              runtime_status_integrator:
+                nats_server: {}
+
+  - it: NATS Password doesn't appear if specified
+    set:
+      cluster:
+        additional_settings:
+          cluster_scanner:
+            runtime_status_integrator:
+              nats_server:
+                password: test-nats-password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+          name: release-name-shield-cluster
+      - equal:
+          path: metadata.namespace
+          value: shield-namespace
+      - exists:
+          path: data["cluster-shield.yaml"]
+      - matchRegex:
+          path: data['cluster-shield.yaml']
+          pattern: |
+            cluster_scanner:
+              runtime_status_integrator:
+                nats_server: {}


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [ ] Chart Version bumped for the respective charts
- [ ] Variables are documented in the README.md (or README.tpl in some charts)
- [ ] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [ ] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
