### PR TITLE
[DO NOT MERGE] Demo: node-analyzer minor bump breaks sysdig-deploy dep resolution

### DIFF
--- a/charts/node-analyzer/Chart.yaml
+++ b/charts/node-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-analyzer
 description: Sysdig Node Analyzer
 # currently matching Sysdig's appVersion 1.14.34
-version: 1.46.0
+version: 1.47.0
 appVersion: 12.9.2
 keywords:
   - monitoring


### PR DESCRIPTION
⚠️ **Demonstration PR — do not merge. For CI verification only; will be closed.**

## Purpose
Prove that bumping `node-analyzer` by a **minor** version without updating the `sysdig-deploy` dependency pin breaks CI, exactly as diagnosed while fixing #2724.

## The single change
- `charts/node-analyzer/Chart.yaml`: `version: 1.46.0 → 1.47.0`
- `charts/sysdig-deploy/Chart.yaml`: **intentionally untouched** (pin stays `~1.46.0`)

## Expected failure
`~1.46.0` resolves to `>=1.46.0, <1.47.0`, so `1.47.0` is excluded. `helm dependency build` for sysdig-deploy therefore cannot vendor the node-analyzer subchart:

```
Error: can't get a valid version for 1 subchart(s): "node-analyzer"
(repository "file://../node-analyzer", version "~1.46.0")
```

→ the sysdig-deploy **Unit-tests** job fails with `template "sysdig-deploy/charts/nodeAnalyzer/templates/..." not exists`, and **lint-test-branch** fails on the same dependency step. (Reproduced locally before pushing.)

## The fix (for real PRs)
When node-analyzer gets a minor/major bump, the same PR must also bump the sysdig-deploy pin (e.g. `~1.47.0`) and the sysdig-deploy chart version — as done in #2724. A patch bump stays within the tilde range and does not need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)