### PR TITLE
feat(shield): grant RBAC for OpenShift Phase 2 resource collection

### DIFF
--- a/charts/shield/Chart.yaml
+++ b/charts/shield/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: mavimo
     email: marcovito.moscaritolo@sysdig.com
 type: application
-version: 1.49.5
+version: 1.49.6
 appVersion: "1.0.0"

--- a/charts/shield/templates/cluster/_config.tpl
+++ b/charts/shield/templates/cluster/_config.tpl
@@ -212,19 +212,37 @@
 {{- end }}
 
 {{/*
-  Checks if posture is enabled and OCP Route collection is enabled.
+  Checks if posture is enabled and the given OCP resource is listed in the
+  kspm_collector ocp_resources setting.
+  Takes a list of two elements: the chart context and the resource name.
+  Usage: include "cluster.posture_ocp_resource_enabled" (list . "route")
 */}}
-{{- define "cluster.posture_ocp_routes_enabled" -}}
-  {{- if and (include "cluster.posture_enabled" .) (dig "kspm_collector" "ocp_route_enabled" false .Values.cluster.additional_settings) -}}
+{{- define "cluster.posture_ocp_resource_enabled" -}}
+  {{- $ctx := index . 0 -}}
+  {{- $resource := index . 1 -}}
+  {{- $ocpResources := dig "kspm_collector" "ocp_resources" (list) $ctx.Values.cluster.additional_settings -}}
+  {{- if and (include "cluster.posture_enabled" $ctx) (has $resource ($ocpResources | default (list))) -}}
     {{- true -}}
   {{- end -}}
 {{- end }}
 
 {{/*
-  Checks if posture is enabled and OCP DeploymentConfig collection is enabled.
+  Checks if posture is enabled and OCP Route collection is enabled, either
+  through ocp_resources or through the deprecated ocp_route_enabled flag.
+*/}}
+{{- define "cluster.posture_ocp_routes_enabled" -}}
+  {{- if or (include "cluster.posture_ocp_resource_enabled" (list . "route")) (and (include "cluster.posture_enabled" .) (dig "kspm_collector" "ocp_route_enabled" false .Values.cluster.additional_settings)) -}}
+    {{- true -}}
+  {{- end -}}
+{{- end }}
+
+{{/*
+  Checks if posture is enabled and OCP DeploymentConfig collection is enabled,
+  either through ocp_resources or through the deprecated
+  ocp_deploymentconfig_enabled flag.
 */}}
 {{- define "cluster.posture_ocp_deploymentconfig_enabled" -}}
-  {{- if and (include "cluster.posture_enabled" .) (dig "kspm_collector" "ocp_deploymentconfig_enabled" false .Values.cluster.additional_settings) -}}
+  {{- if or (include "cluster.posture_ocp_resource_enabled" (list . "deploymentconfig")) (and (include "cluster.posture_enabled" .) (dig "kspm_collector" "ocp_deploymentconfig_enabled" false .Values.cluster.additional_settings)) -}}
     {{- true -}}
   {{- end -}}
 {{- end }}

--- a/charts/shield/templates/cluster/clusterrole.yaml
+++ b/charts/shield/templates/cluster/clusterrole.yaml
@@ -210,6 +210,96 @@ rules:
     - list
     - watch
 {{- end }}
+{{- if (include "cluster.posture_ocp_resource_enabled" (list . "securitycontextconstraints")) }}
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+  verbs:
+    - get
+    - list
+    - watch
+{{- end }}
+{{- if (include "cluster.posture_ocp_resource_enabled" (list . "machineconfig")) }}
+- apiGroups:
+    - machineconfiguration.openshift.io
+  resources:
+    - machineconfigs
+  verbs:
+    - get
+    - list
+    - watch
+{{- end }}
+{{- if (include "cluster.posture_ocp_resource_enabled" (list . "machineconfigpool")) }}
+- apiGroups:
+    - machineconfiguration.openshift.io
+  resources:
+    - machineconfigpools
+  verbs:
+    - get
+    - list
+    - watch
+{{- end }}
+{{- if (include "cluster.posture_ocp_resource_enabled" (list . "machineset")) }}
+- apiGroups:
+    - machine.openshift.io
+  resources:
+    - machinesets
+  verbs:
+    - get
+    - list
+    - watch
+{{- end }}
+{{- if (include "cluster.posture_ocp_resource_enabled" (list . "buildconfig")) }}
+- apiGroups:
+    - build.openshift.io
+  resources:
+    - buildconfigs
+  verbs:
+    - get
+    - list
+    - watch
+{{- end }}
+{{- if (include "cluster.posture_ocp_resource_enabled" (list . "imagestream")) }}
+- apiGroups:
+    - image.openshift.io
+  resources:
+    - imagestreams
+  verbs:
+    - get
+    - list
+    - watch
+{{- end }}
+{{- if (include "cluster.posture_ocp_resource_enabled" (list . "template")) }}
+- apiGroups:
+    - template.openshift.io
+  resources:
+    - templates
+  verbs:
+    - get
+    - list
+    - watch
+{{- end }}
+{{- if (include "cluster.posture_ocp_resource_enabled" (list . "clusteroperator")) }}
+- apiGroups:
+    - config.openshift.io
+  resources:
+    - clusteroperators
+  verbs:
+    - get
+    - list
+    - watch
+{{- end }}
+{{- if (include "cluster.posture_ocp_resource_enabled" (list . "clusterresourcequota")) }}
+- apiGroups:
+    - quota.openshift.io
+  resources:
+    - clusterresourcequotas
+  verbs:
+    - get
+    - list
+    - watch
+{{- end }}
 {{- if or (include "cluster.admission_control_container_vulnerability_management_enabled" .) (include "cluster.admission_control_image_signature_enabled" .) }}
 - apiGroups:
     - ""

--- a/charts/shield/tests/cluster/clusterrole_test.yaml
+++ b/charts/shield/tests/cluster/clusterrole_test.yaml
@@ -1160,3 +1160,407 @@ tests:
               - apps.openshift.io
             resources:
               - deploymentconfigs
+
+  - it: All OCP resources granted through ocp_resources
+    set:
+      features:
+        posture:
+          cluster_posture:
+            enabled: true
+      cluster:
+        additional_settings:
+          kspm_collector:
+            ocp_resources:
+              - route
+              - deploymentconfig
+              - securitycontextconstraints
+              - machineconfig
+              - machineconfigpool
+              - machineset
+              - buildconfig
+              - imagestream
+              - template
+              - clusteroperator
+              - clusterresourcequota
+    asserts:
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: release-name-shield-cluster
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - route.openshift.io
+            resources:
+              - routes
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps.openshift.io
+            resources:
+              - deploymentconfigs
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - security.openshift.io
+            resources:
+              - securitycontextconstraints
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - machineconfiguration.openshift.io
+            resources:
+              - machineconfigs
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - machineconfiguration.openshift.io
+            resources:
+              - machineconfigpools
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - machine.openshift.io
+            resources:
+              - machinesets
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - build.openshift.io
+            resources:
+              - buildconfigs
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - image.openshift.io
+            resources:
+              - imagestreams
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - template.openshift.io
+            resources:
+              - templates
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - config.openshift.io
+            resources:
+              - clusteroperators
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - quota.openshift.io
+            resources:
+              - clusterresourcequotas
+            verbs:
+              - get
+              - list
+              - watch
+
+  - it: No OCP resource granted through ocp_resources when posture is disabled
+    set:
+      features:
+        posture:
+          cluster_posture:
+            enabled: false
+      cluster:
+        additional_settings:
+          kspm_collector:
+            ocp_resources:
+              - route
+              - deploymentconfig
+              - securitycontextconstraints
+              - machineconfig
+              - machineconfigpool
+              - machineset
+              - buildconfig
+              - imagestream
+              - template
+              - clusteroperator
+              - clusterresourcequota
+    asserts:
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: release-name-shield-cluster
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - route.openshift.io
+            resources:
+              - routes
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - apps.openshift.io
+            resources:
+              - deploymentconfigs
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - security.openshift.io
+            resources:
+              - securitycontextconstraints
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - machineconfiguration.openshift.io
+            resources:
+              - machineconfigs
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - machineconfiguration.openshift.io
+            resources:
+              - machineconfigpools
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - machine.openshift.io
+            resources:
+              - machinesets
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - build.openshift.io
+            resources:
+              - buildconfigs
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - image.openshift.io
+            resources:
+              - imagestreams
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - template.openshift.io
+            resources:
+              - templates
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - config.openshift.io
+            resources:
+              - clusteroperators
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - quota.openshift.io
+            resources:
+              - clusterresourcequotas
+
+  - it: Only the OCP resources listed in ocp_resources are granted
+    set:
+      features:
+        posture:
+          cluster_posture:
+            enabled: true
+      cluster:
+        additional_settings:
+          kspm_collector:
+            ocp_resources:
+              - securitycontextconstraints
+              - buildconfig
+    asserts:
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: release-name-shield-cluster
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - security.openshift.io
+            resources:
+              - securitycontextconstraints
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - build.openshift.io
+            resources:
+              - buildconfigs
+            verbs:
+              - get
+              - list
+              - watch
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - route.openshift.io
+            resources:
+              - routes
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - apps.openshift.io
+            resources:
+              - deploymentconfigs
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - image.openshift.io
+            resources:
+              - imagestreams
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - config.openshift.io
+            resources:
+              - clusteroperators
+
+  - it: An empty ocp_resources grants no OCP resource
+    set:
+      features:
+        posture:
+          cluster_posture:
+            enabled: true
+      cluster:
+        additional_settings:
+          kspm_collector:
+            ocp_resources: []
+    asserts:
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: release-name-shield-cluster
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - route.openshift.io
+            resources:
+              - routes
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - security.openshift.io
+            resources:
+              - securitycontextconstraints
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - quota.openshift.io
+            resources:
+              - clusterresourcequotas
+
+  - it: Routes granted through ocp_resources while deploymentconfigs use the deprecated flag
+    set:
+      features:
+        posture:
+          cluster_posture:
+            enabled: true
+      cluster:
+        additional_settings:
+          kspm_collector:
+            ocp_resources:
+              - route
+            ocp_deploymentconfig_enabled: true
+    asserts:
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: release-name-shield-cluster
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - route.openshift.io
+            resources:
+              - routes
+            verbs:
+              - get
+              - list
+              - watch
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps.openshift.io
+            resources:
+              - deploymentconfigs
+            verbs:
+              - get
+              - list
+              - watch
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - security.openshift.io
+            resources:
+              - securitycontextconstraints


### PR DESCRIPTION
## What this PR does / why we need it:

OpenShift posture collection currently covers two resources, `Route` and `DeploymentConfig`, each behind its own boolean. This PR extends it to nine more OpenShift resources by granting `get`/`list`/`watch` on each, so the KSPM collector can list them:

| `ocp_resources` value | apiGroup | resource |
| --- | --- | --- |
| `securitycontextconstraints` | `security.openshift.io` | `securitycontextconstraints` |
| `machineconfig` | `machineconfiguration.openshift.io` | `machineconfigs` |
| `machineconfigpool` | `machineconfiguration.openshift.io` | `machineconfigpools` |
| `machineset` | `machine.openshift.io` | `machinesets` |
| `buildconfig` | `build.openshift.io` | `buildconfigs` |
| `imagestream` | `image.openshift.io` | `imagestreams` |
| `template` | `template.openshift.io` | `templates` |
| `clusteroperator` | `config.openshift.io` | `clusteroperators` |
| `clusterresourcequota` | `quota.openshift.io` | `clusterresourcequotas` |

Rather than adding nine more booleans, resources are opted in through a single list setting:

```yaml
cluster:
  additional_settings:
    kspm_collector:
      ocp_resources:
        - securitycontextconstraints
        - buildconfig
```

A new helper, `cluster.posture_ocp_resource_enabled`, gates each rule on posture being enabled **and** the resource being listed, which is the same semantics the two existing flags already had. `ocp_route_enabled` and `ocp_deploymentconfig_enabled` keep working and now feed the same helper, so no current installation changes behaviour, and `route` / `deploymentconfig` can also be requested through `ocp_resources`.

This follows #2618, which added the RBAC for `Route` and `DeploymentConfig`, and mirrors the equivalent change in the `cluster-shield` chart.

Nothing is granted by default. With posture enabled and no `ocp_resources` set, the rendered ClusterRole is unchanged.

## Checklist

- [x] Title of the PR starts with type and scope, (e.g. `feat(agent,node-analyzer,sysdig-deploy):`)
- [x] Chart Version bumped for the respective charts
- [x] Check GithubAction checks (like lint) to avoid merge-check stoppers
- [x] All test files are added in the tests folder of their respective chart and have a "_test" suffix
