### PR TITLE
fix(shield): strip leading newline from dragent.yaml ConfigMap block scalar

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.49.0
+version: 1.49.1
 appVersion: "1.0.0"

--- a/charts/shield/templates/host/_configmap_helpers.tpl
+++ b/charts/shield/templates/host/_configmap_helpers.tpl
@@ -103,7 +103,7 @@ true
 {{- end }}
 
 {{- define "host.parse_features" }}
-{{/* TODO: Kubernetes metadata */}}
+{{- /* TODO: Kubernetes metadata */}}
 {{- with .Values.features }}
 {{- $config := dict
   "app_checks_enabled" ((dig (include "host.monitor_key" .) "app_checks" "enabled" false .))
@@ -181,7 +181,7 @@ true
 {{- $config = merge $config (dict "rapid_response" (include "host.dragent_yaml.rapid_response" .| fromJson)) }}
 {{- end }}
 {{- $config = merge $config (include "host.parse_features" . | fromYaml) }}
-{{/* Host Scanner requires setting the host fs mount path variable, but that
+{{- /* Host Scanner requires setting the host fs mount path variable, but that
      parameter has not been mapped into the new schema yet. As a result,
      it still needs to be set in the dragent.yaml file. */}}
 {{- if .Values.features.vulnerability_management.host_vulnerability_management.enabled }}

--- a/charts/shield/tests/cluster/configmap_test.yaml
+++ b/charts/shield/tests/cluster/configmap_test.yaml
@@ -1040,3 +1040,13 @@ tests:
             cluster_scanner:
               runtime_status_integrator:
                 nats_server: {}
+
+  # Regression test for https://github.com/sysdiglabs/charts/issues/2686: a
+  # `{{/* comment */}}` in a template's output stream emits a stray newline that
+  # `nindent 4` turns into a whitespace-only first line, which strict YAML
+  # parsers (e.g. YamlDotNet) reject with "found extra spaces in first line".
+  - it: ConfigMap value does not start with a newline
+    asserts:
+      - matchRegex:
+          path: data['cluster-shield.yaml']
+          pattern: \A\S

--- a/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-dragent-yaml_test.yaml
@@ -1344,6 +1344,60 @@ tests:
               host_fs_mount_path: /host
               verify_certificate: true
 
+  # Regression tests for https://github.com/sysdiglabs/charts/issues/2686.
+  # A `{{/* comment */}}` left in a template's output stream emits a stray
+  # newline, which `nindent 4` turns into a whitespace-only first line of the
+  # block scalar. Strict YAML parsers (e.g. YamlDotNet, used by Octopus Deploy)
+  # reject that with "found extra spaces in first line". `\A\S` asserts the
+  # value's very first character is non-whitespace.
+  - it: ConfigMap values do not start with a newline
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: \A\S
+      - matchRegex:
+          path: data['host-shield.yaml']
+          pattern: \A\S
+
+  - it: ConfigMap values do not start with a newline when features are enabled
+    set:
+      features:
+        monitor:
+          prometheus:
+            enabled: true
+          app_checks:
+            enabled: true
+        investigations:
+          event_forwarder:
+            enabled: true
+          network_security:
+            enabled: true
+        posture:
+          host_posture:
+            enabled: true
+        vulnerability_management:
+          host_vulnerability_management:
+            enabled: true
+        respond:
+          rapid_response:
+            enabled: true
+      proxy:
+        https_proxy: "https://user:password@proxy.example.com:8080"
+      cluster_config:
+        name: demo-cluster
+        tags:
+          agentTag1: agentTagValue1
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: \A\S
+      - matchRegex:
+          path: data['host-shield.yaml']
+          pattern: \A\S
+      - matchRegex:
+          path: data['prometheus.yaml']
+          pattern: \A\S
+
   - it: Alternative regions
     set:
       sysdig_endpoint:

--- a/charts/shield/tests/host/configmap-windows-dragent-yaml_test.yaml
+++ b/charts/shield/tests/host/configmap-windows-dragent-yaml_test.yaml
@@ -742,3 +742,16 @@ tests:
           path: data['dragent.yaml']
           pattern: |
             connection_timeout: 1000
+
+  # Regression test for https://github.com/sysdiglabs/charts/issues/2686: a
+  # `{{/* comment */}}` in a template's output stream emits a stray newline that
+  # `nindent 4` turns into a whitespace-only first line, which strict YAML
+  # parsers (e.g. YamlDotNet) reject with "found extra spaces in first line".
+  - it: ConfigMap values do not start with a newline
+    asserts:
+      - matchRegex:
+          path: data['dragent.yaml']
+          pattern: \A\S
+      - matchRegex:
+          path: data['host-shield.yaml']
+          pattern: \A\S


### PR DESCRIPTION
Go template comments written as `{{/* ... */}}` sit in the template's output stream, and `{{-` trimming does not reach past a comment node. The comment above the Host Scanner block in `host.configmap` therefore emitted a stray newline that `nindent 4` rendered as a whitespace-only first line of the `dragent.yaml` block scalar. Strict YAML parsers such as YamlDotNet (used by Octopus Deploy) reject this with "While scanning a literal block scalar, found extra spaces in first line".

Left-trim both output-stream comments so the block scalar starts on the first content line, and add regression tests asserting the ConfigMap values begin with a non-whitespace character.

Fixes #2686

Generated with support from AI

## What this PR does / why we need it:

## Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Variables are documented in the README.md (or README.tpl in some charts)
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix

<!-- Check Contribution guidelines in README.md for more insight. -->
