### PR TITLE
fix(shield): render OpenShift monitoring ClusterRoleBinding under GitOps

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.46.1
+version: 1.46.2
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/openshift-clusterrolebinding-monitor.yaml
+++ b/charts/shield/templates/host/openshift-clusterrolebinding-monitor.yaml
@@ -1,6 +1,5 @@
 {{- if or (.Capabilities.APIVersions.Has "monitoring.openshift.io/v1") (has "monitoring.openshift.io/v1" .Values.extra_capabilities_api_versions) }}
-{{- $clusterRole := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "cluster-monitoring-view" -}}
-{{- if and (include "host.rbac.cluster_role.create" .) $clusterRole }}
+{{- if (include "host.rbac.cluster_role.create" .) }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/shield/tests/host/openshift-clusterrolebinding-monitor_norole_test.yaml
+++ b/charts/shield/tests/host/openshift-clusterrolebinding-monitor_norole_test.yaml
@@ -1,4 +1,4 @@
-suite: Host - OpenShift ClusterRoleBinding Monitor (Role does not exist)
+suite: Host - OpenShift ClusterRoleBinding Monitor (offline / GitOps render, no lookup)
 templates:
   - templates/host/openshift-clusterrolebinding-monitor.yaml
 release:
@@ -7,7 +7,33 @@ release:
 values:
   - ../values/base.yaml
 tests:
-  - it: Does not create the ClusterRoleBinding if the ClusterRole does not exist and monitoring.openshift.io/v1 is supported
+  # No kubernetesProvider is configured, so `lookup` returns empty — this mirrors an
+  # ArgoCD / `helm template` / `--dry-run` render where there is no live cluster API.
+  - it: Creates the ClusterRoleBinding when monitoring.openshift.io/v1 is supported even though lookup is empty
+    capabilities:
+      apiVersions:
+        - monitoring.openshift.io/v1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          name: release-name-shield-host-cluster-monitoring-view
+
+  - it: Creates the ClusterRoleBinding when the monitoring API version is declared via extra_capabilities_api_versions (ArgoCD)
+    set:
+      extra_capabilities_api_versions:
+        - monitoring.openshift.io/v1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          name: release-name-shield-host-cluster-monitoring-view
+
+  - it: Does not create the ClusterRoleBinding if the monitoring API version is neither supported nor declared
     capabilities:
       apiVersions:
         - security.openshift.io/v1

--- a/charts/shield/tests/host/openshift-clusterrolebinding-monitor_test.yaml
+++ b/charts/shield/tests/host/openshift-clusterrolebinding-monitor_test.yaml
@@ -6,19 +6,6 @@ release:
   namespace: shield-namespace
 values:
   - ../values/base.yaml
-kubernetesProvider:
-  scheme:
-    "rbac.authorization.k8s.io/v1/ClusterRole":
-      gvr:
-        group: "rbac.authorization.k8s.io"
-        version: "v1"
-        resource: "clusterroles"
-      namespaced: false
-  objects:
-  - apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: cluster-monitoring-view
 
 tests:
   - it: Does not create the ClusterRoleBinding if rbac.create is false
@@ -61,12 +48,12 @@ tests:
           kind: ClusterRoleBinding
           name: release-name-shield-host-cluster-monitoring-view
 
-  - it: Does not create the ClusterRoleBinding if the ClusterRole exists and monitoring.openshift.io/v1 is not supported
+  - it: Does not create the ClusterRoleBinding if monitoring.openshift.io/v1 is not supported
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: Does create the ClusterRoleBinding if the ClusterRole exists and monitoring.openshift.io/v1 is supported
+  - it: Does create the ClusterRoleBinding if monitoring.openshift.io/v1 is supported
     capabilities:
       apiVersions:
         - monitoring.openshift.io/v1


### PR DESCRIPTION
## Problem

The `<release>-shield-host-cluster-monitoring-view` ClusterRoleBinding is gated on a Helm `lookup` for the `cluster-monitoring-view` ClusterRole in `charts/shield/templates/host/openshift-clusterrolebinding-monitor.yaml`:

```gotemplate
{{- $clusterRole := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "cluster-monitoring-view" -}}
{{- if and (include "host.rbac.cluster_role.create" .) $clusterRole }}
```

Under ArgoCD (and any offline `helm template` / `--dry-run` render) `lookup` returns null because there is no live cluster API to query. The `and` short-circuits to `false`, so the binding is never created — even when the OpenShift monitoring API version is present or declared via `extra_capabilities_api_versions`. GitOps users silently lose the monitoring RBAC.

## Fix

Remove the `lookup` gate. Creation now depends only on the OpenShift API-version check (which already honors `extra_capabilities_api_versions`) plus `host.rbac.cluster_role.create`. Binding to a not-yet-existing ClusterRole is harmless in Kubernetes, and where `monitoring.openshift.io/v1` is served the `cluster-monitoring-view` ClusterRole is always present, so live-cluster behavior is preserved.

## Tests

- Removed the now-unnecessary `kubernetesProvider` block from the main suite (it existed only to make `lookup` succeed), proving the binding renders without a live lookup.
- Repurposed the `_norole` suite to the offline/GitOps case: with an empty `lookup`, the binding renders both when `monitoring.openshift.io/v1` is a live capability and when it is declared via `extra_capabilities_api_versions`; a negative case confirms it is not created when the API version is absent.

## Verification

```
helm unittest --strict -f "tests/**/*_test.yaml" charts/shield
# 556 tests / 37 suites pass

helm template rn charts/shield -f charts/shield/tests/values/base.yaml \
  --set host.rbac.create=true \
  --set 'extra_capabilities_api_versions={monitoring.openshift.io/v1}' \
  --show-only templates/host/openshift-clusterrolebinding-monitor.yaml
# renders the ClusterRoleBinding offline (no live cluster)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)