### PR TITLE
feat(shield): set GOMAXPROCS/GOMEMLIMIT for Go workloads on Windows

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.43.2
+version: 1.44.0
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/_helpers.tpl
+++ b/charts/shield/templates/cluster/_helpers.tpl
@@ -98,6 +98,19 @@ the inheritance logic lives in a single place.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Returns "true" when the cluster-shield pod is pinned to Windows nodes via the
+effective nodeSelector carrying "kubernetes.io/os: windows". Used to enable Go
+runtime tuning (GOMAXPROCS/GOMEMLIMIT), since Windows containers have no cgroups
+for Go to auto-detect limits from. Affinity-only pinning is not detected here.
+*/}}
+{{- define "cluster.scheduled_on_windows" -}}
+{{- $nodeSelector := merge (dict) .Values.node_selector .Values.cluster.node_selector -}}
+{{- if eq (dig "kubernetes.io/os" "" $nodeSelector) "windows" -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{- define "cluster.tolerations" -}}
 {{- $tollerations := concat .Values.tolerations .Values.cluster.tolerations -}}
 {{- with $tollerations -}}

--- a/charts/shield/templates/cluster/deployment.yaml
+++ b/charts/shield/templates/cluster/deployment.yaml
@@ -129,6 +129,9 @@ spec:
             {{- if $customCAEnvs }}
               {{- $customCAEnvs | nindent 12 }}
             {{- end }}
+            {{- if (include "cluster.scheduled_on_windows" .) }}
+            {{- include "common.go_runtime.envs" (dict "ContainerName" "cluster-shield" "Limits" (dig "resources" "limits" (dict) .Values.cluster)) | nindent 12 }}
+            {{- end }}
             {{- include "cluster.env" . | nindent 12 }}
           resources:
             {{- toYaml .Values.cluster.resources | nindent 12 }}

--- a/charts/shield/templates/common/_go_runtime.tpl
+++ b/charts/shield/templates/common/_go_runtime.tpl
@@ -1,0 +1,30 @@
+{{/*
+Go runtime tuning env vars (GOMAXPROCS / GOMEMLIMIT) derived from this container's
+own resource limits, so nothing is hardcoded and it tracks whatever the chart
+renders. Intended for Windows pods, where Go cannot read cgroup limits and would
+otherwise fall back to whole-node CPU count and no memory ceiling. Each var is
+emitted only when the matching limit is set.
+
+Expected context:
+  .ContainerName  name of the container the resourceFieldRef points at
+  .Limits         the container's resources.limits map
+*/}}
+{{- define "common.go_runtime.envs" -}}
+{{- with .Limits }}
+{{- if .cpu }}
+- name: GOMAXPROCS
+  valueFrom:
+    resourceFieldRef:
+      containerName: {{ $.ContainerName }}
+      resource: limits.cpu        # exposed rounded UP to integer cores
+{{- end }}
+{{- if .memory }}
+- name: GOMEMLIMIT
+  valueFrom:
+    resourceFieldRef:
+      containerName: {{ $.ContainerName }}
+      resource: limits.memory
+      divisor: "1"                # raw bytes; Go reads a bare int as bytes
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/shield/templates/host/daemonset-windows.yaml
+++ b/charts/shield/templates/host/daemonset-windows.yaml
@@ -79,6 +79,7 @@ spec:
             {{- if $customCAEnvs }}
               {{- $customCAEnvs | nindent 12 }}
             {{- end }}
+            {{- include "common.go_runtime.envs" (dict "ContainerName" "sysdig-host-shield" "Limits" (dig "resources" "limits" (dict) .Values.host_windows)) | nindent 12 }}
             {{- include "host.windows.env" . | nindent 12 }}
           livenessProbe:
             httpGet:

--- a/charts/shield/tests/cluster/deployment_test.yaml
+++ b/charts/shield/tests/cluster/deployment_test.yaml
@@ -1526,3 +1526,59 @@ tests:
             name: SYSDIG_SHIELD_CHART_VERSION
             value: 1.2.3-helmtest
     template: templates/cluster/deployment.yaml
+
+  - it: Omits Go runtime tuning env vars on Linux nodes (default)
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].env[?(@.name == "GOMAXPROCS")]
+      - notExists:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].env[?(@.name == "GOMEMLIMIT")]
+    template: templates/cluster/deployment.yaml
+
+  - it: Sets Go runtime tuning env vars when scheduled on Windows nodes
+    set:
+      cluster:
+        node_selector:
+          kubernetes.io/os: windows
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].env
+          content:
+            name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: cluster-shield
+                resource: limits.cpu
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].env
+          content:
+            name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: cluster-shield
+                resource: limits.memory
+                divisor: "1"
+    template: templates/cluster/deployment.yaml
+
+  - it: Detects Windows scheduling via global node_selector
+    set:
+      node_selector:
+        kubernetes.io/os: windows
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].env[?(@.name == "GOMAXPROCS")]
+    template: templates/cluster/deployment.yaml
+
+  - it: Omits Go runtime tuning env vars on Windows nodes when limits are unset
+    set:
+      cluster:
+        node_selector:
+          kubernetes.io/os: windows
+        resources:
+          limits: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].env[?(@.name == "GOMAXPROCS")]
+      - notExists:
+          path: spec.template.spec.containers[?(@.name == "cluster-shield")].env[?(@.name == "GOMEMLIMIT")]
+    template: templates/cluster/deployment.yaml

--- a/charts/shield/tests/host/daemonset-windows_test.yaml
+++ b/charts/shield/tests/host/daemonset-windows_test.yaml
@@ -517,3 +517,34 @@ tests:
           value:
               - company.public
               - company.internal
+
+  - it: Sets Go runtime tuning env vars from container limits
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].env
+          content:
+            name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: sysdig-host-shield
+                resource: limits.cpu
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].env
+          content:
+            name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: sysdig-host-shield
+                resource: limits.memory
+                divisor: "1"
+
+  - it: Omits Go runtime tuning env vars when limits are unset
+    set:
+      host_windows:
+        resources:
+          limits: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].env[?(@.name == "GOMAXPROCS")]
+      - notExists:
+          path: spec.template.spec.containers[?(@.name == "sysdig-host-shield")].env[?(@.name == "GOMEMLIMIT")]


### PR DESCRIPTION
## What

Sets `GOMAXPROCS`/`GOMEMLIMIT` explicitly for Shield's Go workloads **on Windows**, derived from each container's own resource limits via the downward API (`resourceFieldRef`).

## Why

Modern Go reads cgroup CPU/memory limits automatically on Linux. **Windows containers have no cgroups**, so the runtime falls back to whole-node CPU count and no memory ceiling — causing scheduler contention and OOM risk under tight limits. We pin the runtime to whatever the chart renders, only where Go can't auto-detect (Windows).

## Changes

- **`templates/common/_go_runtime.tpl`** (new) — `common.go_runtime.envs` helper. Emits each env var only when its matching limit is set (`limits.cpu` → `GOMAXPROCS`, `limits.memory` → `GOMEMLIMIT` with `divisor: "1"`).
- **`templates/host/daemonset-windows.yaml`** — always tuned (always Windows).
- **`templates/cluster/deployment.yaml`** — tuned only when pinned to Windows nodes.
- **`templates/cluster/_helpers.tpl`** — new `cluster.scheduled_on_windows` detector (checks effective nodeSelector for `kubernetes.io/os: windows`).
- Env vars emitted **before** the user-env include, so users can still override.
- Linux `host-shield` DaemonSet left unchanged (Go auto-detects there).
- `Chart.yaml` bumped `1.43.2` → `1.44.0`.
- Tests added to the Windows DaemonSet and cluster Deployment suites.

## Notes

- Windows scheduling is detected via **nodeSelector** only — affinity-only pinning of cluster-shield won't trigger the env vars (matches how the chart's own Windows DaemonSet signals OS; documented in the helper comment).

## Verification

- `helm template`: Windows DaemonSet always tuned; cluster-shield tuned only when Windows-pinned; both gated on limits; Linux host DaemonSet untouched.
- `helm unittest`: 37 suites / 560 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)