### PR TITLE
feat(agent,shield): grant endpointslices RBAC for EndpointSlice watch

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 2.8.2
+version: 2.8.3

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 2.10.2
+version: 2.10.3

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -30,4 +30,4 @@ sources:
 - https://app.sysdigcloud.com/#/settings/user
 - https://github.com/draios/sysdig
 type: application
-version: 2.10.0
+version: 2.10.1

--- a/charts/agent/ci/test-values.yaml.template
+++ b/charts/agent/ci/test-values.yaml.template
@@ -1,2 +1,2 @@
 sysdig:
-  accessKey: ${SECURE_AGENT_TOKEN}
+  accessKey: "${SECURE_AGENT_TOKEN}"

--- a/charts/agent/templates/clusterrole.yaml
+++ b/charts/agent/templates/clusterrole.yaml
@@ -28,6 +28,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - events

--- a/charts/agent/tests/clusterrole_test.yaml
+++ b/charts/agent/tests/clusterrole_test.yaml
@@ -88,3 +88,17 @@ tests:
       - contains:
           path: rules[0].resources
           content: configmaps
+
+  - it: Test agent can watch EndpointSlices in kubernetes
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - discovery.k8s.io
+            resources:
+              - endpointslices
+            verbs:
+              - get
+              - list
+              - watch

--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.45.0
+version: 1.45.1
 appVersion: "1.0.0"

--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.49.2
+version: 1.49.3
 appVersion: "1.0.0"

--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.49.4
+version: 1.49.5
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/clusterrole.yaml
+++ b/charts/shield/templates/host/clusterrole.yaml
@@ -31,6 +31,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - events

--- a/charts/shield/tests/host/clusterrole_test.yaml
+++ b/charts/shield/tests/host/clusterrole_test.yaml
@@ -80,6 +80,20 @@ tests:
               - get
               - list
 
+  - it: Grants endpointslices for network topology
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - discovery.k8s.io
+            resources:
+              - endpointslices
+            verbs:
+              - get
+              - list
+              - watch
+
   - it: Adds posture RBAC rules when host_posture is enabled
     set:
       features:

--- a/charts/shield/tests/host/clusterrole_test.yaml
+++ b/charts/shield/tests/host/clusterrole_test.yaml
@@ -80,6 +80,20 @@ tests:
               - get
               - list
 
+  - it: Grants endpointslices for network topology
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - discovery.k8s.io
+            resources:
+              - endpointslices
+            verbs:
+              - get
+              - list
+              - watch
+
   - it: Do not add RBAC rules when host_posture is enabled and OpenShift API is not detected
     set:
       features:


### PR DESCRIPTION
## What this PR does / why we need it

The agent watches Service endpoint data for its network-topology feature. It is moving from the deprecated `core/v1` `Endpoints` API to `discovery.k8s.io` `EndpointSlice`. The ClusterRoles that run this watcher only grant the core `endpoints` resource, so once the agent issues `EndpointSlice` list/watch calls they are denied (Forbidden) and endpoint topology data is silently lost.

This grants `get/list/watch` on `discovery.k8s.io/endpointslices` in the roles that run the watcher. The existing core `endpoints` grant is intentionally retained so older agents keep working during rollout.

### Scope

- **`agent` chart** — the agent ClusterRole runs the watcher; add the rule.
- **`shield` chart, host role** — Host Shield sets `network_topology.enabled = network_security.enabled` (see `templates/host/_configmap_helpers.tpl`), so the host agent runs the same watcher; add the rule.
- **`shield` chart, cluster role** — already grants `discovery.k8s.io/endpointslices` (gated on `kubernetes_metadata` / `network_security`); no change needed.

### Files

- `charts/agent/templates/clusterrole.yaml` — add `endpointslices` rule.
- `charts/agent/tests/clusterrole_test.yaml` — assert the rule.
- `charts/agent/Chart.yaml` — `2.8.2` → `2.8.3`.
- `charts/shield/templates/host/clusterrole.yaml` — add `endpointslices` rule.
- `charts/shield/tests/host/clusterrole_test.yaml` — assert the rule.
- `charts/shield/Chart.yaml` — `1.45.0` → `1.45.1`.

## Test plan

- [x] `helm unittest charts/agent` and `helm unittest charts/shield` — existing suites pass, new assertions green.
- [x] `helm template` → agent ClusterRole and shield host ClusterRole each contain both `endpoints` and `endpointslices`.

## Checklist

- [x] Title of the PR starts with type and scope (`feat(agent,shield):`)
- [x] Chart Version bumped (agent 2.8.2 → 2.8.3, shield 1.45.0 → 1.45.1)
- [x] Variables are documented in the README.md (no new values introduced)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a `_test` suffix
