### PR TITLE
feat(agent): grant endpointslices RBAC for EndpointSlice watch (superseded)

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 2.8.2
+version: 2.8.3

--- a/charts/agent/templates/clusterrole.yaml
+++ b/charts/agent/templates/clusterrole.yaml
@@ -28,6 +28,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - events


### PR DESCRIPTION
Superseded by #2667. Closing.